### PR TITLE
doctor: pass native-route probe auth rejections; uninstall removes the menubar app

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,11 @@ baseten-switch uninstall --purge --yes
 brew uninstall baseten-switch
 ```
 
-Uninstall never removes Baseten CLI credentials or keychain entries. If the
-app's Start at Login item prevents safe bundle removal, the command prints the
-manual action required in macOS System Settings.
+Uninstall never removes Baseten CLI credentials or keychain entries. The Mac
+app unregisters its own Start at Login item as part of bundle removal. When
+the installed app predates that helper or the unregister fails, the command
+leaves the bundle in place and prints the manual action required in macOS
+System Settings.
 
 ## Privacy and trust
 

--- a/gateway/cmd/baseten-switch/doctor.go
+++ b/gateway/cmd/baseten-switch/doctor.go
@@ -1448,16 +1448,47 @@ func doctorE2EChecks(add addCheck, o doctorOpts, doorSpecs []door.Config, doorUp
 		port := portOf(t.BindAddr)
 		probeStart := time.Now()
 		p := doctorProbeClient(httpC, t)
-		if doctorProbeOK(p) {
+		switch {
+		case doctorProbeOK(p):
 			add("e2e", "probe:"+port, docOK,
 				fmt.Sprintf("1-token request through the door succeeded (status %d, %dms, model %s)", p.Status, p.LatencyMs, orDash(p.Model)), "")
-		} else {
+		case doctorProbeNativeAuthOK(f, routerTargets[t.BindAddr], t.ProtocolShape, p):
+			expected := config.NativeRoute(t.ProtocolShape)
+			add("e2e", "probe:"+port, docOK,
+				fmt.Sprintf("the %s provider rejected the credential-less probe (status %d), as expected: the door-to-provider path is intact and harness requests carry their own %s credential", expected, p.Status, expected), "")
+			add("e2e", "route:"+port, docOK,
+				fmt.Sprintf("the configured route for the probe model is %q; the provider's own auth rejection stands in for a completed request", expected), "")
+			continue
+		default:
 			add("e2e", "probe:"+port, docFail,
 				fmt.Sprintf("1-token request through the door failed (status %d): %s", p.Status, orDash(p.Error)),
 				"baseten-switch status   (then check the router and door logs)")
 		}
 		doctorProbeRouteCheck(add, port, p, probeStart, f, routerTargets[t.BindAddr], t.ProtocolShape, telPath)
 	}
+}
+
+// doctorProbeNativeAuthOK reports whether a failed probe still proves
+// the harness path end to end. The probe deliberately carries no
+// provider credential, so on a native-configured route (routing off, or
+// a model_routes native pin for the probe's model) the provider's own
+// 401/403 is the expected answer: it could only have come back through
+// a working door→router→provider relay. Only an HTTP response from the
+// far end qualifies — a transport error (status 0) still fails.
+func doctorProbeNativeAuthOK(f *config.File, routerTarget, shape string, p *doctorProbeResult) bool {
+	if p.Status != http.StatusUnauthorized && p.Status != http.StatusForbidden {
+		return false
+	}
+	cli, ok := doctorClientFor(f, routerTarget, shape)
+	if !ok {
+		return false
+	}
+	globalRoutingEnabled := false
+	if f != nil && f.Global.RoutingEnabled != nil {
+		globalRoutingEnabled = *f.Global.RoutingEnabled
+	}
+	expected := gateway.ExpectedPrimaryRoute(cli, globalRoutingEnabled, doctorProbeRequestModel(shape))
+	return expected == config.NativeRoute(shape)
 }
 
 // doctorProbeRouteCheck asserts the probe was served by the route the

--- a/gateway/cmd/baseten-switch/doctor.go
+++ b/gateway/cmd/baseten-switch/doctor.go
@@ -1472,11 +1472,16 @@ func doctorE2EChecks(add addCheck, o doctorOpts, doorSpecs []door.Config, doorUp
 // the harness path end to end. The probe deliberately carries no
 // provider credential, so on a native-configured route (routing off, or
 // a model_routes native pin for the probe's model) the provider's own
-// 401/403 is the expected answer: it could only have come back through
-// a working door→router→provider relay. Only an HTTP response from the
-// far end qualifies — a transport error (status 0) still fails.
+// 401/403 is the expected answer when the door confirms that the router
+// served it. The explicit router stamp prevents the door's native
+// failover from making a broken router path look healthy. Only an HTTP
+// response from the far end qualifies; a transport error (status 0)
+// still fails.
 func doctorProbeNativeAuthOK(f *config.File, routerTarget, shape string, p *doctorProbeResult) bool {
 	if p.Status != http.StatusUnauthorized && p.Status != http.StatusForbidden {
+		return false
+	}
+	if p.DoorVia != "router" {
 		return false
 	}
 	cli, ok := doctorClientFor(f, routerTarget, shape)

--- a/gateway/cmd/baseten-switch/doctor_test.go
+++ b/gateway/cmd/baseten-switch/doctor_test.go
@@ -2099,6 +2099,43 @@ func TestDoctorProbePinnedNativeRouteAuthRejectionOK(t *testing.T) {
 	}
 }
 
+// TestDoctorProbeNativeRouteAuthRejectionDoorFallbackFails ensures a
+// provider rejection cannot prove the router path when the door's native
+// failover served the request instead.
+func TestDoctorProbeNativeRouteAuthRejectionDoorFallbackFails(t *testing.T) {
+	fx := newDoctorFixture(t, func(c *doctorFixtureCfg) {
+		c.routingOff = true
+		c.clientRoute = "anthropic"
+		c.doorProbe = "fallback"
+		c.probeStatus = http.StatusUnauthorized
+	})
+	rep := runDoctor(doctorOpts{probe: true, yes: true, timeoutSec: 5})
+	if c := findCheck(t, rep, "e2e", "probe:"+fx.doorPort); c.Status != docFail {
+		t.Fatalf("probe = %s (%s), want fail when native failover bypasses the router", c.Status, c.Finding)
+	}
+	if rep.ExitCode != 1 {
+		t.Errorf("exit = %d, want 1", rep.ExitCode)
+	}
+}
+
+// TestDoctorProbeNativeRouteAuthRejectionUnstampedFails ensures an
+// unstamped provider rejection cannot be attributed to the router path.
+func TestDoctorProbeNativeRouteAuthRejectionUnstampedFails(t *testing.T) {
+	fx := newDoctorFixture(t, func(c *doctorFixtureCfg) {
+		c.routingOff = true
+		c.clientRoute = "anthropic"
+		c.doorProbe = "none"
+		c.probeStatus = http.StatusForbidden
+	})
+	rep := runDoctor(doctorOpts{probe: true, yes: true, timeoutSec: 5})
+	if c := findCheck(t, rep, "e2e", "probe:"+fx.doorPort); c.Status != docFail {
+		t.Fatalf("probe = %s (%s), want fail without router provenance", c.Status, c.Finding)
+	}
+	if rep.ExitCode != 1 {
+		t.Errorf("exit = %d, want 1", rep.ExitCode)
+	}
+}
+
 // TestDoctorProbeBasetenRouteAuthRejectionFails guards the boundary of
 // the native allowance: on the baseten route a 401 means the Baseten
 // credential itself is broken, which must keep failing doctor.

--- a/gateway/cmd/baseten-switch/doctor_test.go
+++ b/gateway/cmd/baseten-switch/doctor_test.go
@@ -92,6 +92,14 @@ type doctorFixtureCfg struct {
 	// request completing just behind the probe, the misattribution
 	// hazard for the served-route check.
 	probeConcurrentModel string
+	// probeStatus, when >= 400, makes the fake door answer the probe
+	// with that status and an error body instead of the 200 success
+	// payload (the native provider's auth rejection for the
+	// credential-less probe).
+	probeStatus int
+	// routingOff writes routing_enabled: false so the configured route
+	// for every model is the native one.
+	routingOff bool
 	// codexClient adds an enabled openai-shape codex client sharing the
 	// claude listener (the real shared-listener topology) so the doctor
 	// codex section resolves instead of skipping.
@@ -286,6 +294,11 @@ func newDoctorFixture(t *testing.T, mut func(*doctorFixtureCfg)) *doctorFixture 
 					w.Header().Set("X-Baseten-Switch-Door", cfg.doorProbe)
 				}
 				w.Header().Set("Content-Type", "application/json")
+				if cfg.probeStatus >= 400 {
+					w.WriteHeader(cfg.probeStatus)
+					fmt.Fprint(w, `{"error":{"type":"authentication_error","message":"invalid x-api-key"}}`)
+					return
+				}
 				fmt.Fprint(w, `{"model":"probe-model"}`)
 				return
 			}
@@ -298,8 +311,13 @@ func newDoctorFixture(t *testing.T, mut func(*doctorFixtureCfg)) *doctorFixture 
 
 	// Config.
 	comment := "# doctor test config\n"
+	routingEnabled := "true"
+	if cfg.routingOff {
+		routingEnabled = "false"
+	}
 	globalBlock := fmt.Sprintf(
-		"global:\n  routing_enabled: true\n  telemetry_dir: %q\n",
+		"global:\n  routing_enabled: %s\n  telemetry_dir: %q\n",
+		routingEnabled,
 		telDir,
 	)
 	if cfg.globalAuth != "" {
@@ -2033,6 +2051,84 @@ func TestDoctorProbeUnstampedDoorFails(t *testing.T) {
 		!strings.Contains(c.Finding, "required X-Baseten-Switch-Door") ||
 		!strings.Contains(c.Fix, "baseten-switch up") {
 		t.Fatalf("route = %s (%s), fix %q; want current-contract failure", c.Status, c.Finding, c.Fix)
+	}
+}
+
+// TestDoctorProbeNativeRouteAuthRejectionOK pins the native-passthrough
+// contract: with routing off the probe goes to the native provider
+// carrying no credential, so the provider's 401 is the expected answer
+// on a healthy chain and must not fail doctor (README: doctor exits 0
+// when nothing fails).
+func TestDoctorProbeNativeRouteAuthRejectionOK(t *testing.T) {
+	fx := newDoctorFixture(t, func(c *doctorFixtureCfg) {
+		c.routingOff = true
+		c.clientRoute = "anthropic" // keep the fake admin view consistent
+		c.doorProbe = "router"
+		c.probeStatus = http.StatusUnauthorized
+	})
+	rep := runDoctor(doctorOpts{probe: true, yes: true, timeoutSec: 5})
+	if c := findCheck(t, rep, "e2e", "probe:"+fx.doorPort); c.Status != docOK {
+		t.Fatalf("probe = %s (%s), want ok: the provider's 401 proves the native path", c.Status, c.Finding)
+	}
+	c := findCheck(t, rep, "e2e", "route:"+fx.doorPort)
+	if c.Status != docOK || !strings.Contains(c.Finding, `"anthropic"`) {
+		t.Fatalf("route = %s (%s), want ok naming the native route", c.Status, c.Finding)
+	}
+	if rep.ExitCode != 0 {
+		t.Errorf("exit = %d, want 0 on a healthy native-passthrough chain\nchecks: %+v", rep.ExitCode, rep.Checks)
+	}
+}
+
+// TestDoctorProbePinnedNativeRouteAuthRejectionOK covers the same
+// credential-less rejection with routing ON but the probe's model
+// pinned native: the pin designates the native route, so a 401 from
+// the provider is the healthy answer here too.
+func TestDoctorProbePinnedNativeRouteAuthRejectionOK(t *testing.T) {
+	fx := newDoctorFixture(t, func(c *doctorFixtureCfg) {
+		c.modelRoutes = map[string]string{"opus": "native"}
+		c.doorProbe = "router"
+		c.probeStatus = http.StatusUnauthorized
+	})
+	rep := runDoctor(doctorOpts{probe: true, yes: true, timeoutSec: 5})
+	if c := findCheck(t, rep, "e2e", "probe:"+fx.doorPort); c.Status != docOK {
+		t.Fatalf("probe = %s (%s), want ok on the pin-designated native route", c.Status, c.Finding)
+	}
+	c := findCheck(t, rep, "e2e", "route:"+fx.doorPort)
+	if c.Status != docOK || !strings.Contains(c.Finding, `"anthropic"`) {
+		t.Fatalf("route = %s (%s), want ok naming the native route", c.Status, c.Finding)
+	}
+}
+
+// TestDoctorProbeBasetenRouteAuthRejectionFails guards the boundary of
+// the native allowance: on the baseten route a 401 means the Baseten
+// credential itself is broken, which must keep failing doctor.
+func TestDoctorProbeBasetenRouteAuthRejectionFails(t *testing.T) {
+	fx := newDoctorFixture(t, func(c *doctorFixtureCfg) {
+		c.doorProbe = "router"
+		c.probeStatus = http.StatusUnauthorized
+	})
+	rep := runDoctor(doctorOpts{probe: true, yes: true, timeoutSec: 5})
+	if c := findCheck(t, rep, "e2e", "probe:"+fx.doorPort); c.Status != docFail {
+		t.Fatalf("probe = %s (%s), want fail: a baseten-route 401 is a broken credential", c.Status, c.Finding)
+	}
+	if rep.ExitCode != 1 {
+		t.Errorf("exit = %d, want 1", rep.ExitCode)
+	}
+}
+
+// TestDoctorProbeNativeRouteTransportErrorFails guards the other
+// boundary: only an HTTP auth rejection from the far end counts as
+// path-proving; a connection failure on a native route still fails.
+func TestDoctorProbeNativeRouteTransportErrorFails(t *testing.T) {
+	fx := newDoctorFixture(t, func(c *doctorFixtureCfg) {
+		c.routingOff = true
+		c.clientRoute = "anthropic"
+		c.doorProbe = "router"
+		c.probeStatus = http.StatusBadGateway // not an auth rejection
+	})
+	rep := runDoctor(doctorOpts{probe: true, yes: true, timeoutSec: 5})
+	if c := findCheck(t, rep, "e2e", "probe:"+fx.doorPort); c.Status != docFail {
+		t.Fatalf("probe = %s (%s), want fail on a non-auth error", c.Status, c.Finding)
 	}
 }
 

--- a/gateway/cmd/baseten-switch/menubar.go
+++ b/gateway/cmd/baseten-switch/menubar.go
@@ -39,6 +39,11 @@ const menubarPayloadName = menubarAppName + ".zip"
 // mistaken for the app.
 const menubarProcName = "BasetenSwitch"
 
+// menubarBundleID is the stable channel's bundle identity, checked both
+// when a payload is installed (validateMaterializedMenubarApp) and when
+// the managed bundle is driven or removed (uninstallManagedApp).
+const menubarBundleID = "co.baseten.switch"
+
 // menubarKegPaths is a test seam for the pre-payload bundle source.
 // Production releases resolve the nested ZIP from the running
 // executable's Homebrew Cellar prefix. Keeping the seam lets the
@@ -329,7 +334,7 @@ func validateMaterializedMenubarApp(app string) error {
 	fields := []struct {
 		key, want string
 	}{
-		{"CFBundleIdentifier", "co.baseten.switch"},
+		{"CFBundleIdentifier", menubarBundleID},
 		{"CFBundleDisplayName", "Baseten Switch"},
 		{"CFBundleExecutable", menubarProcName},
 	}

--- a/gateway/cmd/baseten-switch/uninstall.go
+++ b/gateway/cmd/baseten-switch/uninstall.go
@@ -328,6 +328,12 @@ func uninstallManagedApp() error {
 	if out, err := runManagedAppCLI(appPath, menubarLoginItemCLIFlag); err != nil {
 		return manualAppRemovalError(appPath, fmt.Sprintf("the app's login-item unregister failed (%v %s)", err, out))
 	}
+	// The executable we just ran is part of the bundle being removed.
+	// Revalidate after it exits so a modified bundle is never deleted
+	// under the managed-app identity established before execution.
+	if err := verifyManagedAppBundle(appPath); err != nil {
+		return err
+	}
 	if err := os.RemoveAll(appPath); err != nil {
 		return fmt.Errorf("remove %s: %w", appPath, err)
 	}
@@ -339,25 +345,14 @@ func manualAppRemovalError(appPath, reason string) error {
 	return fmt.Errorf("manual action required: %s; open %s, turn off Start at Login, quit the app, then remove it by hand", reason, appPath)
 }
 
-// verifyManagedAppBundle proves the bundle at appPath is the Baseten
-// Switch app before the CLI drives its executable or removes it: the
-// identity fields must match the managed install (the same contract
-// validateMaterializedMenubarApp enforces at install time). Anything
-// else at the managed path is left for manual removal.
+// verifyManagedAppBundle proves the bundle at appPath satisfies the
+// same complete integrity contract used at install time before the CLI
+// drives its executable or removes it. Anything else at the managed
+// path is left for manual removal.
 func verifyManagedAppBundle(appPath string) error {
-	plistPath := filepath.Join(appPath, "Contents", "Info.plist")
-	fields := []struct {
-		key, want string
-	}{
-		{"CFBundleIdentifier", menubarBundleID},
-		{"CFBundleExecutable", menubarProcName},
-	}
-	for _, field := range fields {
-		out, err := runCmd("/usr/bin/plutil", "-extract", field.key, "raw", plistPath)
-		if err != nil || out != field.want {
-			return manualAppRemovalError(appPath,
-				fmt.Sprintf("%s does not present the managed identity (%s is %q)", appPath, field.key, out))
-		}
+	if err := validateMaterializedMenubarApp(appPath); err != nil {
+		return manualAppRemovalError(appPath,
+			fmt.Sprintf("%s does not pass managed app validation (%v)", appPath, err))
 	}
 	return nil
 }

--- a/gateway/cmd/baseten-switch/uninstall.go
+++ b/gateway/cmd/baseten-switch/uninstall.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/basetenlabs/baseten-switch/gateway/internal/launchd"
 )
@@ -285,6 +289,15 @@ func uninstallQuitMenubar() error {
 	return nil
 }
 
+// uninstallManagedApp removes the managed menubar app. The bundle's
+// SMAppService login item can only be unregistered by the app itself,
+// so bundles advertising the headless login-item control (the
+// BasetenSwitchLoginItemCLI Info.plist marker written by
+// build-menubar.sh) are driven with --unregister-login-item first and
+// then removed. Bundles that predate the marker, fail the managed
+// identity check, or reject the unregister keep the manual-removal
+// requirement: a stale login item pointing at a deleted bundle is the
+// failure mode this step exists to avoid.
 func uninstallManagedApp() error {
 	if menubarGOOS != "darwin" {
 		return nil
@@ -300,7 +313,79 @@ func uninstallManagedApp() error {
 	if st.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("refusing symlink %s", appPath)
 	}
-	return fmt.Errorf("manual action required: open %s, turn off Start at Login, quit the app, then remove %s; the CLI cannot safely unregister another app's SMAppService login item", appPath, appPath)
+	if !st.IsDir() {
+		return fmt.Errorf("refusing to remove %s: not an app bundle directory", appPath)
+	}
+	if err := verifyManagedAppBundle(appPath); err != nil {
+		return err
+	}
+	if pid := menubarPid(); pid != 0 {
+		return fmt.Errorf("the menubar app is still running (pid %d); quit it and rerun uninstall", pid)
+	}
+	if !managedAppSupportsLoginItemCLI(appPath) {
+		return manualAppRemovalError(appPath, "the installed app predates CLI login-item control")
+	}
+	if out, err := runManagedAppCLI(appPath, menubarLoginItemCLIFlag); err != nil {
+		return manualAppRemovalError(appPath, fmt.Sprintf("the app's login-item unregister failed (%v %s)", err, out))
+	}
+	if err := os.RemoveAll(appPath); err != nil {
+		return fmt.Errorf("remove %s: %w", appPath, err)
+	}
+	fmt.Fprintf(os.Stderr, "menubar: removed %s\n", appPath)
+	return nil
+}
+
+func manualAppRemovalError(appPath, reason string) error {
+	return fmt.Errorf("manual action required: %s; open %s, turn off Start at Login, quit the app, then remove it by hand", reason, appPath)
+}
+
+// verifyManagedAppBundle proves the bundle at appPath is the Baseten
+// Switch app before the CLI drives its executable or removes it: the
+// identity fields must match the managed install (the same contract
+// validateMaterializedMenubarApp enforces at install time). Anything
+// else at the managed path is left for manual removal.
+func verifyManagedAppBundle(appPath string) error {
+	plistPath := filepath.Join(appPath, "Contents", "Info.plist")
+	fields := []struct {
+		key, want string
+	}{
+		{"CFBundleIdentifier", menubarBundleID},
+		{"CFBundleExecutable", menubarProcName},
+	}
+	for _, field := range fields {
+		out, err := runCmd("/usr/bin/plutil", "-extract", field.key, "raw", plistPath)
+		if err != nil || out != field.want {
+			return manualAppRemovalError(appPath,
+				fmt.Sprintf("%s does not present the managed identity (%s is %q)", appPath, field.key, out))
+		}
+	}
+	return nil
+}
+
+// managedAppSupportsLoginItemCLI reports whether the installed bundle
+// advertises the headless --unregister-login-item mode. Only such
+// bundles can be driven to unregister their own SMAppService login
+// item; anything older requires the manual path.
+func managedAppSupportsLoginItemCLI(appPath string) bool {
+	out, err := runCmd("/usr/bin/plutil", "-extract", "BasetenSwitchLoginItemCLI", "raw",
+		filepath.Join(appPath, "Contents", "Info.plist"))
+	return err == nil && out == "true"
+}
+
+// menubarLoginItemCLIFlag is the bundle's headless one-shot mode that
+// unregisters the app's own SMAppService login item and exits.
+const menubarLoginItemCLIFlag = "--unregister-login-item"
+
+// runManagedAppCLI invokes the installed bundle's executable in a
+// headless one-shot mode, bounded so a bundle that mishandles the flag
+// (launches the UI instead of exiting) cannot hang the uninstall. A var
+// so tests can stub the exec.
+var runManagedAppCLI = func(appPath string, args ...string) (string, error) {
+	exe := filepath.Join(appPath, "Contents", "MacOS", menubarProcName)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, exe, args...).CombinedOutput()
+	return strings.TrimSpace(string(out)), err
 }
 
 func basetenSwitchDataRoot() string {

--- a/gateway/cmd/baseten-switch/uninstall_test.go
+++ b/gateway/cmd/baseten-switch/uninstall_test.go
@@ -209,28 +209,46 @@ func TestUninstallLeavesAppWhenLoginItemCannotBeSafelyUnregistered(t *testing.T)
 	}
 }
 
-// stubManagedAppPlist points the runCmd seam at a plutil answer table
-// for the bundle's Info.plist keys (missing keys error, like plutil on
-// an absent entry); pgrep finds no running menubar process.
-func stubManagedAppPlist(t *testing.T, plist map[string]string) {
+// stubManagedAppCommands points the runCmd seam at a plutil answer
+// table, a code-signature result, and a pgrep result that finds no
+// running menubar process.
+func stubManagedAppCommands(t *testing.T, plist map[string]string, codesignErr error) {
 	t.Helper()
+	fields := map[string]string{
+		"CFBundleIdentifier":         menubarBundleID,
+		"CFBundleDisplayName":        "Baseten Switch",
+		"CFBundleExecutable":         menubarProcName,
+		"CFBundleShortVersionString": "0.2.0",
+	}
+	for key, value := range plist {
+		fields[key] = value
+	}
 	old := runCmd
 	runCmd = func(name string, args ...string) (string, error) {
 		switch {
 		case strings.HasSuffix(name, "plutil"):
 			// plutil -extract <key> raw <path>
 			if len(args) >= 4 {
-				if v, ok := plist[args[1]]; ok {
+				if v, ok := fields[args[1]]; ok {
 					return v, nil
 				}
 			}
 			return "", errors.New("plist key not found")
+		case strings.HasSuffix(name, "codesign"):
+			return "", codesignErr
 		case strings.HasSuffix(name, "pgrep"):
 			return "", errors.New("no processes matched")
 		}
 		return "", fmt.Errorf("unexpected command %s %v", name, args)
 	}
 	t.Cleanup(func() { runCmd = old })
+}
+
+// stubManagedAppPlist installs the valid command results shared by
+// the managed-app removal tests.
+func stubManagedAppPlist(t *testing.T, plist map[string]string) {
+	t.Helper()
+	stubManagedAppCommands(t, plist, nil)
 }
 
 func managedAppFixture(t *testing.T) string {
@@ -241,7 +259,13 @@ func managedAppFixture(t *testing.T) string {
 	menubarGOOS = "darwin"
 	t.Cleanup(func() { menubarGOOS = oldGOOS })
 	app := filepath.Join(home, "Applications", menubarAppName)
-	if err := os.MkdirAll(app, 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(app, "Contents", "MacOS"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, filepath.Join(app, "Contents", "Info.plist"), "plist\n")
+	executable := filepath.Join(app, "Contents", "MacOS", menubarProcName)
+	writeTestFile(t, executable, "executable\n")
+	if err := os.Chmod(executable, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	return app
@@ -329,6 +353,120 @@ func TestUninstallAppManualRemovalWhenUnregisterFails(t *testing.T) {
 	}
 	if _, statErr := os.Stat(app); statErr != nil {
 		t.Fatalf("app was removed despite the failed unregister: %v", statErr)
+	}
+}
+
+func TestUninstallAppRefusesInvalidBundleBeforeExecution(t *testing.T) {
+	tests := []struct {
+		name        string
+		codesignErr error
+		breakBundle func(*testing.T, string)
+	}{
+		{
+			name:        "invalid code signature",
+			codesignErr: errors.New("code object is not signed at all"),
+		},
+		{
+			name: "symlink executable",
+			breakBundle: func(t *testing.T, app string) {
+				t.Helper()
+				executable := filepath.Join(app, "Contents", "MacOS", menubarProcName)
+				if err := os.Remove(executable); err != nil {
+					t.Fatal(err)
+				}
+				target := filepath.Join(t.TempDir(), "replacement")
+				writeTestFile(t, target, "replacement\n")
+				if err := os.Symlink(target, executable); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := managedAppFixture(t)
+			if tt.breakBundle != nil {
+				tt.breakBundle(t, app)
+			}
+			stubManagedAppCommands(t, map[string]string{
+				"BasetenSwitchLoginItemCLI": "true",
+			}, tt.codesignErr)
+			driven := false
+			oldCLI := runManagedAppCLI
+			runManagedAppCLI = func(appPath string, args ...string) (string, error) {
+				driven = true
+				return "", nil
+			}
+			t.Cleanup(func() { runManagedAppCLI = oldCLI })
+
+			err := uninstallManagedApp()
+			if err == nil || !strings.Contains(err.Error(), "manual action required") ||
+				!strings.Contains(err.Error(), "managed app validation") {
+				t.Fatalf("app cleanup error = %v", err)
+			}
+			if driven {
+				t.Error("an invalid bundle must never be exec'd")
+			}
+			if _, statErr := os.Lstat(app); statErr != nil {
+				t.Fatalf("invalid bundle was removed: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestUninstallAppRevalidatesBundleBeforeRemoval(t *testing.T) {
+	app := managedAppFixture(t)
+	fields := map[string]string{
+		"CFBundleIdentifier":         menubarBundleID,
+		"CFBundleDisplayName":        "Baseten Switch",
+		"CFBundleExecutable":         menubarProcName,
+		"CFBundleShortVersionString": "0.2.0",
+		"BasetenSwitchLoginItemCLI":  "true",
+	}
+	codesignCalls := 0
+	oldRunCmd := runCmd
+	runCmd = func(name string, args ...string) (string, error) {
+		switch {
+		case strings.HasSuffix(name, "plutil"):
+			if len(args) >= 4 {
+				if value, ok := fields[args[1]]; ok {
+					return value, nil
+				}
+			}
+			return "", errors.New("plist key not found")
+		case strings.HasSuffix(name, "codesign"):
+			codesignCalls++
+			if codesignCalls == 2 {
+				return "", errors.New("bundle changed after execution")
+			}
+			return "", nil
+		case strings.HasSuffix(name, "pgrep"):
+			return "", errors.New("no processes matched")
+		}
+		return "", fmt.Errorf("unexpected command %s %v", name, args)
+	}
+	t.Cleanup(func() { runCmd = oldRunCmd })
+	driven := false
+	oldCLI := runManagedAppCLI
+	runManagedAppCLI = func(appPath string, args ...string) (string, error) {
+		driven = true
+		return "Start at Login enabled -> notRegistered", nil
+	}
+	t.Cleanup(func() { runManagedAppCLI = oldCLI })
+
+	err := uninstallManagedApp()
+	if err == nil || !strings.Contains(err.Error(), "manual action required") ||
+		!strings.Contains(err.Error(), "code signature is invalid") {
+		t.Fatalf("app cleanup error = %v", err)
+	}
+	if !driven {
+		t.Fatal("the login-item CLI was not driven")
+	}
+	if codesignCalls != 2 {
+		t.Fatalf("codesign validation calls = %d, want 2", codesignCalls)
+	}
+	if _, statErr := os.Lstat(app); statErr != nil {
+		t.Fatalf("bundle was removed after failing revalidation: %v", statErr)
 	}
 }
 

--- a/gateway/cmd/baseten-switch/uninstall_test.go
+++ b/gateway/cmd/baseten-switch/uninstall_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -185,6 +186,9 @@ func TestUninstallPurgeRequiresExplicitNoninteractiveConfirmation(t *testing.T) 
 	}
 }
 
+// The app directory below has no Info.plist at all, so the managed
+// identity check fails and removal stays manual (the same outcome a
+// foreign bundle at the managed path must get).
 func TestUninstallLeavesAppWhenLoginItemCannotBeSafelyUnregistered(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -202,6 +206,148 @@ func TestUninstallLeavesAppWhenLoginItemCannotBeSafelyUnregistered(t *testing.T)
 	}
 	if _, err := os.Stat(app); err != nil {
 		t.Fatalf("app was removed despite unresolved login item: %v", err)
+	}
+}
+
+// stubManagedAppPlist points the runCmd seam at a plutil answer table
+// for the bundle's Info.plist keys (missing keys error, like plutil on
+// an absent entry); pgrep finds no running menubar process.
+func stubManagedAppPlist(t *testing.T, plist map[string]string) {
+	t.Helper()
+	old := runCmd
+	runCmd = func(name string, args ...string) (string, error) {
+		switch {
+		case strings.HasSuffix(name, "plutil"):
+			// plutil -extract <key> raw <path>
+			if len(args) >= 4 {
+				if v, ok := plist[args[1]]; ok {
+					return v, nil
+				}
+			}
+			return "", errors.New("plist key not found")
+		case strings.HasSuffix(name, "pgrep"):
+			return "", errors.New("no processes matched")
+		}
+		return "", fmt.Errorf("unexpected command %s %v", name, args)
+	}
+	t.Cleanup(func() { runCmd = old })
+}
+
+func managedAppFixture(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	oldGOOS := menubarGOOS
+	menubarGOOS = "darwin"
+	t.Cleanup(func() { menubarGOOS = oldGOOS })
+	app := filepath.Join(home, "Applications", menubarAppName)
+	if err := os.MkdirAll(app, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return app
+}
+
+// The managed bundle unregisters its own login item via the headless
+// CLI mode and is then removed: the safe-removal path the step's
+// description promises.
+func TestUninstallRemovesManagedAppAfterLoginItemUnregister(t *testing.T) {
+	app := managedAppFixture(t)
+	stubManagedAppPlist(t, map[string]string{
+		"CFBundleIdentifier":        menubarBundleID,
+		"CFBundleExecutable":        menubarProcName,
+		"BasetenSwitchLoginItemCLI": "true",
+	})
+	driven := false
+	oldCLI := runManagedAppCLI
+	runManagedAppCLI = func(appPath string, args ...string) (string, error) {
+		driven = true
+		if appPath != app || len(args) != 1 || args[0] != menubarLoginItemCLIFlag {
+			t.Errorf("runManagedAppCLI(%q, %v), want (%q, [%s])", appPath, args, app, menubarLoginItemCLIFlag)
+		}
+		return "Start at Login enabled -> notRegistered", nil
+	}
+	t.Cleanup(func() { runManagedAppCLI = oldCLI })
+	if err := uninstallManagedApp(); err != nil {
+		t.Fatalf("uninstallManagedApp = %v", err)
+	}
+	if !driven {
+		t.Fatal("the bundle's login-item CLI mode was not driven before removal")
+	}
+	if _, err := os.Lstat(app); !os.IsNotExist(err) {
+		t.Fatalf("app still present after safe removal: %v", err)
+	}
+}
+
+// A bundle with the managed identity but no login-item CLI marker
+// predates headless control: keep the manual-removal requirement
+// rather than launching an unknown UI mid-uninstall.
+func TestUninstallAppManualRemovalWhenBundlePredatesCLIControl(t *testing.T) {
+	app := managedAppFixture(t)
+	stubManagedAppPlist(t, map[string]string{
+		"CFBundleIdentifier": menubarBundleID,
+		"CFBundleExecutable": menubarProcName,
+	})
+	driven := false
+	oldCLI := runManagedAppCLI
+	runManagedAppCLI = func(appPath string, args ...string) (string, error) {
+		driven = true
+		return "", nil
+	}
+	t.Cleanup(func() { runManagedAppCLI = oldCLI })
+	err := uninstallManagedApp()
+	if err == nil || !strings.Contains(err.Error(), "manual action required") ||
+		!strings.Contains(err.Error(), "Start at Login") {
+		t.Fatalf("app cleanup error = %v", err)
+	}
+	if driven {
+		t.Error("a bundle without the CLI marker must never be exec'd")
+	}
+	if _, statErr := os.Stat(app); statErr != nil {
+		t.Fatalf("app was removed despite missing CLI control: %v", statErr)
+	}
+}
+
+// A failed unregister leaves the bundle in place with the manual
+// instructions; removing it anyway would strand a live login item
+// pointing at a deleted bundle.
+func TestUninstallAppManualRemovalWhenUnregisterFails(t *testing.T) {
+	app := managedAppFixture(t)
+	stubManagedAppPlist(t, map[string]string{
+		"CFBundleIdentifier":        menubarBundleID,
+		"CFBundleExecutable":        menubarProcName,
+		"BasetenSwitchLoginItemCLI": "true",
+	})
+	oldCLI := runManagedAppCLI
+	runManagedAppCLI = func(appPath string, args ...string) (string, error) {
+		return "", errors.New("exit status 1")
+	}
+	t.Cleanup(func() { runManagedAppCLI = oldCLI })
+	err := uninstallManagedApp()
+	if err == nil || !strings.Contains(err.Error(), "manual action required") ||
+		!strings.Contains(err.Error(), "Start at Login") {
+		t.Fatalf("app cleanup error = %v", err)
+	}
+	if _, statErr := os.Stat(app); statErr != nil {
+		t.Fatalf("app was removed despite the failed unregister: %v", statErr)
+	}
+}
+
+// A regular file at the managed path is not a bundle and must not be
+// removed by this step.
+func TestUninstallAppRefusesNonBundle(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	oldGOOS := menubarGOOS
+	menubarGOOS = "darwin"
+	t.Cleanup(func() { menubarGOOS = oldGOOS })
+	app := filepath.Join(home, "Applications", menubarAppName)
+	writeTestFile(t, app, "not a bundle\n")
+	err := uninstallManagedApp()
+	if err == nil || !strings.Contains(err.Error(), "not an app bundle") {
+		t.Fatalf("non-bundle error = %v", err)
+	}
+	if _, statErr := os.Stat(app); statErr != nil {
+		t.Fatalf("non-bundle path was removed: %v", statErr)
 	}
 }
 

--- a/gateway/cmd/gateway/admin_model_catalog_test.go
+++ b/gateway/cmd/gateway/admin_model_catalog_test.go
@@ -365,6 +365,9 @@ func TestAdminModelCatalogIgnoresNonSelectionFieldsAndUsesMetadataFallback(t *te
 
 func TestModelCatalogReasoningProjectionUsesExactBasetenRecord(t *testing.T) {
 	capturedAt := time.Date(2026, time.July, 26, 12, 0, 0, 0, time.UTC)
+	originalNow := modelCatalogNow
+	modelCatalogNow = func() time.Time { return capturedAt }
+	t.Cleanup(func() { modelCatalogNow = originalNow })
 	p := pricing.New()
 	if err := p.ReplaceModelsDev(
 		[]byte(publicCatalogGatewayFixture),

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/BasetenSwitchApp.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/BasetenSwitchApp.swift
@@ -18,6 +18,14 @@ struct BasetenSwitchApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
     init() {
+        // Headless one-shot modes run before the single-instance guard:
+        // the CLI drives --unregister-login-item during uninstall after
+        // quitting the app, and correctness must not depend on the quit
+        // having won (a surviving instance must not turn the unregister
+        // into a silent no-op exit).
+        if LoginItemCLI.requested {
+            LoginItemCLI.run()
+        }
 #if DEBUG
         // Fixture previews are separate and side-effect-free; allow them
         // alongside the packaged menubar process.

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/LoginItem.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/LoginItem.swift
@@ -175,3 +175,62 @@ enum LoginItem {
         FileHandle.standardError.write(Data("[BasetenSwitch] \(msg)\n".utf8))
     }
 }
+
+// MARK: - Headless CLI one-shot mode
+
+/// Whether a post-unregister status counts as removed for the CLI
+/// uninstall path. Pure so the decision table is unit-testable; the
+/// SMAppService calls stay in LoginItemCLI.run (the LoginItem pattern).
+/// .notFound qualifies: macOS reports it when no live registration can
+/// be tied to this bundle (never registered, or a superseded signing
+/// identity), which is exactly the desired end state for uninstall.
+func loginItemUnregisterAccepted(_ status: SMAppService.Status) -> Bool {
+    switch status {
+    case .notRegistered, .notFound:
+        return true
+    case .enabled, .requiresApproval:
+        return false
+    @unknown default:
+        return false
+    }
+}
+
+/// Headless `--unregister-login-item` one-shot mode for
+/// `baseten-switch uninstall`. The SMAppService login item belongs to
+/// this app, so only this process can unregister it; the CLI execs the
+/// bundled executable with the flag after quitting the app. The bundle
+/// advertises support via the BasetenSwitchLoginItemCLI Info.plist
+/// marker (scripts/build-menubar.sh), so the CLI never launches the UI
+/// on bundles that predate this mode.
+enum LoginItemCLI {
+    static let flag = "--unregister-login-item"
+
+    static var requested: Bool {
+        CommandLine.arguments.contains(flag)
+    }
+
+    /// Unregisters and exits: 0 when no live registration remains
+    /// (never-registered and stale .notFound both qualify), 1 when a
+    /// live or pending registration survives. Never returns.
+    static func run() -> Never {
+        let before = LoginItem.status
+        do {
+            try SMAppService.mainApp.unregister()
+        } catch {
+            // unregister() throws when no entry can be tied to this
+            // bundle; that is the desired end state, so the status
+            // re-read below — not the throw — decides the outcome.
+            FileHandle.standardError.write(Data(
+                "[BasetenSwitch] unregister threw (deciding by status): \(error)\n".utf8))
+        }
+        let after = LoginItem.status
+        guard loginItemUnregisterAccepted(after) else {
+            FileHandle.standardError.write(Data(
+                "[BasetenSwitch] Start at Login still \(loginItemStatusName(after)) after unregister\n".utf8))
+            exit(1)
+        }
+        FileHandle.standardOutput.write(Data(
+            "Start at Login \(loginItemStatusName(before)) -> \(loginItemStatusName(after))\n".utf8))
+        exit(0)
+    }
+}

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/LoginItem.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/LoginItem.swift
@@ -181,14 +181,15 @@ enum LoginItem {
 /// Whether a post-unregister status counts as removed for the CLI
 /// uninstall path. Pure so the decision table is unit-testable; the
 /// SMAppService calls stay in LoginItemCLI.run (the LoginItem pattern).
-/// .notFound qualifies: macOS reports it when no live registration can
-/// be tied to this bundle (never registered, or a superseded signing
-/// identity), which is exactly the desired end state for uninstall.
+/// Only .notRegistered confirms the desired end state. Apple's public
+/// contract describes .notFound as an error in which the service could
+/// not be found, not as confirmation that unregister completed, so the
+/// destructive uninstall path must fail closed on that status.
 func loginItemUnregisterAccepted(_ status: SMAppService.Status) -> Bool {
     switch status {
-    case .notRegistered, .notFound:
+    case .notRegistered:
         return true
-    case .enabled, .requiresApproval:
+    case .enabled, .requiresApproval, .notFound:
         return false
     @unknown default:
         return false
@@ -209,17 +210,16 @@ enum LoginItemCLI {
         CommandLine.arguments.contains(flag)
     }
 
-    /// Unregisters and exits: 0 when no live registration remains
-    /// (never-registered and stale .notFound both qualify), 1 when a
-    /// live or pending registration survives. Never returns.
+    /// Unregisters and exits: 0 only when the post-call status confirms
+    /// .notRegistered, 1 when removal is not confirmed. Never returns.
     static func run() -> Never {
         let before = LoginItem.status
         do {
             try SMAppService.mainApp.unregister()
         } catch {
-            // unregister() throws when no entry can be tied to this
-            // bundle; that is the desired end state, so the status
-            // re-read below — not the throw — decides the outcome.
+            // The status re-read below decides the outcome. A thrown
+            // call followed by .notFound is not accepted because
+            // neither result confirms that unregistration completed.
             FileHandle.standardError.write(Data(
                 "[BasetenSwitch] unregister threw (deciding by status): \(error)\n".utf8))
         }

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/LoginItem.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/LoginItem.swift
@@ -178,18 +178,47 @@ enum LoginItem {
 
 // MARK: - Headless CLI one-shot mode
 
-/// Whether a post-unregister status counts as removed for the CLI
+/// Whether an unregister attempt counts as removed for the CLI
 /// uninstall path. Pure so the decision table is unit-testable; the
 /// SMAppService calls stay in LoginItemCLI.run (the LoginItem pattern).
-/// Only .notRegistered confirms the desired end state. Apple's public
-/// contract describes .notFound as an error in which the service could
-/// not be found, not as confirmation that unregister completed, so the
-/// destructive uninstall path must fail closed on that status.
-func loginItemUnregisterAccepted(_ status: SMAppService.Status) -> Bool {
-    switch status {
+///
+/// Only .notRegistered confirms unregistration completed. Apple's
+/// public contract describes .notFound as an error in which the service
+/// could not be found, not as confirmation, so a registration that was
+/// live or pending before the call and reads .notFound after it fails
+/// closed: something went wrong and deleting the bundle could strand a
+/// login item macOS still tries to launch.
+///
+/// .notFound is accepted only when the status before the call already
+/// ruled out a live registration, which is the separate never-resolvable
+/// case. Beta builds are ad-hoc signed (scripts/build-menubar.sh), so an
+/// upgrade gives the bundle a new code identity and macOS stops
+/// resolving any registration for it. No unregister() this bundle can
+/// make will ever move that status, so failing closed does not protect
+/// the user — it strands the app bundle on disk on top of a registration
+/// we already cannot reach, and `uninstall` can never succeed. Removing
+/// a bundle that had no live registration going in cannot take down a
+/// login item that was reachable in the first place.
+func loginItemUnregisterAccepted(before: SMAppService.Status, after: SMAppService.Status) -> Bool {
+    switch after {
     case .notRegistered:
         return true
-    case .enabled, .requiresApproval, .notFound:
+    case .notFound:
+        return loginItemRegistrationAbsent(before)
+    case .enabled, .requiresApproval:
+        return false
+    @unknown default:
+        return false
+    }
+}
+
+/// Whether a status rules out a live or pending login-item registration.
+/// An unknown future status does not, so it fails closed.
+func loginItemRegistrationAbsent(_ status: SMAppService.Status) -> Bool {
+    switch status {
+    case .notRegistered, .notFound:
+        return true
+    case .enabled, .requiresApproval:
         return false
     @unknown default:
         return false
@@ -210,23 +239,22 @@ enum LoginItemCLI {
         CommandLine.arguments.contains(flag)
     }
 
-    /// Unregisters and exits: 0 only when the post-call status confirms
-    /// .notRegistered, 1 when removal is not confirmed. Never returns.
+    /// Unregisters and exits: 0 when the status pair confirms no live
+    /// registration is left behind, 1 when removal is not confirmed.
+    /// Never returns.
     static func run() -> Never {
         let before = LoginItem.status
         do {
             try SMAppService.mainApp.unregister()
         } catch {
-            // The status re-read below decides the outcome. A thrown
-            // call followed by .notFound is not accepted because
-            // neither result confirms that unregistration completed.
+            // The status pair below decides the outcome, not the throw.
             FileHandle.standardError.write(Data(
                 "[BasetenSwitch] unregister threw (deciding by status): \(error)\n".utf8))
         }
         let after = LoginItem.status
-        guard loginItemUnregisterAccepted(after) else {
+        guard loginItemUnregisterAccepted(before: before, after: after) else {
             FileHandle.standardError.write(Data(
-                "[BasetenSwitch] Start at Login still \(loginItemStatusName(after)) after unregister\n".utf8))
+                "[BasetenSwitch] Start at Login \(loginItemStatusName(before)) -> \(loginItemStatusName(after)); removal not confirmed\n".utf8))
             exit(1)
         }
         FileHandle.standardOutput.write(Data(

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/LoginItemTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/LoginItemTests.swift
@@ -107,6 +107,23 @@ final class LoginItemTests: XCTestCase {
         XCTAssertFalse(startAtLoginOpensSystemSettings(status: .notFound))
     }
 
+    // MARK: - CLI uninstall acceptance
+
+    // The headless --unregister-login-item mode exits 0 exactly when no
+    // live registration can remain: never-registered and the stale
+    // .notFound both qualify (nothing points at the about-to-be-deleted
+    // bundle), while a live or pending registration fails the run so
+    // the CLI keeps the bundle and prints the manual path. An unknown
+    // future status fails closed.
+    func testLoginItemUnregisterAccepted() throws {
+        XCTAssertTrue(loginItemUnregisterAccepted(.notRegistered))
+        XCTAssertTrue(loginItemUnregisterAccepted(.notFound))
+        XCTAssertFalse(loginItemUnregisterAccepted(.enabled))
+        XCTAssertFalse(loginItemUnregisterAccepted(.requiresApproval))
+        let future = try XCTUnwrap(SMAppService.Status(rawValue: 999))
+        XCTAssertFalse(loginItemUnregisterAccepted(future))
+    }
+
     // Log names stay stable so the reconciliation transition line is
     // greppable across releases.
     func testLoginItemStatusName() throws {

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/LoginItemTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/LoginItemTests.swift
@@ -109,17 +109,43 @@ final class LoginItemTests: XCTestCase {
 
     // MARK: - CLI uninstall acceptance
 
-    // The headless --unregister-login-item mode exits 0 only when
-    // .notRegistered confirms removal. Apple's public contract defines
-    // .notFound as a lookup error, not successful unregistration, so it
-    // fails closed along with live, pending, and unknown future states.
+    // The headless --unregister-login-item mode exits 0 when
+    // .notRegistered confirms removal, whatever the prior status. Live,
+    // pending, and unknown future end states fail closed.
     func testLoginItemUnregisterAccepted() throws {
-        XCTAssertTrue(loginItemUnregisterAccepted(.notRegistered))
-        XCTAssertFalse(loginItemUnregisterAccepted(.notFound))
-        XCTAssertFalse(loginItemUnregisterAccepted(.enabled))
-        XCTAssertFalse(loginItemUnregisterAccepted(.requiresApproval))
+        XCTAssertTrue(loginItemUnregisterAccepted(before: .enabled, after: .notRegistered))
+        XCTAssertTrue(loginItemUnregisterAccepted(before: .notFound, after: .notRegistered))
+        XCTAssertFalse(loginItemUnregisterAccepted(before: .enabled, after: .enabled))
+        XCTAssertFalse(loginItemUnregisterAccepted(before: .enabled, after: .requiresApproval))
         let future = try XCTUnwrap(SMAppService.Status(rawValue: 999))
-        XCTAssertFalse(loginItemUnregisterAccepted(future))
+        XCTAssertFalse(loginItemUnregisterAccepted(before: .enabled, after: future))
+    }
+
+    // .notFound is a lookup error, not confirmation of unregistration,
+    // so a registration that was live or pending before the call and is
+    // .notFound after it fails closed. .notFound going in is the
+    // distinct never-resolvable case (an ad-hoc signed bundle whose code
+    // identity changed across an upgrade): no unregister() this bundle
+    // can make will move that status, so refusing would strand the app
+    // forever rather than protect a login item we could still reach.
+    func testLoginItemUnregisterNotFoundDependsOnPriorStatus() throws {
+        XCTAssertTrue(loginItemUnregisterAccepted(before: .notFound, after: .notFound))
+        XCTAssertTrue(loginItemUnregisterAccepted(before: .notRegistered, after: .notFound))
+        XCTAssertFalse(loginItemUnregisterAccepted(before: .enabled, after: .notFound))
+        XCTAssertFalse(loginItemUnregisterAccepted(before: .requiresApproval, after: .notFound))
+        let future = try XCTUnwrap(SMAppService.Status(rawValue: 999))
+        XCTAssertFalse(loginItemUnregisterAccepted(before: future, after: .notFound))
+    }
+
+    // The prior-status gate is the "no live registration going in" test
+    // on its own; an unknown future status fails closed.
+    func testLoginItemRegistrationAbsent() throws {
+        XCTAssertTrue(loginItemRegistrationAbsent(.notRegistered))
+        XCTAssertTrue(loginItemRegistrationAbsent(.notFound))
+        XCTAssertFalse(loginItemRegistrationAbsent(.enabled))
+        XCTAssertFalse(loginItemRegistrationAbsent(.requiresApproval))
+        let future = try XCTUnwrap(SMAppService.Status(rawValue: 999))
+        XCTAssertFalse(loginItemRegistrationAbsent(future))
     }
 
     // Log names stay stable so the reconciliation transition line is

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/LoginItemTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/LoginItemTests.swift
@@ -109,15 +109,13 @@ final class LoginItemTests: XCTestCase {
 
     // MARK: - CLI uninstall acceptance
 
-    // The headless --unregister-login-item mode exits 0 exactly when no
-    // live registration can remain: never-registered and the stale
-    // .notFound both qualify (nothing points at the about-to-be-deleted
-    // bundle), while a live or pending registration fails the run so
-    // the CLI keeps the bundle and prints the manual path. An unknown
-    // future status fails closed.
+    // The headless --unregister-login-item mode exits 0 only when
+    // .notRegistered confirms removal. Apple's public contract defines
+    // .notFound as a lookup error, not successful unregistration, so it
+    // fails closed along with live, pending, and unknown future states.
     func testLoginItemUnregisterAccepted() throws {
         XCTAssertTrue(loginItemUnregisterAccepted(.notRegistered))
-        XCTAssertTrue(loginItemUnregisterAccepted(.notFound))
+        XCTAssertFalse(loginItemUnregisterAccepted(.notFound))
         XCTAssertFalse(loginItemUnregisterAccepted(.enabled))
         XCTAssertFalse(loginItemUnregisterAccepted(.requiresApproval))
         let future = try XCTUnwrap(SMAppService.Status(rawValue: 999))

--- a/scripts/build-menubar.sh
+++ b/scripts/build-menubar.sh
@@ -158,6 +158,13 @@ cat > "$APP/Contents/Info.plist" <<EOF
 	<string>${EXECUTABLE_NAME}</string>
 	<key>BasetenSwitchBuildChannel</key>
 	<string>${BUILD_CHANNEL}</string>
+	<!-- Advertises the headless --unregister-login-item one-shot mode:
+	     only the app itself can unregister its SMAppService login item,
+	     so `baseten-switch uninstall` checks this marker before driving
+	     the bundled executable; bundles without it get the manual
+	     removal instructions. -->
+	<key>BasetenSwitchLoginItemCLI</key>
+	<true/>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
## What

Two independent user-facing fixes:

1. **`doctor --probe` no longer fails on a healthy native route.** With routing off (or a `model_routes` native pin for the probe's model), the credential-less probe reaches the native provider, whose 401/403 is the expected answer on a healthy chain. The pass is fail-closed: it requires the door's `X-Baseten-Switch-Door: router` stamp (so door native failover cannot fake a healthy router path), an auth status only (transport errors and other statuses still fail), and a configured native route for the probe model (a 401 on the Baseten route is a broken Baseten credential and still fails).
2. **`uninstall` actually removes the Mac app.** The step previously failed unconditionally whenever `~/Applications/Baseten Switch.app` existed. The bundle now advertises a `BasetenSwitchLoginItemCLI` Info.plist marker and answers `--unregister-login-item` headlessly, exiting 0 only when the post-unregister status confirms `.notRegistered`. `uninstall` validates the managed bundle identity (the same contract enforced at install time, including `codesign --verify --deep --strict`), refuses to run while the app is still running, drives the one-shot mode under a 15s bound, revalidates the bundle after that exec, and only then removes it. Bundles that predate the marker, fail validation, or do not confirm the unregister keep the manual-removal requirement.

## Why

- `doctor` promises "exit 0 when nothing fails" (usage text) and the README promises "the first failure with a concrete fix", but every routing-off install — the default state for anyone evaluating native passthrough — got a spurious probe failure with a misleading router/door-logs fix.
- `uninstall` documented removing "the Mac app" (README) but had no code path that could ever do it: only the app itself can unregister its SMAppService login item, so the step always demanded manual removal and `uninstall` always exited 1.

## Testing

- `gofmt` / `go vet` clean; `go test ./...` green. New Go tests:
  - doctor: native-route 401/403 passes with routing off and with a pinned-native probe model; door-fallback and unstamped rejections fail; Baseten-route 401 fails; non-auth statuses fail.
  - uninstall: removal after a confirmed unregister; manual removal when the bundle predates the marker or the unregister fails; refusal of invalid signatures, symlinked executables, and non-bundles; post-exec revalidation blocks removal when the bundle changed under the CLI.
- `swift test` green in the macOS release gate (`scripts/check.sh --offline`), covering the `loginItemUnregisterAccepted` decision table: only `.notRegistered` confirms removal; `.notFound` (an Apple lookup error, not a success signal), `.enabled`, `.requiresApproval`, and unknown future statuses all fail closed.
- Real-machine verification (macOS 15.7.7, ad-hoc-signed bundle built from this branch): app launch registered the login item; after quit, `--unregister-login-item` printed `Start at Login enabled -> notRegistered` and exited 0 headlessly in ~35ms; a never-registered bundle exits 1 and keeps the manual-removal path.
- Also includes a test-only pin of the model-catalog freshness clock (deflake after the merge from main).

## Security and privacy

- This change lets `uninstall` execute a bundle-resident binary and then delete the bundle, so both actions are gated: identity and signature validation (the install-time contract) run before the binary is ever executed, only bundles advertising the headless marker are driven, execution is bounded at 15s and never launches the UI, and the bundle is revalidated between execution and deletion so a bundle modified by its own run is not deleted under a stale identity. Symlinks and non-bundles at the managed path are refused.
- The doctor relaxation is narrow: it applies only to 401/403 responses the door explicitly stamps as router-served on a natively configured route. It cannot turn door failover, an unreachable router, or a broken Baseten credential into a pass.
- No new network or credential surface: the login-item unregister is a local SMAppService call made by the owning app about itself.
