### PR TITLE
Fix Claude Code integration settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ baseten-switch pi uninstall
 
 ## Claude Code
 
-`baseten-switch claude on` saves the previous Claude Code setting and points
-new sessions at Baseten Switch. Restart Claude Code after enabling or
-disabling the integration.
+`baseten-switch claude on` saves the previous Claude Code environment values,
+points new sessions at Baseten Switch, enables deferred tool loading, and
+omits Claude Code's attribution block to improve gateway prompt-cache hit
+rates. Restart Claude Code after enabling or disabling the integration.
 
 Useful controls:
 

--- a/gateway/cmd/baseten-switch/claude_adapter.go
+++ b/gateway/cmd/baseten-switch/claude_adapter.go
@@ -1,17 +1,16 @@
 // claude_adapter.go implements `baseten-switch claude on|off|status` and
 // `baseten-switch claude subagents [<model>|off]`.
 //
-// `on` points ~/.claude/settings.json at the gateway door by setting
-// ANTHROPIC_BASE_URL in the env block and takes a key-level backup of
-// the user's prior values on the FIRST on only, and only when the
-// current state is not already gateway-managed, so a repeated `on`
-// can never snapshot our own config as "the user's original".
-// `subagents <model>` manages CLAUDE_CODE_SUBAGENT_MODEL the same way
-// Both managed keys join the backup
-// ADDITIVELY the first time it becomes managed. `off` restores the
-// backup exactly, or degrades to strip-only-owned when the backup is
-// missing, the file drifted after `on`, or the backup itself is
-// poisoned.
+// `on` configures ~/.claude/settings.json for the gateway by setting
+// ANTHROPIC_BASE_URL, CLAUDE_CODE_ATTRIBUTION_HEADER, and
+// ENABLE_TOOL_SEARCH in the env block. It takes a key-level backup of
+// the user's prior values on the FIRST on only, and never snapshots a
+// gateway-owned base URL as "the user's original".
+// Older versions managed CLAUDE_CODE_SUBAGENT_MODEL in settings.
+// `off` retains cleanup support for that retired state. Backups grow
+// additively as new keys become managed. `off` restores the backup
+// exactly, or degrades to strip-only-owned when the backup is missing,
+// the file drifted after `on`, or the backup itself is poisoned.
 //
 // JSON round-trip note: settings.json is parsed and re-marshaled with
 // two-space indentation; all values (including number literals, via
@@ -39,7 +38,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/fs"
 	"net"
 	"net/url"
 	"os"
@@ -51,22 +49,44 @@ import (
 	"github.com/basetenlabs/baseten-switch/gateway/cmd/gateway"
 	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
 	"github.com/basetenlabs/baseten-switch/gateway/internal/pidfile"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/safefile"
 )
 
 const (
-	claudeManagedEnvKey  = "ANTHROPIC_BASE_URL"
-	claudeSubagentEnvKey = "CLAUDE_CODE_SUBAGENT_MODEL"
-	claudeAliasPrefix    = "claude-baseten-" // the model-discovery contract alias namespace
-	claudeHarnessName    = "claude"
+	claudeManagedEnvKey     = "ANTHROPIC_BASE_URL"
+	claudeAttributionEnvKey = "CLAUDE_CODE_ATTRIBUTION_HEADER"
+	claudeToolSearchEnvKey  = "ENABLE_TOOL_SEARCH"
+	claudeSubagentEnvKey    = "CLAUDE_CODE_SUBAGENT_MODEL"
+	claudeAliasPrefix       = "claude-baseten-" // the model-discovery contract alias namespace
+	claudeHarnessName       = "claude"
+
+	claudeAttributionValue = "0"
+	// Claude Code documents "true" as the always-on tool-search value.
+	// Keep this centralized because accepted values are versioned by the
+	// harness, while the adapter's backup/restore behavior is key-based.
+	claudeToolSearchValue = "true"
 
 	// Status uses 0 = on and 3 = off (1 is reserved for operational
 	// errors, 2 for usage).
 	statusExitOff = 3
 )
 
-// claudeManagedEnvKeys is the complete managed key set. off restores or
-// strips exactly these keys; nothing else in the env block is ours.
-var claudeManagedEnvKeys = []string{claudeManagedEnvKey, claudeSubagentEnvKey}
+// claudeOnEnvKeys is the complete settings env state installed by
+// `claude on`. claudeManagedEnvKeys also includes the retired
+// settings-side subagent key so `off` can still clean up old installs.
+var (
+	claudeOnEnvKeys = []string{
+		claudeManagedEnvKey,
+		claudeAttributionEnvKey,
+		claudeToolSearchEnvKey,
+	}
+	claudeManagedEnvKeys = []string{
+		claudeManagedEnvKey,
+		claudeAttributionEnvKey,
+		claudeToolSearchEnvKey,
+		claudeSubagentEnvKey,
+	}
+)
 
 func cmdClaude(args []string) int {
 	if len(args) == 0 {
@@ -127,6 +147,17 @@ type claudeAdapter struct {
 	gatewayPorts map[string]bool   // every local port we consider "ours" (door binds + router listeners)
 	modelAliases map[string]string // the target client's model_aliases (subagent alias validation)
 	out          io.Writer         // human-readable action/warning output
+}
+
+// claudeBeforeSettingsMutation is a test seam for changes after the adapter
+// has staged recovery state but before safefile revalidates the preimage.
+var claudeBeforeSettingsMutation func()
+
+func (a *claudeAdapter) acquireSettingsMutationLock() (*configMutationLock, error) {
+	if err := os.MkdirAll(filepath.Dir(a.backupPath), 0o700); err != nil {
+		return nil, fmt.Errorf("create backup directory for settings lock: %w", err)
+	}
+	return acquireConfigMutationLock(a.backupPath)
 }
 
 func (a *claudeAdapter) requiresJournaledMutation(_ mutationOptions) (bool, error) {
@@ -296,6 +327,36 @@ func (a *claudeAdapter) desiredURL() string {
 	return "http://127.0.0.1:" + a.desiredPort
 }
 
+func (a *claudeAdapter) desiredClaudeEnvValue(key string) string {
+	switch key {
+	case claudeManagedEnvKey:
+		return a.desiredURL()
+	case claudeAttributionEnvKey:
+		return claudeAttributionValue
+	case claudeToolSearchEnvKey:
+		return claudeToolSearchValue
+	default:
+		return ""
+	}
+}
+
+// claudeOnState reports both the routing ownership state and whether all
+// three `claude on` values exactly match the desired configuration.
+func (a *claudeAdapter) claudeOnState(env map[string]any) (baseManaged, complete bool) {
+	base, baseSet := envString(env, claudeManagedEnvKey)
+	baseManaged = baseSet && a.isGatewayURL(base)
+	if !baseManaged {
+		return false, false
+	}
+	for _, key := range claudeOnEnvKeys {
+		cur, ok := envString(env, key)
+		if !ok || cur != a.desiredClaudeEnvValue(key) {
+			return true, false
+		}
+	}
+	return true, true
+}
+
 // isGatewayURL reports whether a base URL points at a local gateway
 // port (127.0.0.1 or localhost on a door or router port). This is the
 // "we own this value" test used for the managed check, the
@@ -346,10 +407,17 @@ func claudeSubagentOwned(v string) bool {
 // ownedEnvValue dispatches the per-key ownership test used by the
 // strip-only-owned paths and the poisoned-backup guard.
 func (a *claudeAdapter) ownedEnvValue(key, val string) bool {
-	if key == claudeSubagentEnvKey {
+	switch key {
+	case claudeSubagentEnvKey:
 		return claudeSubagentOwned(val)
+	case claudeManagedEnvKey:
+		return a.isGatewayURL(val)
+	default:
+		// Fixed-value Claude Code knobs can legitimately predate
+		// Baseten Switch. They are removable only when a backup proves
+		// this invocation managed them.
+		return false
 	}
-	return a.isGatewayURL(val)
 }
 
 // --- settings.json round-trip ---------------------------------------------
@@ -358,62 +426,50 @@ func (a *claudeAdapter) ownedEnvValue(key, val string) bool {
 // are decoded as json.Number so literals survive the round-trip
 // byte-exactly. An absent file returns existed=false and an empty root.
 func loadClaudeSettings(path string) (root map[string]any, raw []byte, existed bool, err error) {
-	raw, err = os.ReadFile(path)
+	root, snap, err := readClaudeSettings(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return map[string]any{}, nil, false, nil
-		}
-		return nil, nil, false, fmt.Errorf("read %s: %w", path, err)
+		return nil, nil, false, err
 	}
+	return root, snap.Data, snap.Exists, nil
+}
+
+// readClaudeSettings keeps the safe-file snapshot associated with the bytes
+// that were parsed. Mutating callers must commit through this exact snapshot
+// so concurrent edits and link retargeting are detected.
+func readClaudeSettings(path string) (map[string]any, *safefile.Snapshot, error) {
+	snap, err := safefile.Read(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	if !snap.Exists {
+		return map[string]any{}, snap, nil
+	}
+	raw := snap.Data
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.UseNumber()
-	root = map[string]any{}
+	root := map[string]any{}
 	if err := dec.Decode(&root); err != nil {
-		return nil, nil, true, fmt.Errorf("parse %s: %w (not touching it)", path, err)
+		return nil, nil, fmt.Errorf("parse %s: %w (not touching it)", path, err)
 	}
-	return root, raw, true, nil
+	return root, snap, nil
 }
 
 // writeClaudeSettings marshals the tree with two-space indentation and
-// writes it atomically (temp file + rename), preserving the existing
-// file mode (0600 for a newly created file since the env block can
-// hold tokens). Returns the bytes written for hashing.
-func writeClaudeSettings(path string, root map[string]any) ([]byte, error) {
+// replaces it through the exact snapshot that was read, preserving the
+// existing file mode (0600 for a newly created file since the env block can
+// hold tokens). The safe-file layer preserves final-component symlinks and
+// rejects stale, dangling, non-regular, or multiply hard-linked targets.
+func writeClaudeSettings(snap *safefile.Snapshot, root map[string]any) ([]byte, *safefile.Snapshot, error) {
 	b, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {
-		return nil, fmt.Errorf("marshal settings: %w", err)
+		return nil, nil, fmt.Errorf("marshal settings: %w", err)
 	}
 	b = append(b, '\n')
-	mode := fs.FileMode(0o600)
-	if st, err := os.Stat(path); err == nil {
-		mode = st.Mode().Perm()
-	}
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return nil, fmt.Errorf("mkdir %s: %w", dir, err)
-	}
-	tmp, err := os.CreateTemp(dir, ".settings.json.*")
+	committed, err := snap.Replace(b, 0o600)
 	if err != nil {
-		return nil, err
+		return b, committed, err
 	}
-	if _, err := tmp.Write(b); err != nil {
-		tmp.Close()
-		os.Remove(tmp.Name())
-		return nil, err
-	}
-	if err := tmp.Close(); err != nil {
-		os.Remove(tmp.Name())
-		return nil, err
-	}
-	if err := os.Chmod(tmp.Name(), mode); err != nil {
-		os.Remove(tmp.Name())
-		return nil, err
-	}
-	if err := os.Rename(tmp.Name(), path); err != nil {
-		os.Remove(tmp.Name())
-		return nil, err
-	}
-	return b, nil
+	return b, committed, nil
 }
 
 // settingsEnv returns the env block as a mutable map, or nil when
@@ -444,18 +500,21 @@ func envString(env map[string]any, key string) (string, bool) {
 // Values/Missing cover the managed env keys only, so user edits to
 // hooks, permissions, and other env between on and off survive off.
 // Model/ModelMissing snapshot the top-level "model" field for the
-// the model-discovery contract persisted-alias trap. WrittenHash is the
-// sha256 of the file exactly as written at `on`; a mismatch at `off`
-// downgrades restore to strip-only-owned.
+// model-discovery contract persisted-alias trap. WrittenHash, ResolvedPath,
+// and WrittenIdentity bind the backup to the file generation written by
+// `on`; a mismatch at `off` downgrades restore to strip-only-owned, while a
+// changed resolved target is refused.
 type claudeBackup struct {
-	ConfigPath   string            `json:"config_path"`
-	Values       map[string]string `json:"values"`
-	Missing      []string          `json:"missing"`
-	EnvExisted   bool              `json:"env_existed"`
-	Model        string            `json:"model,omitempty"`
-	ModelMissing bool              `json:"model_missing"`
-	Existed      bool              `json:"existed"`
-	WrittenHash  string            `json:"written_hash"`
+	ConfigPath      string             `json:"config_path"`
+	ResolvedPath    string             `json:"resolved_path,omitempty"`
+	WrittenIdentity *safefile.Identity `json:"written_identity,omitempty"`
+	Values          map[string]string  `json:"values"`
+	Missing         []string           `json:"missing"`
+	EnvExisted      bool               `json:"env_existed"`
+	Model           string             `json:"model,omitempty"`
+	ModelMissing    bool               `json:"model_missing"`
+	Existed         bool               `json:"existed"`
+	WrittenHash     string             `json:"written_hash"`
 }
 
 // claudeBackupPath keys the backup file by sha256(settings path) so
@@ -528,12 +587,30 @@ func recordBackupKey(bak *claudeBackup, key, cur string, curSet bool) {
 	}
 }
 
-// poisonedBackup reports whether the backup's own values are
-// gateway-owned (per-key test); restoring such a backup would
-// re-manage the harness on `off`, so it is discarded instead.
+func cloneClaudeBackup(bak *claudeBackup) *claudeBackup {
+	if bak == nil {
+		return nil
+	}
+	cloned := *bak
+	cloned.Values = make(map[string]string, len(bak.Values))
+	for key, value := range bak.Values {
+		cloned.Values[key] = value
+	}
+	cloned.Missing = append([]string(nil), bak.Missing...)
+	if bak.WrittenIdentity != nil {
+		identity := *bak.WrittenIdentity
+		cloned.WrittenIdentity = &identity
+	}
+	return &cloned
+}
+
+// poisonedBackup reports whether restoring the backup would route the
+// harness back through the gateway. The fixed attribution/tool-search
+// values do not control routing and can legitimately predate `on`, so
+// they are safe to restore.
 func (a *claudeAdapter) poisonedBackup(bak *claudeBackup) bool {
 	for k, v := range bak.Values {
-		if a.ownedEnvValue(k, v) {
+		if (k == claudeManagedEnvKey || k == claudeSubagentEnvKey) && a.ownedEnvValue(k, v) {
 			return true
 		}
 	}
@@ -545,43 +622,99 @@ func sha256Hex(b []byte) string {
 	return hex.EncodeToString(sum[:])
 }
 
+func recordClaudeBackupFile(bak *claudeBackup, snap *safefile.Snapshot) {
+	bak.ResolvedPath = snap.ResolvedPath
+	if snap.Exists {
+		identity := snap.Identity
+		bak.WrittenIdentity = &identity
+	} else {
+		bak.WrittenIdentity = nil
+	}
+}
+
+// claudeBackupMatchesFile binds a link-aware backup to the file committed by
+// `on`. Legacy backups remain valid for direct regular paths. A legacy backup
+// is not allowed to clean-restore through a link because it does not identify
+// the target to which its values belong.
+func claudeBackupMatchesFile(bak *claudeBackup, snap *safefile.Snapshot) bool {
+	if bak.ResolvedPath == "" || bak.WrittenIdentity == nil {
+		return !snap.Linked
+	}
+	return bak.ResolvedPath == snap.ResolvedPath &&
+		*bak.WrittenIdentity == snap.Identity
+}
+
+// claudeBackupTargetSafe permits the normal Claude Code rewrite case, where
+// the file generation changes at the same logical target. It refuses a linked
+// path that now resolves somewhere else, and refuses legacy backups through
+// links because those backups have no target provenance.
+func claudeBackupTargetSafe(bak *claudeBackup, snap *safefile.Snapshot) bool {
+	if bak.ResolvedPath == "" || bak.WrittenIdentity == nil {
+		return !snap.Linked
+	}
+	return bak.ResolvedPath == snap.ResolvedPath
+}
+
 // --- on ---------------------------------------------------------------------
 
 func (a *claudeAdapter) on() int {
-	root, raw, existed, err := loadClaudeSettings(a.settingsPath)
+	lock, err := a.acquireSettingsMutationLock()
+	if err != nil {
+		fmt.Fprintf(a.out, "claude on: lock settings mutation: %v\n", err)
+		return 1
+	}
+	defer lock.close()
+
+	root, snap, err := readClaudeSettings(a.settingsPath)
 	if err != nil {
 		fmt.Fprintf(a.out, "claude on: %v\n", err)
 		return 1
 	}
+	raw := snap.Data
+	existed := snap.Exists
 	env, err := settingsEnv(root)
 	if err != nil {
 		fmt.Fprintf(a.out, "claude on: %v\n", err)
 		return 1
 	}
 	envExistedPre := env != nil
-	cur, curSet := envString(env, claudeManagedEnvKey)
-	managed := curSet && a.isGatewayURL(cur)
+	baseManaged, _ := a.claudeOnState(env)
 
 	bak, err := loadClaudeBackup(a.backupPath)
 	if err != nil {
 		fmt.Fprintf(a.out, "claude on: %v\n", err)
 		return 1
 	}
+	originalBackup := cloneClaudeBackup(bak)
+	if bak != nil && !claudeBackupTargetSafe(bak, snap) {
+		fmt.Fprintf(a.out, "claude on: refusing to modify %s because it no longer resolves to the target recorded by the backup; link and backup left intact\n",
+			a.settingsPath)
+		return 1
+	}
 
-	desired := a.desiredURL()
-	changed := !curSet || cur != desired
+	changedKeys := make([]string, 0, len(claudeOnEnvKeys))
+	for _, key := range claudeOnEnvKeys {
+		cur, curSet := envString(env, key)
+		if !curSet || cur != a.desiredClaudeEnvValue(key) {
+			changedKeys = append(changedKeys, key)
+		}
+	}
+	changed := len(changedKeys) > 0
 
 	// Persist the backup BEFORE modifying the settings file, so no
 	// failure or crash window exists in which the file is modified but
 	// the user's original state is not durably recorded. The staged
 	// WrittenHash is the pre-on file hash: if we crash before the
 	// write below, off sees a hash match and its restore is a no-op.
-	// A backup that exists but does not cover the base-URL key (it was
-	// created by `subagents` before the first `on`) is extended
-	// ADDITIVELY: the key's prior state is recorded without touching
-	// the entries already there.
+	//
+	// A legacy backup may cover only ANTHROPIC_BASE_URL. Extend it
+	// additively with both fixed-value keys before upgrading the file.
+	// A gateway-owned base URL is never recorded as an original value,
+	// but the fixed-value keys are backed up even in a base-only legacy
+	// state so custom or manually-added values restore exactly.
 	var nb *claudeBackup
-	if bak == nil && !managed {
+	backupChanged := false
+	if bak == nil && changed {
 		nb = &claudeBackup{
 			ConfigPath:  a.settingsPath,
 			Values:      map[string]string{},
@@ -589,37 +722,103 @@ func (a *claudeAdapter) on() int {
 			Existed:     existed,
 			WrittenHash: sha256Hex(raw),
 		}
-		recordBackupKey(nb, claudeManagedEnvKey, cur, curSet)
+		for _, key := range claudeOnEnvKeys {
+			if key == claudeManagedEnvKey && baseManaged {
+				continue
+			}
+			cur, curSet := envString(env, key)
+			recordBackupKey(nb, key, cur, curSet)
+		}
 		if m, ok := root["model"].(string); ok {
 			nb.Model = m
 		} else {
 			nb.ModelMissing = true
 		}
+		recordClaudeBackupFile(nb, snap)
 		if err := saveClaudeBackup(a.backupPath, nb); err != nil {
 			fmt.Fprintf(a.out, "claude on: write backup: %v (settings untouched)\n", err)
 			return 1
 		}
-	} else if bak != nil && !managed && !backupCovers(bak, claudeManagedEnvKey) {
-		recordBackupKey(bak, claudeManagedEnvKey, cur, curSet)
-		bak.WrittenHash = sha256Hex(raw)
-		if err := saveClaudeBackup(a.backupPath, bak); err != nil {
-			fmt.Fprintf(a.out, "claude on: write backup: %v (settings untouched)\n", err)
-			return 1
+		backupChanged = true
+	} else if bak != nil {
+		for _, key := range claudeOnEnvKeys {
+			if backupCovers(bak, key) || (key == claudeManagedEnvKey && baseManaged) {
+				continue
+			}
+			cur, curSet := envString(env, key)
+			recordBackupKey(bak, key, cur, curSet)
+			backupChanged = true
+		}
+		if backupChanged {
+			bak.WrittenHash = sha256Hex(raw)
+			recordClaudeBackupFile(bak, snap)
+			if err := saveClaudeBackup(a.backupPath, bak); err != nil {
+				fmt.Fprintf(a.out, "claude on: write backup: %v (settings untouched)\n", err)
+				return 1
+			}
 		}
 	}
 
 	newRaw := raw
+	committed := snap
 	if changed {
 		if env == nil {
 			env = map[string]any{}
 			root["env"] = env
 		}
-		env[claudeManagedEnvKey] = desired
-		newRaw, err = writeClaudeSettings(a.settingsPath, root)
+		for _, key := range changedKeys {
+			env[key] = a.desiredClaudeEnvValue(key)
+		}
+		if claudeBeforeSettingsMutation != nil {
+			claudeBeforeSettingsMutation()
+		}
+		newRaw, committed, err = writeClaudeSettings(snap, root)
 		if err != nil {
-			if nb != nil {
-				// Nothing was modified; drop the staged backup.
-				os.Remove(a.backupPath)
+			if !safefile.CommitApplied(err) {
+				switch {
+				case nb != nil:
+					// Nothing was modified; drop the staged backup.
+					_ = os.Remove(a.backupPath)
+				case backupChanged && originalBackup != nil:
+					if restoreErr := saveClaudeBackup(a.backupPath, originalBackup); restoreErr != nil {
+						fmt.Fprintf(a.out, "claude on: warning: settings were untouched, but the prior backup could not be restored: %v\n", restoreErr)
+					}
+				}
+			}
+			if safefile.CommitApplied(err) {
+				hashTarget := nb
+				if hashTarget == nil {
+					hashTarget = bak
+				}
+				if committed == nil {
+					if current, readErr := safefile.Read(a.settingsPath); readErr == nil &&
+						current.Exists && bytes.Equal(current.Data, newRaw) {
+						committed = current
+					}
+				}
+				if hashTarget != nil && committed != nil {
+					hashTarget.WrittenHash = sha256Hex(newRaw)
+					recordClaudeBackupFile(hashTarget, committed)
+					if saveErr := saveClaudeBackup(a.backupPath, hashTarget); saveErr != nil {
+						fmt.Fprintf(a.out, "claude on: warning: could not bind the retained backup to the committed file: %v\n", saveErr)
+					}
+				}
+				fmt.Fprintln(a.out, "claude on: settings changed, but post-commit verification failed; original backup retained")
+			}
+			fmt.Fprintf(a.out, "claude on: %v\n", err)
+			return 1
+		}
+	}
+
+	if !changed && backupChanged {
+		if claudeBeforeSettingsMutation != nil {
+			claudeBeforeSettingsMutation()
+		}
+		if err := snap.Verify(); err != nil {
+			if originalBackup != nil {
+				if restoreErr := saveClaudeBackup(a.backupPath, originalBackup); restoreErr != nil {
+					fmt.Fprintf(a.out, "claude on: warning: settings changed concurrently and the prior backup could not be restored: %v\n", restoreErr)
+				}
 			}
 			fmt.Fprintf(a.out, "claude on: %v\n", err)
 			return 1
@@ -630,21 +829,27 @@ func (a *claudeAdapter) on() int {
 	// here only degrades off to its strip-only-owned drift path (the
 	// original user values above are already durable), so warn rather
 	// than fail.
-	if hashTarget := nb; hashTarget != nil || (bak != nil && changed) {
+	if hashTarget := nb; hashTarget != nil || (bak != nil && (changed || backupChanged)) {
 		if hashTarget == nil {
 			hashTarget = bak
 		}
 		hashTarget.WrittenHash = sha256Hex(newRaw)
+		recordClaudeBackupFile(hashTarget, committed)
 		if err := saveClaudeBackup(a.backupPath, hashTarget); err != nil {
 			fmt.Fprintf(a.out, "claude on: warning: could not refresh the backup drift hash: %v\n", err)
 		}
 	}
 
 	if changed {
-		fmt.Fprintf(a.out, "claude: on (%s -> %s in %s)\n", claudeManagedEnvKey, desired, a.settingsPath)
+		assignments := make([]string, 0, len(claudeOnEnvKeys))
+		for _, key := range claudeOnEnvKeys {
+			assignments = append(assignments, key+"="+a.desiredClaudeEnvValue(key))
+		}
+		fmt.Fprintf(a.out, "claude: on (%s in %s)\n", strings.Join(assignments, ", "), a.settingsPath)
 		fmt.Fprintln(a.out, "restart Claude Code sessions to pick this up; revert with 'baseten-switch claude off'.")
 	} else {
-		fmt.Fprintf(a.out, "claude: already on (%s = %s)\n", claudeManagedEnvKey, desired)
+		fmt.Fprintf(a.out, "claude: already on (%s, %s=%s, %s=%s)\n",
+			a.desiredURL(), claudeAttributionEnvKey, claudeAttributionValue, claudeToolSearchEnvKey, claudeToolSearchValue)
 	}
 	return 0
 }
@@ -652,11 +857,20 @@ func (a *claudeAdapter) on() int {
 // --- off --------------------------------------------------------------------
 
 func (a *claudeAdapter) off() int {
-	root, raw, existed, err := loadClaudeSettings(a.settingsPath)
+	lock, err := a.acquireSettingsMutationLock()
+	if err != nil {
+		fmt.Fprintf(a.out, "claude off: lock settings mutation: %v\n", err)
+		return 1
+	}
+	defer lock.close()
+
+	root, snap, err := readClaudeSettings(a.settingsPath)
 	if err != nil {
 		fmt.Fprintf(a.out, "claude off: %v\n", err)
 		return 1
 	}
+	raw := snap.Data
+	existed := snap.Exists
 	bak, err := loadClaudeBackup(a.backupPath)
 	if err != nil {
 		fmt.Fprintf(a.out, "claude off: %v\n", err)
@@ -678,7 +892,13 @@ func (a *claudeAdapter) off() int {
 	}
 
 	if bak == nil {
-		return a.offStripOnly(root, existed, nil)
+		return a.offStripOnly(root, snap, nil)
+	}
+
+	if !claudeBackupTargetSafe(bak, snap) {
+		fmt.Fprintf(a.out, "claude off: refusing to modify %s because it no longer resolves to the target recorded by 'on'; link and backup left intact\n",
+			a.settingsPath)
+		return 1
 	}
 
 	if !existed {
@@ -686,6 +906,10 @@ func (a *claudeAdapter) off() int {
 		// on, gone is exactly the restored state.
 		if bak.Existed {
 			fmt.Fprintf(a.out, "warning: %s is gone but the backup says it existed before 'on'; original managed values: %v\n", a.settingsPath, bak.Values)
+		}
+		if err := snap.Remove(); err != nil {
+			fmt.Fprintf(a.out, "claude off: verify absent settings %s: %v\n", a.settingsPath, err)
+			return 1
 		}
 		if err := os.Remove(a.backupPath); err != nil {
 			fmt.Fprintf(a.out, "claude off: remove backup: %v\n", err)
@@ -695,7 +919,7 @@ func (a *claudeAdapter) off() int {
 		return 0
 	}
 
-	if sha256Hex(raw) != bak.WrittenHash {
+	if sha256Hex(raw) != bak.WrittenHash || !claudeBackupMatchesFile(bak, snap) {
 		env, envErr := settingsEnv(root)
 		cur, curSet := envString(env, claudeManagedEnvKey)
 		stillManaged := envErr == nil && curSet && a.isGatewayURL(cur)
@@ -707,29 +931,32 @@ func (a *claudeAdapter) off() int {
 			// Present tense: the definitive success line comes from
 			// offStripOnly after the write lands, so nothing is
 			// claimed done before it is.
-			fmt.Fprintf(a.out, "claude off: %s changed since 'on' (normal: Claude Code rewrites it as you work), so stripping only the gateway-owned keys instead of restoring the backup; your edits are kept\n",
-				a.settingsPath)
-			rc := a.offStripOnly(root, existed, bak)
-			// Strip-only DELETES the managed key; it never restores
-			// bak.Values. When a pre-'on' value existed the file now
-			// ends with no base URL at all and Claude Code silently
-			// routes to api.anthropic.com, so say the value was not
-			// put back and how to get it back. A key that was unset
-			// before 'on' needs no note: stripping IS the restore.
+			if sha256Hex(raw) == bak.WrittenHash {
+				fmt.Fprintf(a.out, "claude off: %s no longer resolves to the file generation recorded by 'on', so stripping only the gateway-owned keys instead of restoring the backup\n",
+					a.settingsPath)
+			} else {
+				fmt.Fprintf(a.out, "claude off: %s changed since 'on' (normal: Claude Code rewrites it as you work), so stripping only the gateway-owned keys instead of restoring the backup; your edits are kept\n",
+					a.settingsPath)
+			}
+			rc := a.offStripOnly(root, snap, bak)
+			// Strip-only DELETES gateway-owned values; it never restores
+			// bak.Values. Name every pre-'on' value that was not put
+			// back so the conservative drift behavior is explicit.
 			if rc == 0 {
-				if v, ok := bak.Values[claudeManagedEnvKey]; ok {
-					fmt.Fprintf(a.out, "note: your pre-'on' %s %q was NOT restored on this path; re-add it to %s manually if you still need it\n",
-						claudeManagedEnvKey, v, a.settingsPath)
-				}
+				a.reportUnrestoredBackupValues(root, bak)
 			}
 			return rc
 		}
 		// Genuinely surprising, unlike the drift above: the file no
 		// longer points at the gateway at all, so something other than
 		// this tool redirected the harness. Keep the warning prefix.
-		fmt.Fprintf(a.out, "warning: %s changed since 'on' and no longer points at the gateway; leaving it alone and clearing the backup. Original %s: %s\n",
+		fmt.Fprintf(a.out, "warning: %s changed since 'on' and no longer points at the gateway; preserving user-owned values, stripping covered Switch values, and clearing the backup. Original %s: %s\n",
 			a.settingsPath, claudeManagedEnvKey, backupValueLabel(bak))
-		return a.offStripOnly(root, existed, bak)
+		rc := a.offStripOnly(root, snap, bak)
+		if rc == 0 {
+			a.reportUnrestoredBackupValues(root, bak)
+		}
+		return rc
 	}
 
 	// Clean restore: hash matches the file exactly as written at on.
@@ -763,13 +990,17 @@ func (a *claudeAdapter) off() int {
 	a.fixModelAlias(root, bak)
 
 	if !bak.Existed && len(root) == 0 {
-		if err := os.Remove(a.settingsPath); err != nil && !os.IsNotExist(err) {
+		if snap.FinalLinked {
+			fmt.Fprintf(a.out, "claude off: refusing to remove linked settings target %s; backup retained\n", a.settingsPath)
+			return 1
+		}
+		if err := snap.Remove(); err != nil {
 			fmt.Fprintf(a.out, "claude off: remove %s: %v\n", a.settingsPath, err)
 			return 1
 		}
 		fmt.Fprintf(a.out, "claude: off (%s did not exist before 'on'; removed)\n", a.settingsPath)
 	} else {
-		if _, err := writeClaudeSettings(a.settingsPath, root); err != nil {
+		if _, _, err := writeClaudeSettings(snap, root); err != nil {
 			fmt.Fprintf(a.out, "claude off: %v\n", err)
 			return 1
 		}
@@ -782,13 +1013,18 @@ func (a *claudeAdapter) off() int {
 	return 0
 }
 
-// offStripOnly is the conservative path: delete the managed keys only
-// when their value points at a gateway port; never touch other
-// values, never create a missing file. bak, when non-nil, is consumed
-// (deleted) and used only to resolve a persisted model alias.
-func (a *claudeAdapter) offStripOnly(root map[string]any, existed bool, bak *claudeBackup) int {
-	if !existed {
+// offStripOnly is the conservative path: delete routing values only
+// when they are gateway-owned, and delete fixed-value Claude knobs only
+// when a backup proves `on` changed them and they still match what it
+// wrote. Never touch preexisting matching, drifted, or unproven values,
+// and never create a missing file. bak, when non-nil, is consumed.
+func (a *claudeAdapter) offStripOnly(root map[string]any, snap *safefile.Snapshot, bak *claudeBackup) int {
+	if !snap.Exists {
 		if bak != nil {
+			if err := snap.Remove(); err != nil {
+				fmt.Fprintf(a.out, "claude off: verify absent settings %s: %v\n", a.settingsPath, err)
+				return 1
+			}
 			os.Remove(a.backupPath)
 		}
 		fmt.Fprintf(a.out, "claude: off (no settings file at %s; nothing to do)\n", a.settingsPath)
@@ -802,7 +1038,21 @@ func (a *claudeAdapter) offStripOnly(root map[string]any, existed bool, bak *cla
 	changed := false
 	var strippedKeys []string
 	for _, k := range claudeManagedEnvKeys {
-		if cur, ok := envString(env, k); ok && a.ownedEnvValue(k, cur) {
+		cur, ok := envString(env, k)
+		strip := ok && a.ownedEnvValue(k, cur)
+		prior, priorSet := "", false
+		if bak != nil {
+			prior, priorSet = bak.Values[k]
+		}
+		// A covered prior value equal to the desired value predated
+		// `on`; preserve it during drift instead of claiming ownership.
+		if ok && backupCovers(bak, k) &&
+			(k == claudeAttributionEnvKey || k == claudeToolSearchEnvKey) &&
+			cur == a.desiredClaudeEnvValue(k) &&
+			!(priorSet && prior == cur) {
+			strip = true
+		}
+		if strip {
 			delete(env, k)
 			changed = true
 			strippedKeys = append(strippedKeys, k)
@@ -815,12 +1065,18 @@ func (a *claudeAdapter) offStripOnly(root map[string]any, existed bool, bak *cla
 		changed = true
 	}
 	if changed {
-		if _, err := writeClaudeSettings(a.settingsPath, root); err != nil {
+		if _, _, err := writeClaudeSettings(snap, root); err != nil {
 			fmt.Fprintf(a.out, "claude off: %v\n", err)
 			return 1
 		}
 	}
 	if bak != nil {
+		if !changed {
+			if err := snap.Verify(); err != nil {
+				fmt.Fprintf(a.out, "claude off: settings changed before backup cleanup: %v\n", err)
+				return 1
+			}
+		}
 		if err := os.Remove(a.backupPath); err != nil {
 			fmt.Fprintf(a.out, "claude off: remove backup: %v\n", err)
 			return 1
@@ -835,6 +1091,24 @@ func (a *claudeAdapter) offStripOnly(root map[string]any, existed bool, bak *cla
 		fmt.Fprintf(a.out, "claude: off (noop; %s is not gateway-managed)\n", a.settingsPath)
 	}
 	return 0
+}
+
+// reportUnrestoredBackupValues explains values that the conservative
+// drift path could not safely restore. Do not report a value when the
+// post-strip settings already contain the same value.
+func (a *claudeAdapter) reportUnrestoredBackupValues(root map[string]any, bak *claudeBackup) {
+	afterEnv, _ := settingsEnv(root)
+	for _, key := range claudeManagedEnvKeys {
+		v, ok := bak.Values[key]
+		if !ok {
+			continue
+		}
+		if got, set := envString(afterEnv, key); set && got == v {
+			continue
+		}
+		fmt.Fprintf(a.out, "note: your pre-'on' %s %q was NOT restored on this path; re-add it to %s manually if you still need it\n",
+			key, v, a.settingsPath)
+	}
 }
 
 // fixModelAlias handles the the model-discovery contract persisted-alias
@@ -1659,22 +1933,22 @@ func routeEnvSlotKeys() []string {
 // --- status -----------------------------------------------------------------
 
 func (a *claudeAdapter) status(stdout io.Writer) int {
-	root, _, existed, err := loadClaudeSettings(a.settingsPath)
+	root, snap, err := readClaudeSettings(a.settingsPath)
 	if err != nil {
 		fmt.Fprintf(a.out, "claude status: %v\n", err)
 		return 1
 	}
-	var cur string
-	var curSet bool
+	existed := snap.Exists
+	var env map[string]any
 	if existed {
-		env, envErr := settingsEnv(root)
+		var envErr error
+		env, envErr = settingsEnv(root)
 		if envErr != nil {
 			fmt.Fprintf(a.out, "claude status: %v\n", envErr)
 			return 1
 		}
-		cur, curSet = envString(env, claudeManagedEnvKey)
 	}
-	managed := curSet && a.isGatewayURL(cur)
+	baseManaged, complete := a.claudeOnState(env)
 	backupPresent := false
 	if _, err := os.Stat(a.backupPath); err == nil {
 		backupPresent = true
@@ -1690,19 +1964,37 @@ func (a *claudeAdapter) status(stdout io.Writer) int {
 		}
 	}
 	state := "off (not gateway-managed)"
-	if managed {
+	if complete {
 		state = "on (gateway-managed)"
+	} else if baseManaged {
+		state = "incomplete (base URL is gateway-managed; run 'baseten-switch claude on' to repair settings)"
 	}
 	fmt.Fprintf(stdout, "claude: %s\n", state)
-	fmt.Fprintf(stdout, "  settings:            %s%s\n", a.settingsPath, map[bool]string{true: "", false: " (absent)"}[existed])
-	fmt.Fprintf(stdout, "  %s:  %s\n", claudeManagedEnvKey, orDash(cur))
+	fmt.Fprintf(stdout, "  settings:            %s (%s)\n", a.settingsPath, safefileTopologyLabel(snap))
+	for _, key := range claudeOnEnvKeys {
+		cur, _ := envString(env, key)
+		fmt.Fprintf(stdout, "  %-21s %s\n", key+":", orDash(cur))
+	}
 	fmt.Fprintf(stdout, "  subagents:           %s\n", subLabel)
 	fmt.Fprintf(stdout, "  door port:           %s (target %s)\n", a.desiredPort, a.desiredURL())
 	fmt.Fprintf(stdout, "  backup:              %s\n", map[bool]string{true: "present (" + a.backupPath + ")", false: "none"}[backupPresent])
-	if managed {
+	if complete {
 		return 0
 	}
 	return statusExitOff
+}
+
+func safefileTopologyLabel(snap *safefile.Snapshot) string {
+	if snap == nil {
+		return "unresolved"
+	}
+	if !snap.Exists {
+		return "absent"
+	}
+	if snap.Linked {
+		return "linked -> " + snap.ResolvedPath
+	}
+	return "direct regular file"
 }
 
 // backupValueLabel renders the backed-up managed values for warnings.

--- a/gateway/cmd/baseten-switch/claude_adapter_link_test.go
+++ b/gateway/cmd/baseten-switch/claude_adapter_link_test.go
@@ -1,0 +1,611 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+func requireSymlinks(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("symbolic-link test requires link privileges")
+	}
+}
+
+func TestClaudeOnOffPreservesLinkedSettings(t *testing.T) {
+	requireSymlinks(t)
+	cases := []struct {
+		name string
+		link func(t *testing.T, requested, target string)
+	}{
+		{
+			name: "absolute",
+			link: func(t *testing.T, requested, target string) {
+				t.Helper()
+				if err := os.Symlink(target, requested); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "relative multihop",
+			link: func(t *testing.T, requested, target string) {
+				t.Helper()
+				middle := filepath.Join(filepath.Dir(requested), "settings.shared")
+				if err := os.Symlink(filepath.Base(target), middle); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(filepath.Base(middle), requested); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a, out := testAdapter(t)
+			if err := os.MkdirAll(filepath.Dir(a.settingsPath), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			target := filepath.Join(filepath.Dir(a.settingsPath), "cloud-settings.json")
+			original := []byte(`{"env":{"ANTHROPIC_BASE_URL":"https://proxy.example.com","CLAUDE_CODE_ATTRIBUTION_HEADER":"custom-before","ENABLE_TOOL_SEARCH":"auto:25","OTHER":"keep"},"theme":"dark"}`)
+			if err := os.WriteFile(target, original, 0o640); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chmod(target, 0o640); err != nil {
+				t.Fatal(err)
+			}
+			tc.link(t, a.settingsPath, target)
+			linkText, err := os.Readlink(a.settingsPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if code := a.on(); code != 0 {
+				t.Fatalf("on = %d (%s)", code, out.String())
+			}
+			if got, err := os.Readlink(a.settingsPath); err != nil || got != linkText {
+				t.Fatalf("on changed link: text=%q err=%v, want %q", got, err, linkText)
+			}
+			assertClaudeOnValues(t, a)
+			if got, _ := envValue(t, target, "OTHER"); got != "keep" {
+				t.Fatalf("unrelated env after on = %q", got)
+			}
+			if got := readTree(t, target)["theme"]; got != "dark" {
+				t.Fatalf("unrelated setting after on = %v", got)
+			}
+			if st, err := os.Stat(target); err != nil || st.Mode().Perm() != 0o640 {
+				t.Fatalf("linked target mode after on = %v, err=%v", st.Mode().Perm(), err)
+			}
+			bak, err := loadClaudeBackup(a.backupPath)
+			if err != nil || bak == nil {
+				t.Fatalf("load backup: bak=%v err=%v", bak, err)
+			}
+			wantResolved, err := filepath.EvalSymlinks(a.settingsPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if bak.ResolvedPath != wantResolved || bak.WrittenIdentity == nil {
+				t.Fatalf("backup target metadata = resolved %q identity %v, want %q", bak.ResolvedPath, bak.WrittenIdentity, wantResolved)
+			}
+			for _, key := range claudeOnEnvKeys {
+				if !backupCovers(bak, key) {
+					t.Errorf("backup does not cover %s", key)
+				}
+			}
+
+			if code := a.off(); code != 0 {
+				t.Fatalf("off = %d (%s)", code, out.String())
+			}
+			if got, err := os.Readlink(a.settingsPath); err != nil || got != linkText {
+				t.Fatalf("off changed link: text=%q err=%v, want %q", got, err, linkText)
+			}
+			for key, want := range map[string]string{
+				claudeManagedEnvKey:     "https://proxy.example.com",
+				claudeAttributionEnvKey: "custom-before",
+				claudeToolSearchEnvKey:  "auto:25",
+				"OTHER":                 "keep",
+			} {
+				if got, ok := envValue(t, target, key); !ok || got != want {
+					t.Errorf("%s after off = %q, ok=%v, want %q", key, got, ok, want)
+				}
+			}
+			if st, err := os.Stat(target); err != nil || st.Mode().Perm() != 0o640 {
+				t.Fatalf("linked target mode after off = %v, err=%v", st.Mode().Perm(), err)
+			}
+		})
+	}
+}
+
+func TestClaudeLinkedSettingsRefusalsLeaveTopologyUntouched(t *testing.T) {
+	t.Run("hard linked target", func(t *testing.T) {
+		a, out := testAdapter(t)
+		if err := os.MkdirAll(filepath.Dir(a.settingsPath), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		target := filepath.Join(filepath.Dir(a.settingsPath), "shared.json")
+		original := []byte(`{"env":{"ANTHROPIC_BASE_URL":"https://proxy.example.com","CLAUDE_CODE_ATTRIBUTION_HEADER":"custom","ENABLE_TOOL_SEARCH":"auto"}}`)
+		if err := os.WriteFile(target, original, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Link(target, a.settingsPath); err != nil {
+			t.Fatal(err)
+		}
+		if code := a.on(); code != 1 {
+			t.Fatalf("on = %d, want refusal (%s)", code, out.String())
+		}
+		if got := fileBytes(t, target); !bytes.Equal(got, original) {
+			t.Fatalf("hard-linked target changed: %s", got)
+		}
+		if got := fileBytes(t, a.settingsPath); !bytes.Equal(got, original) {
+			t.Fatalf("hard-linked requested path changed: %s", got)
+		}
+		if _, err := os.Stat(a.backupPath); !os.IsNotExist(err) {
+			t.Fatalf("backup survived refused mutation: %v", err)
+		}
+	})
+
+	t.Run("dangling final symlink", func(t *testing.T) {
+		requireSymlinks(t)
+		a, out := testAdapter(t)
+		if err := os.MkdirAll(filepath.Dir(a.settingsPath), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		linkText := "missing.json"
+		if err := os.Symlink(linkText, a.settingsPath); err != nil {
+			t.Fatal(err)
+		}
+		if code := a.on(); code != 1 {
+			t.Fatalf("on = %d, want refusal (%s)", code, out.String())
+		}
+		if got, err := os.Readlink(a.settingsPath); err != nil || got != linkText {
+			t.Fatalf("dangling link changed: text=%q err=%v", got, err)
+		}
+		if _, err := os.Stat(a.backupPath); !os.IsNotExist(err) {
+			t.Fatalf("backup written for dangling link: %v", err)
+		}
+	})
+}
+
+func TestClaudeSettingsSnapshotRejectsConcurrentReplacement(t *testing.T) {
+	a, _ := testAdapter(t)
+	writeSettingsFile(t, a, `{"env":{"ANTHROPIC_BASE_URL":"https://proxy.example.com"}}`)
+	root, snap, err := readClaudeSettings(a.settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env, err := settingsEnv(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range claudeOnEnvKeys {
+		env[key] = a.desiredClaudeEnvValue(key)
+	}
+	concurrent := []byte(`{"env":{"ANTHROPIC_BASE_URL":"https://concurrent.example.com","CLAUDE_CODE_ATTRIBUTION_HEADER":"concurrent","ENABLE_TOOL_SEARCH":"manual"}}`)
+	replacement := a.settingsPath + ".concurrent"
+	if err := os.WriteFile(replacement, concurrent, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(replacement, a.settingsPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := writeClaudeSettings(snap, root); err == nil {
+		t.Fatal("write through stale snapshot succeeded")
+	}
+	if got := fileBytes(t, a.settingsPath); !bytes.Equal(got, concurrent) {
+		t.Fatalf("stale snapshot overwrote concurrent edit: %s", got)
+	}
+}
+
+func TestClaudeSettingsSnapshotRejectsLinkRetarget(t *testing.T) {
+	requireSymlinks(t)
+	a, _ := testAdapter(t)
+	if err := os.MkdirAll(filepath.Dir(a.settingsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	first := filepath.Join(filepath.Dir(a.settingsPath), "first.json")
+	second := filepath.Join(filepath.Dir(a.settingsPath), "second.json")
+	firstRaw := []byte(`{"env":{"ANTHROPIC_BASE_URL":"https://first.example.com"}}`)
+	secondRaw := []byte(`{"env":{"ANTHROPIC_BASE_URL":"https://second.example.com"}}`)
+	if err := os.WriteFile(first, firstRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(second, secondRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Base(first), a.settingsPath); err != nil {
+		t.Fatal(err)
+	}
+	root, snap, err := readClaudeSettings(a.settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env, err := settingsEnv(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range claudeOnEnvKeys {
+		env[key] = a.desiredClaudeEnvValue(key)
+	}
+	if err := os.Remove(a.settingsPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Base(second), a.settingsPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := writeClaudeSettings(snap, root); err == nil {
+		t.Fatal("write through retargeted link succeeded")
+	}
+	if got := fileBytes(t, first); !bytes.Equal(got, firstRaw) {
+		t.Fatalf("original target changed: %s", got)
+	}
+	if got := fileBytes(t, second); !bytes.Equal(got, secondRaw) {
+		t.Fatalf("retargeted target changed: %s", got)
+	}
+}
+
+func TestClaudeOffRefusesRetargetedSettingsLink(t *testing.T) {
+	requireSymlinks(t)
+	a, out := testAdapter(t)
+	if err := os.MkdirAll(filepath.Dir(a.settingsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	first := filepath.Join(filepath.Dir(a.settingsPath), "first.json")
+	second := filepath.Join(filepath.Dir(a.settingsPath), "second.json")
+	original := []byte(`{"env":{"ANTHROPIC_BASE_URL":"https://first.example.com","CLAUDE_CODE_ATTRIBUTION_HEADER":"first","ENABLE_TOOL_SEARCH":"first"},"owner":"first"}`)
+	unrelated := []byte(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081","CLAUDE_CODE_ATTRIBUTION_HEADER":"0","ENABLE_TOOL_SEARCH":"true"},"owner":"second"}`)
+	if err := os.WriteFile(first, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(second, unrelated, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Base(first), a.settingsPath); err != nil {
+		t.Fatal(err)
+	}
+	if code := a.on(); code != 0 {
+		t.Fatalf("on = %d (%s)", code, out.String())
+	}
+	firstAfterOn := fileBytes(t, first)
+	if err := os.Remove(a.settingsPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Base(second), a.settingsPath); err != nil {
+		t.Fatal(err)
+	}
+
+	out.Reset()
+	if code := a.off(); code != 1 {
+		t.Fatalf("off = %d, want retarget refusal (%s)", code, out.String())
+	}
+	if got := fileBytes(t, first); !bytes.Equal(got, firstAfterOn) {
+		t.Fatalf("original target changed: %s", got)
+	}
+	if got := fileBytes(t, second); !bytes.Equal(got, unrelated) {
+		t.Fatalf("retargeted file changed: %s", got)
+	}
+	if _, err := os.Stat(a.backupPath); err != nil {
+		t.Fatalf("retarget refusal cleared backup: %v", err)
+	}
+}
+
+func TestClaudeOnRejectsLinkRetargetAfterBackup(t *testing.T) {
+	requireSymlinks(t)
+	a, out := testAdapter(t)
+	if err := os.MkdirAll(filepath.Dir(a.settingsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	first := filepath.Join(filepath.Dir(a.settingsPath), "first.json")
+	second := filepath.Join(filepath.Dir(a.settingsPath), "second.json")
+	firstRaw := []byte(`{"env":{"ANTHROPIC_BASE_URL":"https://first.example.com","CLAUDE_CODE_ATTRIBUTION_HEADER":"first","ENABLE_TOOL_SEARCH":"first"}}`)
+	secondRaw := []byte(`{"env":{"ANTHROPIC_BASE_URL":"https://second.example.com","CLAUDE_CODE_ATTRIBUTION_HEADER":"second","ENABLE_TOOL_SEARCH":"second"}}`)
+	if err := os.WriteFile(first, firstRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(second, secondRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Base(first), a.settingsPath); err != nil {
+		t.Fatal(err)
+	}
+	oldHook := claudeBeforeSettingsMutation
+	claudeBeforeSettingsMutation = func() {
+		if err := os.Remove(a.settingsPath); err != nil {
+			panic(err)
+		}
+		if err := os.Symlink(filepath.Base(second), a.settingsPath); err != nil {
+			panic(err)
+		}
+	}
+	t.Cleanup(func() { claudeBeforeSettingsMutation = oldHook })
+
+	if code := a.on(); code != 1 {
+		t.Fatalf("on = %d, want retarget conflict (%s)", code, out.String())
+	}
+	if got := fileBytes(t, first); !bytes.Equal(got, firstRaw) {
+		t.Fatalf("original target changed: %s", got)
+	}
+	if got := fileBytes(t, second); !bytes.Equal(got, secondRaw) {
+		t.Fatalf("retargeted target changed: %s", got)
+	}
+	if got, err := os.Readlink(a.settingsPath); err != nil || got != filepath.Base(second) {
+		t.Fatalf("retargeted link changed: text=%q err=%v", got, err)
+	}
+	if _, err := os.Stat(a.backupPath); !os.IsNotExist(err) {
+		t.Fatalf("staged backup survived retarget conflict: %v", err)
+	}
+}
+
+func TestClaudeOnConcurrentWriteRestoresLegacyBackupBeforeRetry(t *testing.T) {
+	a, out := testAdapter(t)
+	original := []byte(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081","OTHER":"keep"}}`)
+	writeSettingsFile(t, a, string(original))
+	legacy := &claudeBackup{
+		ConfigPath:  a.settingsPath,
+		Values:      map[string]string{claudeManagedEnvKey: "https://legacy.example.com"},
+		EnvExisted:  true,
+		Existed:     true,
+		WrittenHash: sha256Hex(original),
+	}
+	if err := saveClaudeBackup(a.backupPath, legacy); err != nil {
+		t.Fatal(err)
+	}
+	concurrent := []byte(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081","CLAUDE_CODE_ATTRIBUTION_HEADER":"concurrent","ENABLE_TOOL_SEARCH":"manual","OTHER":"keep"}}`)
+	oldHook := claudeBeforeSettingsMutation
+	claudeBeforeSettingsMutation = func() {
+		if err := os.WriteFile(a.settingsPath, concurrent, 0o600); err != nil {
+			panic(err)
+		}
+	}
+	t.Cleanup(func() { claudeBeforeSettingsMutation = oldHook })
+
+	if code := a.on(); code != 1 {
+		t.Fatalf("on = %d, want conflict (%s)", code, out.String())
+	}
+	if got := fileBytes(t, a.settingsPath); !bytes.Equal(got, concurrent) {
+		t.Fatalf("concurrent settings lost: %s", got)
+	}
+	rolledBack, err := loadClaudeBackup(a.backupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if backupCovers(rolledBack, claudeAttributionEnvKey) || backupCovers(rolledBack, claudeToolSearchEnvKey) {
+		t.Fatalf("failed mutation left stale additive backup: %+v", rolledBack)
+	}
+
+	claudeBeforeSettingsMutation = nil
+	out.Reset()
+	if code := a.on(); code != 0 {
+		t.Fatalf("retry on = %d (%s)", code, out.String())
+	}
+	assertClaudeOnValues(t, a)
+	if code := a.off(); code != 0 {
+		t.Fatalf("off = %d (%s)", code, out.String())
+	}
+	for key, want := range map[string]string{
+		claudeManagedEnvKey:     "https://legacy.example.com",
+		claudeAttributionEnvKey: "concurrent",
+		claudeToolSearchEnvKey:  "manual",
+		"OTHER":                 "keep",
+	} {
+		if got, ok := envValue(t, a.settingsPath, key); !ok || got != want {
+			t.Errorf("%s after retry/off = %q, ok=%v, want %q", key, got, ok, want)
+		}
+	}
+}
+
+func TestConcurrentClaudeOnKeepsRecoveryState(t *testing.T) {
+	a, out := testAdapter(t)
+	writeSettingsFile(t, a, `{"env":{"ANTHROPIC_BASE_URL":"https://proxy.example.com","CLAUDE_CODE_ATTRIBUTION_HEADER":"custom","ENABLE_TOOL_SEARCH":"manual"}}`)
+	a2 := *a
+	out2 := &bytes.Buffer{}
+	a2.out = out2
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	oldHook := claudeBeforeSettingsMutation
+	claudeBeforeSettingsMutation = func() {
+		once.Do(func() {
+			close(entered)
+			<-release
+		})
+	}
+	t.Cleanup(func() { claudeBeforeSettingsMutation = oldHook })
+
+	firstResult := make(chan int, 1)
+	secondResult := make(chan int, 1)
+	go func() { firstResult <- a.on() }()
+	<-entered
+	go func() { secondResult <- a2.on() }()
+	close(release)
+	if code := <-firstResult; code != 0 {
+		t.Fatalf("first on = %d (%s)", code, out.String())
+	}
+	if code := <-secondResult; code != 0 {
+		t.Fatalf("second on = %d (%s)", code, out2.String())
+	}
+	if _, err := os.Stat(a.backupPath); err != nil {
+		t.Fatalf("concurrent on lost backup: %v", err)
+	}
+	assertClaudeOnValues(t, a)
+	if code := a.off(); code != 0 {
+		t.Fatalf("off = %d (%s)", code, out.String())
+	}
+	for key, want := range map[string]string{
+		claudeManagedEnvKey:     "https://proxy.example.com",
+		claudeAttributionEnvKey: "custom",
+		claudeToolSearchEnvKey:  "manual",
+	} {
+		if got, ok := envValue(t, a.settingsPath, key); !ok || got != want {
+			t.Errorf("%s after concurrent on/off = %q, ok=%v, want %q", key, got, ok, want)
+		}
+	}
+}
+
+func TestClaudeOnOffCreatesAndRemovesThroughSymlinkedParent(t *testing.T) {
+	requireSymlinks(t)
+	a, out := testAdapter(t)
+	configuredDir := filepath.Dir(a.settingsPath)
+	realDir := configuredDir + ".real"
+	if err := os.MkdirAll(realDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(configuredDir), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realDir, configuredDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if code := a.on(); code != 0 {
+		t.Fatalf("on = %d (%s)", code, out.String())
+	}
+	target := filepath.Join(realDir, filepath.Base(a.settingsPath))
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("linked-parent target not created: %v", err)
+	}
+	if code := a.off(); code != 0 {
+		t.Fatalf("off = %d (%s)", code, out.String())
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Fatalf("linked-parent target not removed: %v", err)
+	}
+	if info, err := os.Lstat(configuredDir); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("configured parent symlink changed: info=%v err=%v", info, err)
+	}
+}
+
+func TestClaudeLegacyBackupDoesNotRestoreThroughFinalLink(t *testing.T) {
+	requireSymlinks(t)
+	a, out := testAdapter(t)
+	if err := os.MkdirAll(filepath.Dir(a.settingsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(filepath.Dir(a.settingsPath), "cloud-settings.json")
+	managed := []byte(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081","CLAUDE_CODE_ATTRIBUTION_HEADER":"0","ENABLE_TOOL_SEARCH":"true","OTHER":"keep"}}`)
+	if err := os.WriteFile(target, managed, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, a.settingsPath); err != nil {
+		t.Fatal(err)
+	}
+	legacy := &claudeBackup{
+		ConfigPath:  a.settingsPath,
+		Values:      map[string]string{claudeManagedEnvKey: "https://legacy.example.com"},
+		EnvExisted:  true,
+		Existed:     true,
+		WrittenHash: sha256Hex(managed),
+	}
+	if err := saveClaudeBackup(a.backupPath, legacy); err != nil {
+		t.Fatal(err)
+	}
+
+	if code := a.off(); code != 1 {
+		t.Fatalf("off = %d, want legacy linked-target refusal (%s)", code, out.String())
+	}
+	if got := fileBytes(t, target); !bytes.Equal(got, managed) {
+		t.Fatalf("legacy refusal changed linked target: %s", got)
+	}
+	if _, err := os.Readlink(a.settingsPath); err != nil {
+		t.Fatalf("off replaced settings link: %v", err)
+	}
+	if _, err := os.Stat(a.backupPath); err != nil {
+		t.Fatalf("legacy refusal cleared backup: %v", err)
+	}
+}
+
+func TestClaudeLegacyBackupDoesNotRestoreThroughSymlinkedParent(t *testing.T) {
+	requireSymlinks(t)
+	a, out := testAdapter(t)
+	configuredDir := filepath.Dir(a.settingsPath)
+	firstDir := configuredDir + ".first"
+	secondDir := configuredDir + ".second"
+	for _, dir := range []string{firstDir, secondDir} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	firstRaw := []byte(`{"env":{"ANTHROPIC_BASE_URL":"https://first.example.com"}}`)
+	secondRaw := []byte(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081","CLAUDE_CODE_ATTRIBUTION_HEADER":"0","ENABLE_TOOL_SEARCH":"true"},"owner":"second"}`)
+	if err := os.WriteFile(filepath.Join(firstDir, filepath.Base(a.settingsPath)), firstRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	secondTarget := filepath.Join(secondDir, filepath.Base(a.settingsPath))
+	if err := os.WriteFile(secondTarget, secondRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secondDir, configuredDir); err != nil {
+		t.Fatal(err)
+	}
+	legacy := &claudeBackup{
+		ConfigPath:  a.settingsPath,
+		Values:      map[string]string{claudeManagedEnvKey: "https://legacy.example.com"},
+		EnvExisted:  true,
+		Existed:     true,
+		WrittenHash: sha256Hex(secondRaw),
+	}
+	if err := saveClaudeBackup(a.backupPath, legacy); err != nil {
+		t.Fatal(err)
+	}
+
+	if code := a.off(); code != 1 {
+		t.Fatalf("off = %d, want legacy parent-link refusal (%s)", code, out.String())
+	}
+	if got := fileBytes(t, secondTarget); !bytes.Equal(got, secondRaw) {
+		t.Fatalf("legacy refusal changed retargeted parent file: %s", got)
+	}
+	if _, err := os.Stat(a.backupPath); err != nil {
+		t.Fatalf("legacy refusal cleared backup: %v", err)
+	}
+}
+
+func TestClaudeOffNeverRemovesFinalSymlinkTarget(t *testing.T) {
+	requireSymlinks(t)
+	a, out := testAdapter(t)
+	if err := os.MkdirAll(filepath.Dir(a.settingsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(filepath.Dir(a.settingsPath), "shared-empty.json")
+	raw := []byte("{}")
+	if err := os.WriteFile(target, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, a.settingsPath); err != nil {
+		t.Fatal(err)
+	}
+	_, snap, err := readClaudeSettings(a.settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bak := &claudeBackup{
+		ConfigPath:   a.settingsPath,
+		Values:       map[string]string{},
+		Missing:      append([]string(nil), claudeOnEnvKeys...),
+		ModelMissing: true,
+		Existed:      false,
+		WrittenHash:  sha256Hex(raw),
+	}
+	recordClaudeBackupFile(bak, snap)
+	if err := saveClaudeBackup(a.backupPath, bak); err != nil {
+		t.Fatal(err)
+	}
+
+	if code := a.off(); code != 1 {
+		t.Fatalf("off = %d, want linked removal refusal (%s)", code, out.String())
+	}
+	if got := fileBytes(t, target); !bytes.Equal(got, raw) {
+		t.Fatalf("linked target changed: %s", got)
+	}
+	if _, err := os.Readlink(a.settingsPath); err != nil {
+		t.Fatalf("settings symlink changed: %v", err)
+	}
+	if _, err := os.Stat(a.backupPath); err != nil {
+		t.Fatalf("refusal cleared backup: %v", err)
+	}
+}

--- a/gateway/cmd/baseten-switch/claude_adapter_test.go
+++ b/gateway/cmd/baseten-switch/claude_adapter_test.go
@@ -19,6 +19,10 @@ const testDoorPort = "8081"
 func testAdapter(t *testing.T) (*claudeAdapter, *bytes.Buffer) {
 	t.Helper()
 	dir := t.TempDir()
+	dir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
 	settings := filepath.Join(dir, "claude", "settings.json")
 	out := &bytes.Buffer{}
 	return &claudeAdapter{
@@ -68,6 +72,19 @@ func envValue(t *testing.T, path, key string) (string, bool) {
 	return s, ok
 }
 
+func assertClaudeOnValues(t *testing.T, a *claudeAdapter) {
+	t.Helper()
+	for key, want := range map[string]string{
+		claudeManagedEnvKey:     "http://127.0.0.1:8081",
+		claudeAttributionEnvKey: claudeAttributionValue,
+		claudeToolSearchEnvKey:  claudeToolSearchValue,
+	} {
+		if got, ok := envValue(t, a.settingsPath, key); !ok || got != want {
+			t.Errorf("%s = %q, ok=%v, want %q", key, got, ok, want)
+		}
+	}
+}
+
 func fileBytes(t *testing.T, path string) []byte {
 	t.Helper()
 	b, err := os.ReadFile(path)
@@ -82,6 +99,8 @@ func TestClaudeOnOffRoundTripRestoresKeyExactly(t *testing.T) {
 	writeSettingsFile(t, a, `{
   "env": {
     "ANTHROPIC_BASE_URL": "https://corp-proxy.example.com",
+    "CLAUDE_CODE_ATTRIBUTION_HEADER": "custom-attribution",
+    "ENABLE_TOOL_SEARCH": "auto:25",
     "OTHER": "keep"
   },
   "model": "claude-sonnet-4-6",
@@ -94,6 +113,7 @@ func TestClaudeOnOffRoundTripRestoresKeyExactly(t *testing.T) {
 	if v, _ := envValue(t, a.settingsPath, claudeManagedEnvKey); v != "http://127.0.0.1:8081" {
 		t.Fatalf("after on, base url = %q", v)
 	}
+	assertClaudeOnValues(t, a)
 	if _, err := os.Stat(a.backupPath); err != nil {
 		t.Fatalf("backup not written: %v", err)
 	}
@@ -104,6 +124,12 @@ func TestClaudeOnOffRoundTripRestoresKeyExactly(t *testing.T) {
 	env := root["env"].(map[string]any)
 	if env[claudeManagedEnvKey] != "https://corp-proxy.example.com" {
 		t.Errorf("base url not restored: %v", env[claudeManagedEnvKey])
+	}
+	if env[claudeAttributionEnvKey] != "custom-attribution" {
+		t.Errorf("attribution header not restored: %v", env[claudeAttributionEnvKey])
+	}
+	if env[claudeToolSearchEnvKey] != "auto:25" {
+		t.Errorf("tool search not restored: %v", env[claudeToolSearchEnvKey])
 	}
 	if env["OTHER"] != "keep" {
 		t.Errorf("OTHER lost: %v", env["OTHER"])
@@ -280,6 +306,39 @@ func TestClaudeOffDriftRedirectedStaysAWarning(t *testing.T) {
 	}
 }
 
+func TestClaudeOffRedirectedDriftReportsUnrestoredKnobs(t *testing.T) {
+	a, out := testAdapter(t)
+	writeSettingsFile(t, a, `{"env":{"ANTHROPIC_BASE_URL":"https://corp-proxy.example.com","CLAUDE_CODE_ATTRIBUTION_HEADER":"custom-before","ENABLE_TOOL_SEARCH":"auto:25"}}`)
+	if code := a.on(); code != 0 {
+		t.Fatal("on failed")
+	}
+	root := readTree(t, a.settingsPath)
+	root["env"].(map[string]any)[claudeManagedEnvKey] = "https://other-proxy.example.com"
+	b, _ := json.MarshalIndent(root, "", "  ")
+	if err := os.WriteFile(a.settingsPath, append(b, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if code := a.off(); code != 0 {
+		t.Fatalf("off = %d (%s)", code, out.String())
+	}
+	if got, _ := envValue(t, a.settingsPath, claudeManagedEnvKey); got != "https://other-proxy.example.com" {
+		t.Errorf("redirected base URL changed: %q", got)
+	}
+	for _, key := range []string{claudeAttributionEnvKey, claudeToolSearchEnvKey} {
+		if _, ok := envValue(t, a.settingsPath, key); ok {
+			t.Errorf("covered Switch value %s not stripped", key)
+		}
+	}
+	for _, want := range []string{
+		"CLAUDE_CODE_ATTRIBUTION_HEADER \"custom-before\" was NOT restored",
+		"ENABLE_TOOL_SEARCH \"auto:25\" was NOT restored",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("missing unrestored-value note %q in %q", want, out.String())
+		}
+	}
+}
+
 func TestClaudeStripOnlyOwnedNeverTouchesUserValues(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -363,8 +422,13 @@ func TestClaudeOnCreatesFileAndOffDeletesIt(t *testing.T) {
 	if bak.Existed {
 		t.Errorf("backup existed=true for a created file")
 	}
-	if len(bak.Missing) != 1 || bak.Missing[0] != claudeManagedEnvKey {
+	if len(bak.Missing) != len(claudeOnEnvKeys) {
 		t.Errorf("backup missing list = %v", bak.Missing)
+	}
+	for _, key := range claudeOnEnvKeys {
+		if !backupCovers(&bak, key) {
+			t.Errorf("backup does not cover missing %s", key)
+		}
 	}
 	if code := a.off(); code != 0 {
 		t.Fatal("off failed")
@@ -374,26 +438,35 @@ func TestClaudeOnCreatesFileAndOffDeletesIt(t *testing.T) {
 	}
 }
 
-func TestClaudeOnDoesNotBackupWhenAlreadyManaged(t *testing.T) {
+func TestClaudeOnUpgradesAlreadyManagedBaseWithoutBackingUpBase(t *testing.T) {
 	// Manually gateway-managed (old port), no backup: on must not
-	// snapshot our own config as the user's original state.
+	// snapshot our own base URL as the user's original state, but must
+	// record the two new keys so the upgrade remains reversible.
 	a, _ := testAdapter(t)
 	writeSettingsFile(t, a, `{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:18081"}}`)
 	if code := a.on(); code != 0 {
 		t.Fatal("on failed")
 	}
-	if _, err := os.Stat(a.backupPath); !os.IsNotExist(err) {
-		t.Errorf("on snapshotted an already gateway-managed state")
+	bak, err := loadClaudeBackup(a.backupPath)
+	if err != nil || bak == nil {
+		t.Fatalf("load upgrade backup: bak=%v err=%v", bak, err)
 	}
-	if v, _ := envValue(t, a.settingsPath, claudeManagedEnvKey); v != "http://127.0.0.1:8081" {
-		t.Errorf("on did not update to the door port: %q", v)
+	if backupCovers(bak, claudeManagedEnvKey) {
+		t.Errorf("on snapshotted an already gateway-managed base URL")
 	}
-	// off falls back to strip-only-owned.
+	for _, key := range []string{claudeAttributionEnvKey, claudeToolSearchEnvKey} {
+		if !backupCovers(bak, key) {
+			t.Errorf("upgrade backup does not cover %s", key)
+		}
+	}
+	assertClaudeOnValues(t, a)
 	if code := a.off(); code != 0 {
 		t.Fatal("off failed")
 	}
-	if _, ok := envValue(t, a.settingsPath, claudeManagedEnvKey); ok {
-		t.Errorf("strip-only-owned did not strip the gateway value")
+	for _, key := range claudeOnEnvKeys {
+		if _, ok := envValue(t, a.settingsPath, key); ok {
+			t.Errorf("off did not strip %s", key)
+		}
 	}
 }
 
@@ -460,7 +533,7 @@ func TestClaudeOnPreservesOtherSettingsContent(t *testing.T) {
 
 func TestClaudeOnOnlyWritesWhenChanged(t *testing.T) {
 	a, out := testAdapter(t)
-	writeSettingsFile(t, a, `{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081"}}`)
+	writeSettingsFile(t, a, `{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081","CLAUDE_CODE_ATTRIBUTION_HEADER":"0","ENABLE_TOOL_SEARCH":"true"}}`)
 	before := fileBytes(t, a.settingsPath)
 	if code := a.on(); code != 0 {
 		t.Fatal("on failed")
@@ -494,6 +567,183 @@ func TestClaudeStatusExitCodes(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "http://127.0.0.1:8081") {
 		t.Errorf("status missing base url: %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), claudeAttributionEnvKey) ||
+		!strings.Contains(stdout.String(), claudeToolSearchEnvKey) {
+		t.Errorf("status missing managed env values: %q", stdout.String())
+	}
+}
+
+func TestClaudeStatusBaseOnlyIsIncomplete(t *testing.T) {
+	a, _ := testAdapter(t)
+	writeSettingsFile(t, a, `{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081"}}`)
+	var stdout bytes.Buffer
+	if code := a.status(&stdout); code != statusExitOff {
+		t.Fatalf("status = %d, want %d", code, statusExitOff)
+	}
+	if !strings.Contains(stdout.String(), "incomplete") ||
+		!strings.Contains(stdout.String(), "claude on") {
+		t.Errorf("partial status does not identify repair: %q", stdout.String())
+	}
+}
+
+func TestClaudeOnRepairsLegacyBaseOnlyBackup(t *testing.T) {
+	a, _ := testAdapter(t)
+	writeSettingsFile(t, a, `{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081","OTHER":"keep"},"theme":"dark"}`)
+	legacy := &claudeBackup{
+		ConfigPath:  a.settingsPath,
+		Values:      map[string]string{claudeManagedEnvKey: "https://corp-proxy.example.com"},
+		EnvExisted:  true,
+		Existed:     true,
+		WrittenHash: sha256Hex(fileBytes(t, a.settingsPath)),
+	}
+	if err := saveClaudeBackup(a.backupPath, legacy); err != nil {
+		t.Fatal(err)
+	}
+
+	if code := a.on(); code != 0 {
+		t.Fatal("legacy upgrade on failed")
+	}
+	assertClaudeOnValues(t, a)
+	upgraded, err := loadClaudeBackup(a.backupPath)
+	if err != nil || upgraded == nil {
+		t.Fatalf("load upgraded backup: bak=%v err=%v", upgraded, err)
+	}
+	for _, key := range claudeOnEnvKeys {
+		if !backupCovers(upgraded, key) {
+			t.Errorf("upgraded backup does not cover %s", key)
+		}
+	}
+	if code := a.off(); code != 0 {
+		t.Fatal("off after legacy upgrade failed")
+	}
+	if got, _ := envValue(t, a.settingsPath, claudeManagedEnvKey); got != "https://corp-proxy.example.com" {
+		t.Errorf("legacy base URL restore = %q", got)
+	}
+	for _, key := range []string{claudeAttributionEnvKey, claudeToolSearchEnvKey} {
+		if _, ok := envValue(t, a.settingsPath, key); ok {
+			t.Errorf("legacy-missing %s was not removed", key)
+		}
+	}
+	if got, _ := envValue(t, a.settingsPath, "OTHER"); got != "keep" {
+		t.Errorf("unrelated env lost: %q", got)
+	}
+}
+
+func TestClaudeOnRepairsCurrentBaseWithMissingKnobs(t *testing.T) {
+	a, out := testAdapter(t)
+	writeSettingsFile(t, a, `{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081","OTHER":"keep"}}`)
+	if code := a.on(); code != 0 {
+		t.Fatalf("on = %d (%s)", code, out.String())
+	}
+	assertClaudeOnValues(t, a)
+	if strings.Contains(out.String(), "already on") {
+		t.Errorf("base-only state incorrectly reported already on: %q", out.String())
+	}
+	if got, _ := envValue(t, a.settingsPath, "OTHER"); got != "keep" {
+		t.Errorf("unrelated env lost: %q", got)
+	}
+}
+
+func TestClaudeOffWithoutBackupPreservesMatchingUserKnobs(t *testing.T) {
+	a, _ := testAdapter(t)
+	content := `{"env":{"CLAUDE_CODE_ATTRIBUTION_HEADER":"0","ENABLE_TOOL_SEARCH":"true","OTHER":"keep"}}` + "\n"
+	writeSettingsFile(t, a, content)
+	if code := a.off(); code != 0 {
+		t.Fatal("off failed")
+	}
+	if got := string(fileBytes(t, a.settingsPath)); got != content {
+		t.Errorf("off without ownership proof modified user settings:\n%s", got)
+	}
+}
+
+func TestClaudeDriftReportSkipsValueAlreadyRestoredByUser(t *testing.T) {
+	a, out := testAdapter(t)
+	writeSettingsFile(t, a, `{"env":{"ANTHROPIC_BASE_URL":"https://corp-proxy.example.com","CLAUDE_CODE_ATTRIBUTION_HEADER":"custom-before","ENABLE_TOOL_SEARCH":"auto:25"}}`)
+	if code := a.on(); code != 0 {
+		t.Fatal("on failed")
+	}
+	root := readTree(t, a.settingsPath)
+	root["env"].(map[string]any)[claudeAttributionEnvKey] = "custom-before"
+	root["theme"] = "dark"
+	b, _ := json.MarshalIndent(root, "", "  ")
+	if err := os.WriteFile(a.settingsPath, append(b, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if code := a.off(); code != 0 {
+		t.Fatalf("off = %d (%s)", code, out.String())
+	}
+	if strings.Contains(out.String(), `CLAUDE_CODE_ATTRIBUTION_HEADER "custom-before" was NOT restored`) {
+		t.Errorf("reported a false unrestored warning: %q", out.String())
+	}
+	if got, _ := envValue(t, a.settingsPath, claudeAttributionEnvKey); got != "custom-before" {
+		t.Errorf("user-restored value lost: %q", got)
+	}
+}
+
+func TestClaudeDriftPreservesPreexistingMatchingKnob(t *testing.T) {
+	a, out := testAdapter(t)
+	writeSettingsFile(t, a, `{"env":{"ANTHROPIC_BASE_URL":"https://corp-proxy.example.com","ENABLE_TOOL_SEARCH":"true"}}`)
+	if code := a.on(); code != 0 {
+		t.Fatal("on failed")
+	}
+	root := readTree(t, a.settingsPath)
+	root["theme"] = "dark"
+	b, _ := json.MarshalIndent(root, "", "  ")
+	if err := os.WriteFile(a.settingsPath, append(b, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if code := a.off(); code != 0 {
+		t.Fatalf("off = %d (%s)", code, out.String())
+	}
+	if got, ok := envValue(t, a.settingsPath, claudeToolSearchEnvKey); !ok || got != claudeToolSearchValue {
+		t.Errorf("preexisting matching tool-search value lost: %q ok=%v", got, ok)
+	}
+	if _, ok := envValue(t, a.settingsPath, claudeAttributionEnvKey); ok {
+		t.Errorf("attribution value added by on was not stripped")
+	}
+	if _, ok := envValue(t, a.settingsPath, claudeManagedEnvKey); ok {
+		t.Errorf("gateway base URL was not stripped")
+	}
+	if strings.Contains(out.String(), `ENABLE_TOOL_SEARCH "true" was NOT restored`) {
+		t.Errorf("preexisting matching value incorrectly reported unrestored: %q", out.String())
+	}
+}
+
+func TestClaudeDriftedManagedKnobsPreserveUserValues(t *testing.T) {
+	a, out := testAdapter(t)
+	writeSettingsFile(t, a, `{"env":{"ANTHROPIC_BASE_URL":"https://corp-proxy.example.com","CLAUDE_CODE_ATTRIBUTION_HEADER":"custom-before","ENABLE_TOOL_SEARCH":"auto:25"}}`)
+	if code := a.on(); code != 0 {
+		t.Fatal("on failed")
+	}
+	root := readTree(t, a.settingsPath)
+	env := root["env"].(map[string]any)
+	env[claudeAttributionEnvKey] = "custom-after"
+	env[claudeToolSearchEnvKey] = "auto"
+	root["theme"] = "dark"
+	b, _ := json.MarshalIndent(root, "", "  ")
+	if err := os.WriteFile(a.settingsPath, append(b, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if code := a.off(); code != 0 {
+		t.Fatalf("off = %d (%s)", code, out.String())
+	}
+	if _, ok := envValue(t, a.settingsPath, claudeManagedEnvKey); ok {
+		t.Errorf("gateway base URL not stripped")
+	}
+	if got, _ := envValue(t, a.settingsPath, claudeAttributionEnvKey); got != "custom-after" {
+		t.Errorf("drifted attribution value lost: %q", got)
+	}
+	if got, _ := envValue(t, a.settingsPath, claudeToolSearchEnvKey); got != "auto" {
+		t.Errorf("drifted tool-search value lost: %q", got)
+	}
+	for _, want := range []string{
+		"CLAUDE_CODE_ATTRIBUTION_HEADER \"custom-before\" was NOT restored",
+		"ENABLE_TOOL_SEARCH \"auto:25\" was NOT restored",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("missing unrestored-value note %q in %q", want, out.String())
+		}
 	}
 }
 

--- a/gateway/cmd/baseten-switch/claude_subagents_test.go
+++ b/gateway/cmd/baseten-switch/claude_subagents_test.go
@@ -837,6 +837,11 @@ func TestClaudeOffRestoresBaseURLStripsSubagent(t *testing.T) {
 	}
 	bak := loadBackup(t, a)
 	bak.WrittenHash = sha256Hex(newRaw)
+	_, snap, err := readClaudeSettings(a.settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recordClaudeBackupFile(bak, snap)
 	if err := saveClaudeBackup(a.backupPath, bak); err != nil {
 		t.Fatal(err)
 	}

--- a/gateway/cmd/baseten-switch/doctor.go
+++ b/gateway/cmd/baseten-switch/doctor.go
@@ -779,9 +779,9 @@ func doctorDoorChecks(add addCheck, doorSpecs []door.Config, haveStatus bool, bo
 }
 
 // doctorClaudeChecks verifies the Claude Code wiring through the
-// adapter's own seams: settings parse, the settings ANTHROPIC_BASE_URL
-// targets the claude door port, the shell environment does not
-// override it wrongly (sessions inherit the shell env, which wins over
+// adapter's own seams: settings parse, the three `claude on` env
+// values are complete, the shell environment does not override the
+// base URL wrongly (sessions inherit the shell env, which wins over
 // settings), the subagent split-routing config is valid, and the
 // on-state backup is intact. f is the parsed gateway config (nil when
 // it failed to load); telPath is the pre-resolved telemetry store path
@@ -790,7 +790,7 @@ func doctorClaudeChecks(add addCheck, f *config.File, telPath string) {
 	a, err := newClaudeAdapterFromEnv()
 	if err != nil {
 		reason := fmt.Sprintf("cannot resolve the claude door port: %v", err)
-		for _, name := range []string{"settings", "base_url", "shell_env", "subagents", "model_routes", "model_env", "backup"} {
+		for _, name := range []string{"settings", "base_url", "attribution_header", "tool_search", "shell_env", "subagents", "model_routes", "model_env", "backup"} {
 			add("claude", name, docSkip, reason, "")
 		}
 		return
@@ -798,7 +798,7 @@ func doctorClaudeChecks(add addCheck, f *config.File, telPath string) {
 	root, _, existed, err := loadClaudeSettings(a.settingsPath)
 	if err != nil {
 		add("claude", "settings", docFail, err.Error(), "fix the JSON in "+a.settingsPath+" by hand")
-		for _, name := range []string{"base_url", "shell_env", "subagents"} {
+		for _, name := range []string{"base_url", "attribution_header", "tool_search", "shell_env", "subagents"} {
 			add("claude", name, docSkip, "settings unreadable", "")
 		}
 		// The model_routes/model_env checks still run: the config-validity
@@ -811,11 +811,13 @@ func doctorClaudeChecks(add addCheck, f *config.File, telPath string) {
 	}
 	var cur string
 	var curSet bool
+	var env map[string]any
 	if existed {
-		env, envErr := settingsEnv(root)
+		var envErr error
+		env, envErr = settingsEnv(root)
 		if envErr != nil {
 			add("claude", "settings", docFail, envErr.Error(), "fix the env block in "+a.settingsPath+" by hand")
-			for _, name := range []string{"base_url", "shell_env", "subagents"} {
+			for _, name := range []string{"base_url", "attribution_header", "tool_search", "shell_env", "subagents"} {
 				add("claude", name, docSkip, "settings env block unreadable", "")
 			}
 			// As above: config validity needs only gateway.yaml, and the
@@ -846,6 +848,28 @@ func doctorClaudeChecks(add addCheck, f *config.File, telPath string) {
 		add("claude", "base_url", docOK, "settings point at the door ("+cur+")", "")
 	} else {
 		add("claude", "base_url", docFail, "claude "+fnd, "baseten-switch claude on", claudeOnArgv...)
+	}
+	for _, check := range []struct {
+		name string
+		key  string
+	}{
+		{name: "attribution_header", key: claudeAttributionEnvKey},
+		{name: "tool_search", key: claudeToolSearchEnvKey},
+	} {
+		got, ok := envString(env, check.key)
+		want := a.desiredClaudeEnvValue(check.key)
+		switch {
+		case !ok:
+			add("claude", check.name, docFail,
+				fmt.Sprintf("%s is missing from %s", check.key, a.settingsPath),
+				"baseten-switch claude on", claudeOnArgv...)
+		case got != want:
+			add("claude", check.name, docFail,
+				fmt.Sprintf("%s=%q in %s, want %q", check.key, got, a.settingsPath, want),
+				"baseten-switch claude on", claudeOnArgv...)
+		default:
+			add("claude", check.name, docOK, fmt.Sprintf("%s=%q", check.key, got), "")
+		}
 	}
 
 	shell := os.Getenv(claudeManagedEnvKey)

--- a/gateway/cmd/baseten-switch/doctor_test.go
+++ b/gateway/cmd/baseten-switch/doctor_test.go
@@ -368,7 +368,7 @@ func newDoctorFixture(t *testing.T, mut func(*doctorFixtureCfg)) *doctorFixture 
 				modelEnvPart += fmt.Sprintf(`,%q:%q`, k, v)
 			}
 		}
-		settingsJSON = fmt.Sprintf(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:%s"%s%s}}`, fx.doorPort, subagentEnvPart, modelEnvPart)
+		settingsJSON = fmt.Sprintf(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:%s","CLAUDE_CODE_ATTRIBUTION_HEADER":"0","ENABLE_TOOL_SEARCH":"true"%s%s}}`, fx.doorPort, subagentEnvPart, modelEnvPart)
 	}
 	if err := os.WriteFile(fx.settings, []byte(settingsJSON), 0o600); err != nil {
 		t.Fatal(err)
@@ -549,7 +549,8 @@ func TestDoctorAllGreen(t *testing.T) {
 	for _, want := range [][2]string{
 		{"config", "load"}, {"auth", "signin"}, {"router", "client:claude-code"},
 		{"door", "doorz:" + fx.doorPort}, {"door", "wiring:" + fx.doorPort},
-		{"claude", "base_url"}, {"claude", "subagents"}, {"claude", "subagent_env"},
+		{"claude", "base_url"}, {"claude", "attribution_header"}, {"claude", "tool_search"},
+		{"claude", "subagents"}, {"claude", "subagent_env"},
 		{"claude", "model_routes"}, {"claude", "model_env"},
 		{"claude", "backup"}, {"telemetry", "log"}, {"telemetry", "freshness"}, {"telemetry", "logs"},
 	} {
@@ -619,6 +620,51 @@ func TestDoctorClaudeWrongPort(t *testing.T) {
 	if rep.FirstFailure != "claude/base_url" {
 		t.Errorf("first_failure = %q", rep.FirstFailure)
 	}
+}
+
+func TestDoctorClaudeManagedEnvKnobsRequireExactValues(t *testing.T) {
+	t.Run("missing", func(t *testing.T) {
+		fx := newDoctorFixture(t, nil)
+		root := readTree(t, fx.settings)
+		env := root["env"].(map[string]any)
+		delete(env, claudeAttributionEnvKey)
+		delete(env, claudeToolSearchEnvKey)
+		b, _ := json.Marshal(root)
+		if err := os.WriteFile(fx.settings, b, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		rep := runDoctor(doctorOpts{})
+		for _, name := range []string{"attribution_header", "tool_search"} {
+			c := findCheck(t, rep, "claude", name)
+			if c.Status != docFail || !strings.Contains(c.Finding, "missing") {
+				t.Errorf("%s = %+v, want missing failure", name, c)
+			}
+			if len(c.fixArgv) != 2 || c.fixArgv[0] != "claude" || c.fixArgv[1] != "on" {
+				t.Errorf("%s fixArgv = %v, want [claude on]", name, c.fixArgv)
+			}
+		}
+	})
+	t.Run("wrong values", func(t *testing.T) {
+		fx := newDoctorFixture(t, nil)
+		root := readTree(t, fx.settings)
+		env := root["env"].(map[string]any)
+		env[claudeAttributionEnvKey] = "1"
+		env[claudeToolSearchEnvKey] = "auto"
+		b, _ := json.Marshal(root)
+		if err := os.WriteFile(fx.settings, b, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		rep := runDoctor(doctorOpts{})
+		for name, want := range map[string]string{
+			"attribution_header": `"0"`,
+			"tool_search":        `"true"`,
+		} {
+			c := findCheck(t, rep, "claude", name)
+			if c.Status != docFail || !strings.Contains(c.Finding, "want "+want) {
+				t.Errorf("%s = %+v, want exact-value failure for %s", name, c, want)
+			}
+		}
+	})
 }
 
 func TestDoctorShellEnvOverridesSettings(t *testing.T) {
@@ -1152,7 +1198,7 @@ func TestDoctorClaudeEarlyExitShapes(t *testing.T) {
 		// fails inside doctorClaudeChecks.
 		t.Setenv("BASETEN_SWITCH_CONFIG_PATH", filepath.Join(t.TempDir(), "missing.yaml"))
 		rep := runDoctor(doctorOpts{})
-		for _, name := range []string{"settings", "base_url", "shell_env", "subagents", "model_routes", "model_env", "backup"} {
+		for _, name := range []string{"settings", "base_url", "attribution_header", "tool_search", "shell_env", "subagents", "model_routes", "model_env", "backup"} {
 			if c := findCheck(t, rep, "claude", name); c.Status != docSkip {
 				t.Errorf("claude/%s = %+v, want skip on the adapter-error path", name, c)
 			}
@@ -1425,8 +1471,8 @@ func TestDoctorFixLoopCap(t *testing.T) {
 	fx := newDoctorFixture(t, nil)
 	liveAdmin := os.Getenv("BASETEN_SWITCH_ADMIN_ADDR")
 	closedAdmin := closedPortAddr(t)
-	goodSettings := fmt.Sprintf(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:%s"}}`, fx.doorPort)
-	badSettings := `{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:1"}}`
+	goodSettings := fmt.Sprintf(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:%s","CLAUDE_CODE_ATTRIBUTION_HEADER":"0","ENABLE_TOOL_SEARCH":"true"}}`, fx.doorPort)
+	badSettings := `{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:1","CLAUDE_CODE_ATTRIBUTION_HEADER":"0","ENABLE_TOOL_SEARCH":"true"}}`
 	if err := os.WriteFile(fx.settings, []byte(badSettings), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/gateway/cmd/baseten-switch/main.go
+++ b/gateway/cmd/baseten-switch/main.go
@@ -297,9 +297,10 @@ Plain doctor is read-only. --fix cannot be combined with --json.
   baseten-switch claude route [<family> <target|default>]
   baseten-switch claude reasoning baseten <model> off|follow-harness|effort <value>|default
 
-on points ANTHROPIC_BASE_URL in ~/.claude/settings.json at the gateway door
-and backs up the prior value. off restores it exactly when possible, or strips
-only gateway-owned values after drift. start and stop alias on and off.
+on sets ANTHROPIC_BASE_URL, CLAUDE_CODE_ATTRIBUTION_HEADER, and
+ENABLE_TOOL_SEARCH in ~/.claude/settings.json, and backs up prior values. off
+restores them exactly when possible, or strips only values proven to have been
+written by Switch after drift. start and stop alias on and off.
 
 subagents selects a configured alias, raw Baseten slug, or native model for
 Task and sidechain requests. "on" re-enables the kept model. "inherit" leaves

--- a/gateway/cmd/baseten-switch/uninstall.go
+++ b/gateway/cmd/baseten-switch/uninstall.go
@@ -133,7 +133,10 @@ func uninstallClaude() error {
 	settings := envDefault("BASETEN_SWITCH_CLAUDE_SETTINGS", homeJoin(".claude", "settings.json"))
 	backupRoot := envDefault("BASETEN_SWITCH_BACKUP_DIR", filepath.Join(basetenSwitchDataRoot(), "backups"))
 	backup := claudeBackupPath(backupRoot, settings)
-	if err := rejectSymlinkTargets(settings, backup); err != nil {
+	// Harness settings may intentionally be a symlink. The adapter restores
+	// through a validated safe-file snapshot; the internal backup itself must
+	// remain an ordinary file.
+	if err := rejectSymlinkTargets(backup); err != nil {
 		return err
 	}
 	if !pathExists(settings) && !pathExists(backup) {

--- a/gateway/cmd/baseten-switch/uninstall_test.go
+++ b/gateway/cmd/baseten-switch/uninstall_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -37,7 +38,7 @@ func TestUninstallDryRunIsReadOnlyAndEnumeratesActions(t *testing.T) {
 
 func TestUninstallHarnessStepsRestoreOnlyManagedState(t *testing.T) {
 	claude, claudeOut := testAdapter(t)
-	writeSettingsFile(t, claude, `{"env":{"ANTHROPIC_BASE_URL":"https://corp-proxy.example.com","OTHER":"keep"}}`)
+	writeSettingsFile(t, claude, `{"env":{"ANTHROPIC_BASE_URL":"https://corp-proxy.example.com","CLAUDE_CODE_ATTRIBUTION_HEADER":"custom-before","ENABLE_TOOL_SEARCH":"auto:25","OTHER":"keep"}}`)
 	if code := claude.on(); code != 0 {
 		t.Fatalf("claude on = %d (%s)", code, claudeOut.String())
 	}
@@ -68,6 +69,12 @@ func TestUninstallHarnessStepsRestoreOnlyManagedState(t *testing.T) {
 	if got, _ := envValue(t, claude.settingsPath, claudeManagedEnvKey); got != "https://corp-proxy.example.com" {
 		t.Errorf("Claude original value = %q", got)
 	}
+	if got, _ := envValue(t, claude.settingsPath, claudeAttributionEnvKey); got != "custom-before" {
+		t.Errorf("Claude original attribution value = %q", got)
+	}
+	if got, _ := envValue(t, claude.settingsPath, claudeToolSearchEnvKey); got != "auto:25" {
+		t.Errorf("Claude original tool-search value = %q", got)
+	}
 	if got := string(fileBytes(t, codex.overlayPath)); got != codexTestStaleOverlay {
 		t.Errorf("Codex original overlay not restored exactly:\n%s", got)
 	}
@@ -81,7 +88,7 @@ func TestUninstallHarnessStepsRestoreOnlyManagedState(t *testing.T) {
 	}
 
 	foreignClaude, _ := testAdapter(t)
-	foreignClaudeRaw := `{"env":{"ANTHROPIC_BASE_URL":"https://another.example.com"}}` + "\n"
+	foreignClaudeRaw := `{"env":{"ANTHROPIC_BASE_URL":"https://another.example.com","CLAUDE_CODE_ATTRIBUTION_HEADER":"0","ENABLE_TOOL_SEARCH":"true"}}` + "\n"
 	writeSettingsFile(t, foreignClaude, foreignClaudeRaw)
 	if code := foreignClaude.off(); code != 0 {
 		t.Fatalf("foreign claude off = %d", code)
@@ -97,6 +104,47 @@ func TestUninstallHarnessStepsRestoreOnlyManagedState(t *testing.T) {
 	}
 	if got := string(fileBytes(t, foreignCodex.overlayPath)); got != codexTestForeignOverlay {
 		t.Errorf("unowned Codex overlay changed:\n%s", got)
+	}
+}
+
+func TestUninstallClaudeRestoresThroughLinkedSettings(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symbolic-link test requires link privileges")
+	}
+	env := newRouteTestEnv(t, false)
+	target := env.settings + ".shared"
+	original := `{"env":{"ANTHROPIC_BASE_URL":"https://proxy.example.com","CLAUDE_CODE_ATTRIBUTION_HEADER":"custom-before","ENABLE_TOOL_SEARCH":"auto:25","OTHER":"keep"}}`
+	if err := os.WriteFile(target, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(env.settings); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, env.settings); err != nil {
+		t.Fatal(err)
+	}
+	linkText, err := os.Readlink(env.settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code, _, stderr := runClaudeCaptured(t, []string{"on"}); code != 0 {
+		t.Fatalf("claude on = %d (%s)", code, stderr)
+	}
+	if err := uninstallClaude(); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.Readlink(env.settings); err != nil || got != linkText {
+		t.Fatalf("uninstall changed settings link: text=%q err=%v", got, err)
+	}
+	for key, want := range map[string]string{
+		claudeManagedEnvKey:     "https://proxy.example.com",
+		claudeAttributionEnvKey: "custom-before",
+		claudeToolSearchEnvKey:  "auto:25",
+		"OTHER":                 "keep",
+	} {
+		if got, ok := envValue(t, target, key); !ok || got != want {
+			t.Errorf("%s after uninstall = %q, ok=%v, want %q", key, got, ok, want)
+		}
 	}
 }
 

--- a/gateway/internal/safefile/safefile.go
+++ b/gateway/internal/safefile/safefile.go
@@ -40,11 +40,11 @@ func CommitApplied(err error) bool {
 
 // Identity describes the file generation captured by a Snapshot.
 type Identity struct {
-	Device          uint64
-	Inode           uint64
-	Links           uint64
-	Size            int64
-	ModTimeUnixNano int64
+	Device          uint64 `json:"device"`
+	Inode           uint64 `json:"inode"`
+	Links           uint64 `json:"links"`
+	Size            int64  `json:"size"`
+	ModTimeUnixNano int64  `json:"mod_time_unix_nano"`
 }
 
 // Snapshot binds file bytes to the configured path, resolved target, mode, and
@@ -54,6 +54,7 @@ type Snapshot struct {
 	ResolvedPath  string
 	Exists        bool
 	Linked        bool
+	FinalLinked   bool
 	Data          []byte
 	Mode          fs.FileMode
 	Identity      Identity
@@ -63,6 +64,7 @@ type Snapshot struct {
 	preimageIdentity Identity
 	preimageExists   bool
 	preimageLinked   bool
+	preimageFinal    bool
 	preimageResolved string
 }
 
@@ -90,12 +92,18 @@ func Read(path string) (*Snapshot, error) {
 	if err != nil {
 		return nil, err
 	}
+	finalLinked, err := finalComponentLinked(requested)
+	if err != nil {
+		return nil, err
+	}
 	if !exists {
 		return &Snapshot{
 			RequestedPath:    requested,
 			ResolvedPath:     resolved,
 			Linked:           linked,
+			FinalLinked:      finalLinked,
 			preimageLinked:   linked,
+			preimageFinal:    finalLinked,
 			preimageResolved: resolved,
 		}, nil
 	}
@@ -152,7 +160,11 @@ func Read(path string) (*Snapshot, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !checkExists || checkResolved != resolved || checkLinked != linked {
+	checkFinalLinked, err := finalComponentLinked(requested)
+	if err != nil {
+		return nil, err
+	}
+	if !checkExists || checkResolved != resolved || checkLinked != linked || checkFinalLinked != finalLinked {
 		return nil, fmt.Errorf("%w: %s changed while it was resolved", ErrConflict, requested)
 	}
 
@@ -161,6 +173,7 @@ func Read(path string) (*Snapshot, error) {
 		ResolvedPath:     resolved,
 		Exists:           true,
 		Linked:           linked,
+		FinalLinked:      finalLinked,
 		Data:             bytes.Clone(data),
 		Mode:             afterPath.Mode().Perm(),
 		Identity:         afterPathIdentity,
@@ -169,6 +182,7 @@ func Read(path string) (*Snapshot, error) {
 		preimageIdentity: afterPathIdentity,
 		preimageExists:   true,
 		preimageLinked:   linked,
+		preimageFinal:    finalLinked,
 		preimageResolved: resolved,
 	}, nil
 }
@@ -321,6 +335,18 @@ func (s *Snapshot) Remove() error {
 	return nil
 }
 
+// Verify confirms that the configured path still identifies the exact
+// preimage captured by Read without changing it.
+func (s *Snapshot) Verify() error {
+	if s == nil {
+		return fmt.Errorf("%w: nil snapshot", ErrUnsafeTarget)
+	}
+	if beforeCommitHook != nil {
+		beforeCommitHook()
+	}
+	return s.verifyCurrent()
+}
+
 func (s *Snapshot) verifyCurrent() error {
 	current, err := Read(s.RequestedPath)
 	if err != nil {
@@ -331,7 +357,8 @@ func (s *Snapshot) verifyCurrent() error {
 	}
 	if current.ResolvedPath != s.preimageResolved ||
 		current.Exists != s.preimageExists ||
-		current.Linked != s.preimageLinked {
+		current.Linked != s.preimageLinked ||
+		current.FinalLinked != s.preimageFinal {
 		return fmt.Errorf("%w: %s resolves differently", ErrConflict, s.RequestedPath)
 	}
 	if !s.preimageExists {
@@ -343,6 +370,17 @@ func (s *Snapshot) verifyCurrent() error {
 		return fmt.Errorf("%w: %s no longer matches its snapshot", ErrConflict, s.RequestedPath)
 	}
 	return nil
+}
+
+func finalComponentLinked(requested string) (bool, error) {
+	info, err := os.Lstat(requested)
+	if err == nil {
+		return info.Mode()&os.ModeSymlink != 0, nil
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	return false, fmt.Errorf("%w: inspect %s: %v", ErrUnsafeTarget, requested, err)
 }
 
 func resolveConfiguredPath(requested string) (resolved string, exists, linked bool, err error) {

--- a/gateway/internal/safefile/safefile_test.go
+++ b/gateway/internal/safefile/safefile_test.go
@@ -72,7 +72,7 @@ func TestReplacePreservesRelativeMultihopSymlink(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !snapshot.Linked || snapshot.ResolvedPath != resolvedTarget {
+	if !snapshot.Linked || !snapshot.FinalLinked || snapshot.ResolvedPath != resolvedTarget {
 		t.Fatalf("snapshot path = %+v", snapshot)
 	}
 	if _, err := snapshot.Replace([]byte("after\n"), 0o600); err != nil {
@@ -104,7 +104,7 @@ func TestReplaceCreatesThroughSymlinkedParent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if snapshot.Exists || !snapshot.Linked {
+	if snapshot.Exists || !snapshot.Linked || snapshot.FinalLinked {
 		t.Fatalf("snapshot = %+v", snapshot)
 	}
 	if _, err := snapshot.Replace([]byte("created\n"), 0o600); err != nil {
@@ -324,6 +324,21 @@ func TestRemoveRefusesHardLinkAddedAfterSnapshot(t *testing.T) {
 	}
 	assertFile(t, path, "value\n")
 	assertFile(t, alias, "value\n")
+}
+
+func TestVerifyRefusesPreimageConflict(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	writeFile(t, path, []byte("before\n"), 0o600)
+	snapshot, err := Read(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, path, []byte("concurrent\n"), 0o600)
+
+	if err := snapshot.Verify(); !errors.Is(err, ErrConflict) {
+		t.Fatalf("Verify error = %v, want ErrConflict", err)
+	}
+	assertFile(t, path, "concurrent\n")
 }
 
 func writeFile(t *testing.T, path string, data []byte, mode fs.FileMode) {


### PR DESCRIPTION
## What

- Configure `CLAUDE_CODE_ATTRIBUTION_HEADER=0` and `ENABLE_TOOL_SEARCH=true` alongside `ANTHROPIC_BASE_URL` when running `baseten-switch claude on`.
- Repair installations that already have the gateway base URL but are missing either required value.
- Extend backup, restore, drift handling, status, doctor, uninstall, and help behavior to cover all three values.
- Mutate Claude settings through the shared safe-file layer so final-component symlinks and symlinked parent directories are preserved.
- Refuse dangling, non-regular, and multiply hard-linked settings targets, and detect concurrent edits or link retargeting before committing.
- Bind new backups to the resolved settings target and file identity while remaining compatible with legacy backups for direct regular files.
- Preserve unrelated settings and restore preexisting custom values when disabling the integration.

## Why

`baseten-switch claude on` previously configured only the gateway base URL. Claude Code sessions could therefore start without deferred tool loading or the attribution setting needed for a stable prompt prefix.

Claude settings may also be symlinked by configuration-management or synchronization tools. Replacing the logical path directly can detach that link or update a different target after a concurrent change.

## Testing

- `go test -count=1 ./...`
- `scripts/check.sh`
- Added regression coverage for new and existing installations, all three managed values, legacy backups, repeated enablement, settings drift, diagnostics, uninstall, symbolic links, hard links, target retargeting, concurrent writes, mode preservation, and legacy-backup compatibility.
- Manually exercised `status`, `on`, and `off` against an isolated copy of a populated Claude settings file. Unrelated settings were preserved and prior managed values were restored.

## Security and privacy

This changes local Claude Code settings to omit the attribution block and enable deferred MCP tool loading. It does not change credential handling, request destinations, telemetry, dependencies, or release artifacts.
