### PR TITLE
feat: add direct Pi provider installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,36 @@ the app from the current Homebrew package.
 The app and CLI update the same configuration. You can use either interface
 without maintaining separate state.
 
+## Pi
+
+Install the direct Baseten provider for
+[Pi](https://github.com/badlogic/pi-mono) without starting Baseten Switch:
+
+```sh
+brew install basetenlabs/baseten/baseten-switch
+export BASETEN_API_KEY="<your-api-key>"
+baseten-switch pi install
+pi --provider baseten --model <model-slug>
+```
+
+`pi install` reads the visible model catalog through the Baseten CLI and adds
+only the direct `baseten` provider to Pi. It joins exact model IDs with the
+public [models.dev](https://models.dev/) catalog for reasoning and text/image
+input capabilities. Models without an exact capability match use conservative
+defaults and are reported during installation. The API key remains in the
+environment; Pi's configuration contains only a `$BASETEN_API_KEY` reference.
+The command does not create gateway configuration, install launch agents,
+start the router or front door, or change another harness profile.
+
+The Homebrew formula contains the optional Mac app archive, but this flow does
+not install the app in `~/Applications` or open it. Manage the direct provider
+without running local services:
+
+```sh
+baseten-switch pi status
+baseten-switch pi uninstall
+```
+
 ## Claude Code
 
 `baseten-switch claude on` saves the previous Claude Code setting and points

--- a/gateway/cmd/baseten-switch/help_test.go
+++ b/gateway/cmd/baseten-switch/help_test.go
@@ -29,6 +29,7 @@ var expectedAdvertisedCommands = []string{
 	"doctor",
 	"claude",
 	"codex",
+	"pi",
 }
 
 func TestRootHelpUsesOneLinePerAdvertisedCommand(t *testing.T) {
@@ -175,6 +176,7 @@ func TestCommandHelpRecognizesUnsafeNestedPaths(t *testing.T) {
 		{"config", "reset", "--preview-root", "--help"},
 		{"claude", "on", "--help"},
 		{"codex", "on", "-h"},
+		{"pi", "install", "--help"},
 		{"healthz", "--help"},
 		{"mutation", "reconcile", "--operation-id", "--help"},
 	} {

--- a/gateway/cmd/baseten-switch/main.go
+++ b/gateway/cmd/baseten-switch/main.go
@@ -104,6 +104,8 @@ func dispatch(args []string) int {
 		return cmdClaude(args[1:])
 	case "codex":
 		return cmdCodex(args[1:])
+	case "pi":
+		return cmdPi(args[1:])
 	case "menubar":
 		return cmdMenubar(args[1:])
 	default:
@@ -332,6 +334,24 @@ active profiled sessions use the new target without a Codex restart.
 
 reasoning configures a catalog-validated, Codex-only reasoning policy for the
 final Baseten model.
+`},
+	{"pi", "Install the direct Baseten provider for Pi", `Usage:
+  baseten-switch pi install
+  baseten-switch pi status
+  baseten-switch pi uninstall
+
+install adds the direct Baseten provider to Pi using the account-visible model
+catalog from "baseten model-api list --output json". Exact model IDs are
+enriched with reasoning and text/image input capabilities from models.dev.
+Unmatched models use conservative defaults and are reported. The command
+requires BASETEN_API_KEY in Pi's environment, but writes only the literal
+$BASETEN_API_KEY reference. It does not start the gateway, install services,
+open the macOS app, or change any other harness configuration.
+
+status reports whether the managed provider is installed and healthy.
+uninstall removes only the managed Baseten provider. The default Pi agent
+directory is ~/.pi/agent. A nonempty PI_CODING_AGENT_DIR overrides it and may
+begin with ~.
 `},
 }
 

--- a/gateway/cmd/baseten-switch/pi_adapter.go
+++ b/gateway/cmd/baseten-switch/pi_adapter.go
@@ -1,0 +1,454 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	piProviderID             = "baseten"
+	piProviderName           = "Baseten"
+	piProviderBaseURL        = "https://inference.baseten.co/v1"
+	piProviderAPI            = "openai-completions"
+	piAPIKeyReference        = "$BASETEN_API_KEY"
+	piAuthHeaderValue        = "Api-Key $BASETEN_API_KEY"
+	piDefaultMaxTokens       = 16384
+	piModelsFilename         = "models.json"
+	piStatusExitNotInstalled = 3
+)
+
+var errPiConfigBackendUnavailable = errors.New("Pi configuration backend is unavailable")
+
+// piProviderSpec is the package boundary between the CLI and the safe Pi
+// configuration writer. It contains configuration literals only, never the
+// value of BASETEN_API_KEY.
+type piProviderSpec struct {
+	ID      string
+	Name    string
+	BaseURL string
+	API     string
+	APIKey  string
+	Headers map[string]string
+	Models  []piProviderModel
+}
+
+type piProviderModel struct {
+	ID              string
+	Name            string
+	ContextWindow   int
+	MaxTokens       int
+	Cost            piProviderCost
+	Reasoning       bool
+	Input           []string
+	CapabilityKnown bool
+}
+
+type piProviderCost struct {
+	Input      float64 `json:"input"`
+	Output     float64 `json:"output"`
+	CacheRead  float64 `json:"cacheRead"`
+	CacheWrite float64 `json:"cacheWrite"`
+}
+
+type piInstallRequest struct {
+	AgentDir string
+	Provider piProviderSpec
+}
+
+type piInstallResult struct {
+	ModelsPath string
+	ModelCount int
+	Changed    bool
+}
+
+type piStatusResult struct {
+	ModelsPath string
+	ModelCount int
+	Installed  bool
+	Healthy    bool
+	Detail     string
+}
+
+type piUninstallResult struct {
+	ModelsPath string
+	Changed    bool
+}
+
+// piConfigStore keeps the CLI independent of backup, drift, and atomic-write
+// implementation details.
+type piConfigStore interface {
+	Install(context.Context, piInstallRequest) (piInstallResult, error)
+	Status(context.Context, string) (piStatusResult, error)
+	Uninstall(context.Context, string) (piUninstallResult, error)
+}
+
+// unavailablePiConfigStore keeps configuration mutation fail-closed if the
+// production file store is not registered during package initialization.
+type unavailablePiConfigStore struct{}
+
+func (unavailablePiConfigStore) Install(context.Context, piInstallRequest) (piInstallResult, error) {
+	return piInstallResult{}, errPiConfigBackendUnavailable
+}
+
+func (unavailablePiConfigStore) Status(context.Context, string) (piStatusResult, error) {
+	return piStatusResult{}, errPiConfigBackendUnavailable
+}
+
+func (unavailablePiConfigStore) Uninstall(context.Context, string) (piUninstallResult, error) {
+	return piUninstallResult{}, errPiConfigBackendUnavailable
+}
+
+type piCatalogSource interface {
+	Models(context.Context) ([]piProviderModel, error)
+}
+
+type piCapabilityEnrichment struct {
+	Models  []piProviderModel
+	Matched int
+}
+
+type piCapabilitySource interface {
+	Enrich(context.Context, []piProviderModel) (piCapabilityEnrichment, error)
+}
+
+type basetenCLICatalogSource struct {
+	find    func() (string, error)
+	version func(string) string
+	run     func(context.Context, string, ...string) ([]byte, error)
+	timeout time.Duration
+}
+
+func (s basetenCLICatalogSource) Models(ctx context.Context) ([]piProviderModel, error) {
+	bin, err := s.find()
+	if err != nil {
+		return nil, fmt.Errorf("find Baseten CLI: %w", err)
+	}
+	if !filepath.IsAbs(bin) {
+		return nil, fmt.Errorf("Baseten CLI path is not absolute: %s", bin)
+	}
+	versionOutput := s.version(bin)
+	version, err := parseSemanticVersion(versionOutput)
+	if err != nil {
+		return nil, fmt.Errorf("determine Baseten CLI version: %w", err)
+	}
+	minimum, _ := parseSemanticVersion(minimumBasetenCLIVersion)
+	if version.less(minimum) {
+		return nil, fmt.Errorf(
+			"Baseten CLI v%s is too old; v%s or newer is required",
+			version, minimum,
+		)
+	}
+	timeout := s.timeout
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	raw, err := s.run(runCtx, bin, "model-api", "list", "--output", "json")
+	if err != nil {
+		return nil, fmt.Errorf("run 'baseten model-api list --output json': %w", err)
+	}
+	return parsePiModelCatalog(raw)
+}
+
+func runPiCatalogCommand(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	return stdout.Bytes(), nil
+}
+
+type piAdapterDependencies struct {
+	catalog      piCatalogSource
+	capabilities piCapabilitySource
+	store        piConfigStore
+	homeDir      func() (string, error)
+	getenv       func(string) string
+}
+
+var newPiConfigStore = func() piConfigStore {
+	return unavailablePiConfigStore{}
+}
+
+var piDependencies = func() piAdapterDependencies {
+	return piAdapterDependencies{
+		catalog: basetenCLICatalogSource{
+			find:    lookBaseten,
+			version: basetenCLIVersion,
+			run:     runPiCatalogCommand,
+			timeout: 30 * time.Second,
+		},
+		capabilities: newModelsDevPiCapabilitySource(),
+		store:        newPiConfigStore(),
+		homeDir:      os.UserHomeDir,
+		getenv:       os.Getenv,
+	}
+}
+
+func cmdPi(args []string) int {
+	return runPi(context.Background(), args, piDependencies(), os.Stdout, os.Stderr)
+}
+
+func runPi(
+	ctx context.Context,
+	args []string,
+	deps piAdapterDependencies,
+	out io.Writer,
+	errOut io.Writer,
+) int {
+	if len(args) != 1 {
+		fmt.Fprintln(errOut, "usage: baseten-switch pi install|status|uninstall")
+		return 2
+	}
+	switch args[0] {
+	case "install", "status", "uninstall":
+	case "on":
+		fmt.Fprintln(errOut, "unknown pi subcommand: on (use install|status|uninstall; Pi direct mode does not start the gateway)")
+		return 2
+	default:
+		fmt.Fprintf(errOut, "unknown pi subcommand: %s (use install|status|uninstall)\n", args[0])
+		return 2
+	}
+
+	agentDir, err := resolvePiAgentDir(deps.getenv("PI_CODING_AGENT_DIR"), deps.homeDir)
+	if err != nil {
+		fmt.Fprintf(errOut, "pi: resolve agent directory: %v\n", err)
+		return 1
+	}
+
+	switch args[0] {
+	case "install":
+		if strings.TrimSpace(deps.getenv("BASETEN_API_KEY")) == "" {
+			fmt.Fprintln(errOut, "pi install: BASETEN_API_KEY must be set in the environment")
+			return 1
+		}
+		models, err := deps.catalog.Models(ctx)
+		if err != nil {
+			fmt.Fprintf(errOut, "pi install: load Baseten model catalog: %v\n", err)
+			return 1
+		}
+		enrichment, err := deps.capabilities.Enrich(ctx, models)
+		if err != nil {
+			fmt.Fprintf(errOut, "pi install: load public model capabilities: %v\n", err)
+			return 1
+		}
+		models = enrichment.Models
+		result, err := deps.store.Install(ctx, piInstallRequest{
+			AgentDir: agentDir,
+			Provider: piProviderSpec{
+				ID:      piProviderID,
+				Name:    piProviderName,
+				BaseURL: piProviderBaseURL,
+				API:     piProviderAPI,
+				APIKey:  piAPIKeyReference,
+				Headers: map[string]string{
+					"Authorization": piAuthHeaderValue,
+				},
+				Models: models,
+			},
+		})
+		if err != nil {
+			fmt.Fprintf(errOut, "pi install: %v\n", err)
+			return 1
+		}
+		if result.ModelsPath == "" {
+			result.ModelsPath = filepath.Join(agentDir, piModelsFilename)
+		}
+		if result.ModelCount == 0 {
+			result.ModelCount = len(models)
+		}
+		action := "installed"
+		if !result.Changed {
+			action = "already installed"
+		}
+		fmt.Fprintf(out, "Baseten provider %s in %s (%d models)\n",
+			action, result.ModelsPath, result.ModelCount)
+		if enrichment.Matched != len(models) {
+			fmt.Fprintf(
+				errOut,
+				"pi install: warning: exact capability metadata is unavailable for %d of %d models; Pi will show conservative defaults for those models\n",
+				len(models)-enrichment.Matched,
+				len(models),
+			)
+		}
+		fmt.Fprintln(out, "Select it in Pi with /model or start Pi with --provider baseten.")
+		return 0
+
+	case "status":
+		result, err := deps.store.Status(ctx, agentDir)
+		if err != nil {
+			fmt.Fprintf(errOut, "pi status: %v\n", err)
+			return 1
+		}
+		if result.ModelsPath == "" {
+			result.ModelsPath = filepath.Join(agentDir, piModelsFilename)
+		}
+		if !result.Installed {
+			fmt.Fprintf(out, "Baseten provider is not installed in %s\n", result.ModelsPath)
+			return piStatusExitNotInstalled
+		}
+		if !result.Healthy {
+			detail := strings.TrimSpace(result.Detail)
+			if detail == "" {
+				detail = "managed provider configuration is unhealthy"
+			}
+			fmt.Fprintf(errOut, "pi status: %s\n", detail)
+			return 1
+		}
+		fmt.Fprintf(out, "Baseten provider is installed in %s (%d models)\n",
+			result.ModelsPath, result.ModelCount)
+		return 0
+
+	case "uninstall":
+		result, err := deps.store.Uninstall(ctx, agentDir)
+		if err != nil {
+			fmt.Fprintf(errOut, "pi uninstall: %v\n", err)
+			return 1
+		}
+		if result.ModelsPath == "" {
+			result.ModelsPath = filepath.Join(agentDir, piModelsFilename)
+		}
+		if result.Changed {
+			fmt.Fprintf(out, "Removed the Baseten provider from %s\n", result.ModelsPath)
+		} else {
+			fmt.Fprintf(out, "Baseten provider is not installed in %s; nothing to do\n", result.ModelsPath)
+		}
+		return 0
+
+	}
+	panic("unreachable")
+}
+
+func resolvePiAgentDir(configured string, homeDir func() (string, error)) (string, error) {
+	home, err := homeDir()
+	if err != nil {
+		return "", err
+	}
+	if configured == "" {
+		return filepath.Join(home, ".pi", "agent"), nil
+	}
+	switch {
+	case configured == "~":
+		return home, nil
+	case strings.HasPrefix(configured, "~/") || strings.HasPrefix(configured, `~\`):
+		return filepath.Join(home, configured[2:]), nil
+	case strings.HasPrefix(configured, "~"):
+		return "", fmt.Errorf("user-specific home expansion is not supported: %s", configured)
+	default:
+		return filepath.Clean(configured), nil
+	}
+}
+
+func parsePiModelCatalog(raw []byte) ([]piProviderModel, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var response struct {
+		Items []struct {
+			Name                       string      `json:"name"`
+			DisplayName                string      `json:"display_name"`
+			ContextLength              int         `json:"context_length"`
+			CostPerMillionInputTokens  interface{} `json:"cost_per_million_input_tokens"`
+			CostPerMillionOutputTokens interface{} `json:"cost_per_million_output_tokens"`
+		} `json:"items"`
+	}
+	if err := decoder.Decode(&response); err != nil {
+		return nil, fmt.Errorf("decode Baseten model catalog: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, errors.New("decode Baseten model catalog: multiple JSON values")
+		}
+		return nil, fmt.Errorf("decode Baseten model catalog: %w", err)
+	}
+	if len(response.Items) == 0 {
+		return nil, errors.New("Baseten model catalog contains no models")
+	}
+	models := make([]piProviderModel, 0, len(response.Items))
+	seen := make(map[string]struct{}, len(response.Items))
+	for _, item := range response.Items {
+		id := strings.TrimSpace(item.Name)
+		if id == "" {
+			return nil, errors.New("Baseten model catalog contains an empty model name")
+		}
+		if item.ContextLength <= 0 {
+			return nil, fmt.Errorf("Baseten model %q has invalid context length %d", id, item.ContextLength)
+		}
+		if _, ok := seen[id]; ok {
+			return nil, fmt.Errorf("Baseten model catalog contains duplicate model %q", id)
+		}
+		seen[id] = struct{}{}
+		input, err := piCatalogCost(item.CostPerMillionInputTokens)
+		if err != nil {
+			return nil, fmt.Errorf("Baseten model %q input cost: %w", id, err)
+		}
+		output, err := piCatalogCost(item.CostPerMillionOutputTokens)
+		if err != nil {
+			return nil, fmt.Errorf("Baseten model %q output cost: %w", id, err)
+		}
+		name := strings.TrimSpace(item.DisplayName)
+		if name == "" {
+			name = id
+		}
+		maxTokens := piDefaultMaxTokens
+		if item.ContextLength < maxTokens {
+			maxTokens = item.ContextLength
+		}
+		models = append(models, piProviderModel{
+			ID:            id,
+			Name:          name,
+			ContextWindow: item.ContextLength,
+			MaxTokens:     maxTokens,
+			Cost: piProviderCost{
+				Input:  input,
+				Output: output,
+			},
+		})
+	}
+	sort.Slice(models, func(i, j int) bool {
+		return models[i].ID < models[j].ID
+	})
+	return models, nil
+}
+
+func piCatalogCost(value interface{}) (float64, error) {
+	switch value := value.(type) {
+	case nil:
+		return 0, errors.New("cost is missing")
+	case json.Number:
+		cost, err := value.Float64()
+		if err != nil {
+			return 0, err
+		}
+		if cost < 0 || math.IsNaN(cost) || math.IsInf(cost, 0) {
+			return 0, fmt.Errorf("invalid cost %q", value)
+		}
+		return cost, nil
+	case string:
+		cost, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid decimal %q", value)
+		}
+		if cost < 0 || math.IsNaN(cost) || math.IsInf(cost, 0) {
+			return 0, fmt.Errorf("invalid cost %q", value)
+		}
+		return cost, nil
+	default:
+		return 0, fmt.Errorf("unexpected JSON type %T", value)
+	}
+}

--- a/gateway/cmd/baseten-switch/pi_adapter_test.go
+++ b/gateway/cmd/baseten-switch/pi_adapter_test.go
@@ -1,0 +1,428 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type fakePiCatalog struct {
+	models []piProviderModel
+	err    error
+	calls  int
+}
+
+type defaultPiCapabilities struct{}
+
+func (defaultPiCapabilities) Enrich(
+	_ context.Context,
+	models []piProviderModel,
+) (piCapabilityEnrichment, error) {
+	enriched := append([]piProviderModel(nil), models...)
+	for index := range enriched {
+		enriched[index].Input = append([]string(nil), enriched[index].Input...)
+		if len(enriched[index].Input) == 0 {
+			enriched[index].Input = []string{"text"}
+		}
+		enriched[index].CapabilityKnown = true
+	}
+	return piCapabilityEnrichment{Models: enriched, Matched: len(enriched)}, nil
+}
+
+type fakePiCapabilities struct {
+	result piCapabilityEnrichment
+	err    error
+	calls  int
+}
+
+func (f *fakePiCapabilities) Enrich(
+	_ context.Context,
+	_ []piProviderModel,
+) (piCapabilityEnrichment, error) {
+	f.calls++
+	return f.result, f.err
+}
+
+func (f *fakePiCatalog) Models(context.Context) ([]piProviderModel, error) {
+	f.calls++
+	return f.models, f.err
+}
+
+type fakePiStore struct {
+	installResult   piInstallResult
+	installErr      error
+	installRequests []piInstallRequest
+	statusResult    piStatusResult
+	statusErr       error
+	statusDirs      []string
+	uninstallResult piUninstallResult
+	uninstallErr    error
+	uninstallDirs   []string
+}
+
+func (f *fakePiStore) Install(_ context.Context, request piInstallRequest) (piInstallResult, error) {
+	f.installRequests = append(f.installRequests, request)
+	return f.installResult, f.installErr
+}
+
+func (f *fakePiStore) Status(_ context.Context, agentDir string) (piStatusResult, error) {
+	f.statusDirs = append(f.statusDirs, agentDir)
+	return f.statusResult, f.statusErr
+}
+
+func (f *fakePiStore) Uninstall(_ context.Context, agentDir string) (piUninstallResult, error) {
+	f.uninstallDirs = append(f.uninstallDirs, agentDir)
+	return f.uninstallResult, f.uninstallErr
+}
+
+func piTestDependencies(catalog piCatalogSource, store piConfigStore, env map[string]string) piAdapterDependencies {
+	return piAdapterDependencies{
+		catalog:      catalog,
+		capabilities: defaultPiCapabilities{},
+		store:        store,
+		homeDir:      func() (string, error) { return "/Users/example", nil },
+		getenv:       func(key string) string { return env[key] },
+	}
+}
+
+func TestPiInstallUsesDirectProviderLiteralsWithoutExposingAPIKey(t *testing.T) {
+	const secret = "private-test-key"
+	catalog := &fakePiCatalog{models: []piProviderModel{{
+		ID:              "example/model",
+		Name:            "Example Model",
+		ContextWindow:   128000,
+		MaxTokens:       piDefaultMaxTokens,
+		Cost:            piProviderCost{Input: 0.1, Output: 0.5},
+		Reasoning:       true,
+		Input:           []string{"text", "image"},
+		CapabilityKnown: true,
+	}}}
+	store := &fakePiStore{installResult: piInstallResult{
+		ModelsPath: "/tmp/pi/models.json",
+		ModelCount: 1,
+		Changed:    true,
+	}}
+	deps := piTestDependencies(catalog, store, map[string]string{
+		"BASETEN_API_KEY":     secret,
+		"PI_CODING_AGENT_DIR": "~/custom-pi",
+	})
+	var stdout, stderr bytes.Buffer
+
+	if code := runPi(context.Background(), []string{"install"}, deps, &stdout, &stderr); code != 0 {
+		t.Fatalf("install exit = %d, stderr = %s", code, stderr.String())
+	}
+	if catalog.calls != 1 {
+		t.Fatalf("catalog calls = %d, want 1", catalog.calls)
+	}
+	if len(store.installRequests) != 1 {
+		t.Fatalf("install requests = %d, want 1", len(store.installRequests))
+	}
+	request := store.installRequests[0]
+	if request.AgentDir != "/Users/example/custom-pi" {
+		t.Errorf("agent dir = %q", request.AgentDir)
+	}
+	wantHeaders := map[string]string{"Authorization": piAuthHeaderValue}
+	if request.Provider.ID != piProviderID ||
+		request.Provider.Name != piProviderName ||
+		request.Provider.BaseURL != piProviderBaseURL ||
+		request.Provider.API != piProviderAPI ||
+		request.Provider.APIKey != piAPIKeyReference ||
+		!reflect.DeepEqual(request.Provider.Headers, wantHeaders) {
+		t.Fatalf("provider = %#v", request.Provider)
+	}
+	if !reflect.DeepEqual(request.Provider.Models, catalog.models) {
+		t.Fatalf("models = %#v, want %#v", request.Provider.Models, catalog.models)
+	}
+	allOutput := stdout.String() + stderr.String()
+	if strings.Contains(allOutput, secret) {
+		t.Fatal("command output exposed BASETEN_API_KEY")
+	}
+	if !strings.Contains(stdout.String(), "Baseten provider installed") ||
+		!strings.Contains(stdout.String(), "--provider baseten") {
+		t.Fatalf("install output = %q", stdout.String())
+	}
+}
+
+func TestPiInstallCapabilityFailureDoesNotMutate(t *testing.T) {
+	catalog := &fakePiCatalog{models: []piProviderModel{{
+		ID: "example/model", Name: "Example Model",
+		ContextWindow: 128000, MaxTokens: piDefaultMaxTokens,
+		Cost: piProviderCost{Input: 0.1, Output: 0.5},
+	}}}
+	capabilities := &fakePiCapabilities{err: errors.New("catalog unavailable")}
+	store := &fakePiStore{}
+	deps := piTestDependencies(catalog, store, map[string]string{
+		"BASETEN_API_KEY": "present",
+	})
+	deps.capabilities = capabilities
+	var stdout, stderr bytes.Buffer
+
+	if code := runPi(context.Background(), []string{"install"}, deps, &stdout, &stderr); code != 1 {
+		t.Fatalf("install exit = %d, want 1", code)
+	}
+	if capabilities.calls != 1 || len(store.installRequests) != 0 {
+		t.Fatalf("capability failure reached store: calls=%d store=%d",
+			capabilities.calls, len(store.installRequests))
+	}
+	if !strings.Contains(stderr.String(), "load public model capabilities") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestPiInstallWarnsWhenExactCapabilitiesAreMissing(t *testing.T) {
+	model := piProviderModel{
+		ID: "example/model", Name: "Example Model",
+		ContextWindow: 128000, MaxTokens: piDefaultMaxTokens,
+		Cost:  piProviderCost{Input: 0.1, Output: 0.5},
+		Input: []string{"text"},
+	}
+	catalog := &fakePiCatalog{models: []piProviderModel{model}}
+	capabilities := &fakePiCapabilities{result: piCapabilityEnrichment{
+		Models: []piProviderModel{model},
+	}}
+	store := &fakePiStore{installResult: piInstallResult{Changed: true}}
+	deps := piTestDependencies(catalog, store, map[string]string{
+		"BASETEN_API_KEY": "present",
+	})
+	deps.capabilities = capabilities
+	var stdout, stderr bytes.Buffer
+
+	if code := runPi(context.Background(), []string{"install"}, deps, &stdout, &stderr); code != 0 {
+		t.Fatalf("install exit = %d, stderr = %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "unavailable for 1 of 1 models") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestPiInstallRequiresAPIKeyBeforeCatalogOrMutation(t *testing.T) {
+	catalog := &fakePiCatalog{}
+	store := &fakePiStore{}
+	deps := piTestDependencies(catalog, store, nil)
+	var stdout, stderr bytes.Buffer
+
+	if code := runPi(context.Background(), []string{"install"}, deps, &stdout, &stderr); code != 1 {
+		t.Fatalf("install exit = %d, want 1", code)
+	}
+	if catalog.calls != 0 || len(store.installRequests) != 0 {
+		t.Fatalf("missing key reached catalog/store: catalog=%d store=%d",
+			catalog.calls, len(store.installRequests))
+	}
+	if !strings.Contains(stderr.String(), "BASETEN_API_KEY must be set") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestPiInstallCatalogFailureDoesNotMutate(t *testing.T) {
+	catalog := &fakePiCatalog{err: errors.New("catalog unavailable")}
+	store := &fakePiStore{}
+	deps := piTestDependencies(catalog, store, map[string]string{
+		"BASETEN_API_KEY": "present",
+	})
+	var stdout, stderr bytes.Buffer
+
+	if code := runPi(context.Background(), []string{"install"}, deps, &stdout, &stderr); code != 1 {
+		t.Fatalf("install exit = %d, want 1", code)
+	}
+	if len(store.installRequests) != 0 {
+		t.Fatal("catalog failure mutated Pi configuration")
+	}
+}
+
+func TestPiStatusAndUninstallDoNotRequireAPIKeyOrCatalog(t *testing.T) {
+	t.Run("installed status", func(t *testing.T) {
+		catalog := &fakePiCatalog{}
+		store := &fakePiStore{statusResult: piStatusResult{
+			Installed:  true,
+			Healthy:    true,
+			ModelCount: 2,
+		}}
+		deps := piTestDependencies(catalog, store, nil)
+		var stdout, stderr bytes.Buffer
+		if code := runPi(context.Background(), []string{"status"}, deps, &stdout, &stderr); code != 0 {
+			t.Fatalf("status exit = %d, stderr = %s", code, stderr.String())
+		}
+		if catalog.calls != 0 || len(store.statusDirs) != 1 {
+			t.Fatalf("unexpected calls: catalog=%d status=%d", catalog.calls, len(store.statusDirs))
+		}
+		if !strings.Contains(stdout.String(), "(2 models)") {
+			t.Fatalf("status output = %q", stdout.String())
+		}
+	})
+
+	t.Run("not installed status", func(t *testing.T) {
+		catalog := &fakePiCatalog{}
+		store := &fakePiStore{}
+		deps := piTestDependencies(catalog, store, nil)
+		var stdout, stderr bytes.Buffer
+		if code := runPi(context.Background(), []string{"status"}, deps, &stdout, &stderr); code != piStatusExitNotInstalled {
+			t.Fatalf("status exit = %d, want %d", code, piStatusExitNotInstalled)
+		}
+	})
+
+	t.Run("uninstall", func(t *testing.T) {
+		catalog := &fakePiCatalog{}
+		store := &fakePiStore{uninstallResult: piUninstallResult{Changed: true}}
+		deps := piTestDependencies(catalog, store, nil)
+		var stdout, stderr bytes.Buffer
+		if code := runPi(context.Background(), []string{"uninstall"}, deps, &stdout, &stderr); code != 0 {
+			t.Fatalf("uninstall exit = %d, stderr = %s", code, stderr.String())
+		}
+		if catalog.calls != 0 || len(store.uninstallDirs) != 1 {
+			t.Fatalf("unexpected calls: catalog=%d uninstall=%d", catalog.calls, len(store.uninstallDirs))
+		}
+	})
+}
+
+func TestPiRejectsOnAndUnknownSubcommandsWithoutConsultingDependencies(t *testing.T) {
+	for _, subcommand := range []string{"on", "start", "off"} {
+		t.Run(subcommand, func(t *testing.T) {
+			catalog := &fakePiCatalog{}
+			store := &fakePiStore{}
+			deps := piAdapterDependencies{
+				catalog: catalog,
+				store:   store,
+				homeDir: func() (string, error) {
+					t.Fatal("invalid subcommand resolved the home directory")
+					return "", nil
+				},
+				getenv: func(string) string {
+					t.Fatal("invalid subcommand read the environment")
+					return ""
+				},
+			}
+			var stdout, stderr bytes.Buffer
+			if code := runPi(context.Background(), []string{subcommand}, deps, &stdout, &stderr); code != 2 {
+				t.Fatalf("%s exit = %d, want 2", subcommand, code)
+			}
+			if catalog.calls != 0 ||
+				len(store.installRequests) != 0 ||
+				len(store.statusDirs) != 0 ||
+				len(store.uninstallDirs) != 0 {
+				t.Fatal("invalid subcommand consulted a Pi dependency")
+			}
+			if subcommand == "on" && !strings.Contains(stderr.String(), "does not start the gateway") {
+				t.Fatalf("on stderr = %q", stderr.String())
+			}
+		})
+	}
+}
+
+func TestPiRejectsMissingOrExtraSubcommands(t *testing.T) {
+	deps := piAdapterDependencies{}
+	for _, args := range [][]string{nil, {"install", "extra"}} {
+		var stdout, stderr bytes.Buffer
+		if code := runPi(context.Background(), args, deps, &stdout, &stderr); code != 2 {
+			t.Fatalf("runPi(%v) exit = %d, want 2", args, code)
+		}
+	}
+}
+
+func TestResolvePiAgentDir(t *testing.T) {
+	home := func() (string, error) { return "/Users/example", nil }
+	tests := []struct {
+		configured string
+		want       string
+		wantErr    bool
+	}{
+		{"", "/Users/example/.pi/agent", false},
+		{"~", "/Users/example", false},
+		{"~/agent-dir", "/Users/example/agent-dir", false},
+		{"/tmp/pi", "/tmp/pi", false},
+		{"~someone/pi", "", true},
+	}
+	for _, test := range tests {
+		t.Run(test.configured, func(t *testing.T) {
+			got, err := resolvePiAgentDir(test.configured, home)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, test.wantErr)
+			}
+			if got != test.want {
+				t.Errorf("path = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestBasetenCLICatalogSourceUsesMachineReadableListCommand(t *testing.T) {
+	var gotName string
+	var gotArgs []string
+	source := basetenCLICatalogSource{
+		find:    func() (string, error) { return "/usr/local/bin/baseten", nil },
+		version: func(string) string { return "baseten 0.3.0" },
+		run: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			gotName = name
+			gotArgs = append([]string(nil), args...)
+			return []byte(`{"items":[{"name":"example/model","display_name":"Example","context_length":128000,"cost_per_million_input_tokens":"0.10","cost_per_million_output_tokens":0.5}]}`), nil
+		},
+	}
+	models, err := source.Models(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotName != "/usr/local/bin/baseten" ||
+		!reflect.DeepEqual(gotArgs, []string{"model-api", "list", "--output", "json"}) {
+		t.Fatalf("command = %s %v", gotName, gotArgs)
+	}
+	if len(models) != 1 ||
+		models[0].ID != "example/model" ||
+		models[0].Cost.Input != 0.1 ||
+		models[0].Cost.Output != 0.5 {
+		t.Fatalf("models = %#v", models)
+	}
+}
+
+func TestParsePiModelCatalogValidatesAndSortsModels(t *testing.T) {
+	raw := []byte(`{"items":[
+		{"name":"z/model","display_name":"","context_length":64000,"cost_per_million_input_tokens":0,"cost_per_million_output_tokens":"1.25"},
+		{"name":"a/model","display_name":"A Model","context_length":128000,"cost_per_million_input_tokens":0.2,"cost_per_million_output_tokens":0.8}
+	]}`)
+	models, err := parsePiModelCatalog(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := []string{models[0].ID, models[1].ID}; !reflect.DeepEqual(got, []string{"a/model", "z/model"}) {
+		t.Fatalf("order = %v", got)
+	}
+	if models[1].Name != "z/model" ||
+		models[1].MaxTokens != piDefaultMaxTokens ||
+		models[1].Cost.Output != 1.25 {
+		t.Fatalf("fallback model = %#v", models[1])
+	}
+
+	for name, body := range map[string]string{
+		"malformed": `{"items":`,
+		"empty":     `{"items":[]}`,
+		"blank id":  `{"items":[{"name":""}]}`,
+		"duplicate": `{"items":[{"name":"same"},{"name":"same"}]}`,
+		"bad cost":  `{"items":[{"name":"model","cost_per_million_input_tokens":{}}]}`,
+		"missing cost": `{"items":[
+			{"name":"model","context_length":1,"cost_per_million_input_tokens":null,"cost_per_million_output_tokens":1}
+		]}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parsePiModelCatalog([]byte(body)); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestPiUsesDefaultModelsPathWhenBackendOmitsIt(t *testing.T) {
+	catalog := &fakePiCatalog{}
+	store := &fakePiStore{uninstallResult: piUninstallResult{Changed: false}}
+	deps := piTestDependencies(catalog, store, nil)
+	var stdout, stderr bytes.Buffer
+
+	if code := runPi(context.Background(), []string{"uninstall"}, deps, &stdout, &stderr); code != 0 {
+		t.Fatalf("uninstall exit = %d, stderr = %s", code, stderr.String())
+	}
+	want := filepath.Join("/Users/example", ".pi", "agent", "models.json")
+	if !strings.Contains(stdout.String(), want) {
+		t.Fatalf("output = %q, want path %q", stdout.String(), want)
+	}
+}

--- a/gateway/cmd/baseten-switch/pi_catalog.go
+++ b/gateway/cmd/baseten-switch/pi_catalog.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/basetenlabs/baseten-switch/gateway/internal/pricing"
+)
+
+type modelsDevPiCapabilitySource struct {
+	client   *http.Client
+	endpoint string
+	timeout  time.Duration
+	now      func() time.Time
+}
+
+func newModelsDevPiCapabilitySource() piCapabilitySource {
+	return modelsDevPiCapabilitySource{
+		client:   &http.Client{},
+		endpoint: pricing.ModelsDevURL,
+		timeout:  pricing.ModelsDevFetchTimeout,
+		now:      time.Now,
+	}
+}
+
+func (s modelsDevPiCapabilitySource) Enrich(
+	ctx context.Context,
+	models []piProviderModel,
+) (piCapabilityEnrichment, error) {
+	timeout := s.timeout
+	if timeout <= 0 {
+		timeout = pricing.ModelsDevFetchTimeout
+	}
+	fetchCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	result, err := pricing.FetchModelsDev(
+		fetchCtx,
+		s.client,
+		s.endpoint,
+		"",
+		pricing.ModelsDevMaxResponseBytes,
+	)
+	if err != nil {
+		return piCapabilityEnrichment{}, err
+	}
+	if result.NotModified {
+		return piCapabilityEnrichment{}, fmt.Errorf(
+			"models.dev returned not-modified without a local candidate",
+		)
+	}
+	capturedAt := time.Now().UTC()
+	if s.now != nil {
+		capturedAt = s.now().UTC()
+	}
+	catalog := pricing.New()
+	if err := catalog.ReplaceModelsDev(
+		result.Body,
+		capturedAt,
+		result.ETag,
+	); err != nil {
+		return piCapabilityEnrichment{}, err
+	}
+	snapshot := catalog.Capture()
+	enriched := make([]piProviderModel, len(models))
+	matched := 0
+	for index, model := range models {
+		enriched[index] = model
+		enriched[index].Input = []string{"text"}
+		reasoning, reasoningKnown := snapshot.ModelReasoning(
+			pricing.ProviderBaseten,
+			model.ID,
+		)
+		if reasoningKnown {
+			enriched[index].Reasoning = reasoning.Supported
+		}
+		modalities, modalitiesKnown := snapshot.ModelInputModalities(
+			pricing.ProviderBaseten,
+			model.ID,
+		)
+		if projected, ok := piInputModalities(modalities); modalitiesKnown && ok {
+			enriched[index].Input = projected
+		} else {
+			modalitiesKnown = false
+		}
+		enriched[index].CapabilityKnown = reasoningKnown && modalitiesKnown
+		if enriched[index].CapabilityKnown {
+			matched++
+		}
+	}
+	return piCapabilityEnrichment{
+		Models:  enriched,
+		Matched: matched,
+	}, nil
+}
+
+func piInputModalities(source []string) ([]string, bool) {
+	projected := make([]string, 0, 2)
+	hasText := false
+	for _, modality := range source {
+		switch modality {
+		case "text":
+			hasText = true
+			projected = append(projected, modality)
+		case "image":
+			projected = append(projected, modality)
+		}
+	}
+	if !hasText {
+		return nil, false
+	}
+	return projected, true
+}

--- a/gateway/cmd/baseten-switch/pi_catalog_test.go
+++ b/gateway/cmd/baseten-switch/pi_catalog_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+)
+
+const piModelsDevFixture = `{
+  "anthropic": {
+    "id": "anthropic",
+    "models": {
+      "claude-test": {
+        "id": "claude-test",
+        "name": "Claude Test",
+        "reasoning": false,
+        "modalities": {"input": ["text"], "output": ["text"]}
+      }
+    }
+  },
+  "openai": {
+    "id": "openai",
+    "models": {
+      "gpt-test": {
+        "id": "gpt-test",
+        "name": "GPT Test",
+        "reasoning": false,
+        "modalities": {"input": ["text"], "output": ["text"]}
+      }
+    }
+  },
+  "baseten": {
+    "id": "baseten",
+    "models": {
+      "example/vision": {
+        "id": "example/vision",
+        "name": "Vision",
+        "reasoning": true,
+        "reasoning_options": [{"type": "toggle"}],
+        "modalities": {"input": ["text", "image", "audio"], "output": ["text"]}
+      },
+      "example/text": {
+        "id": "example/text",
+        "name": "Text",
+        "reasoning": false,
+        "modalities": {"input": ["text"], "output": ["text"]}
+      }
+    }
+  }
+}`
+
+func TestModelsDevPiCapabilitySourceEnrichesExactModels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet ||
+				r.Header.Get("Accept") != "application/json" ||
+				r.Header.Get("Authorization") != "" ||
+				r.Header.Get("X-Api-Key") != "" {
+				t.Fatalf("unexpected request: method=%s headers=%v", r.Method, r.Header)
+			}
+			w.Header().Set("ETag", `"fixture"`)
+			_, _ = io.WriteString(w, piModelsDevFixture)
+		},
+	))
+	defer server.Close()
+
+	source := modelsDevPiCapabilitySource{
+		client: server.Client(), endpoint: server.URL,
+		timeout: time.Second,
+		now: func() time.Time {
+			return time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
+		},
+	}
+	models := []piProviderModel{
+		{ID: "example/vision"},
+		{ID: "example/text"},
+		{ID: "example/missing"},
+	}
+	result, err := source.Enrich(context.Background(), models)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Matched != 2 {
+		t.Fatalf("matched = %d, want 2", result.Matched)
+	}
+	if !result.Models[0].Reasoning ||
+		!result.Models[0].CapabilityKnown ||
+		!reflect.DeepEqual(result.Models[0].Input, []string{"text", "image"}) {
+		t.Fatalf("vision model = %#v", result.Models[0])
+	}
+	if result.Models[1].Reasoning ||
+		!result.Models[1].CapabilityKnown ||
+		!reflect.DeepEqual(result.Models[1].Input, []string{"text"}) {
+		t.Fatalf("text model = %#v", result.Models[1])
+	}
+	if result.Models[2].Reasoning ||
+		result.Models[2].CapabilityKnown ||
+		!reflect.DeepEqual(result.Models[2].Input, []string{"text"}) {
+		t.Fatalf("missing model = %#v", result.Models[2])
+	}
+	if models[0].Input != nil || models[0].Reasoning {
+		t.Fatalf("source mutated input models: %#v", models)
+	}
+}
+
+func TestModelsDevPiCapabilitySourceRejectsInvalidCatalog(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = io.WriteString(w, `{"baseten":`)
+		},
+	))
+	defer server.Close()
+	source := modelsDevPiCapabilitySource{
+		client: server.Client(), endpoint: server.URL, timeout: time.Second,
+	}
+	if _, err := source.Enrich(
+		context.Background(),
+		[]piProviderModel{{ID: "example/model"}},
+	); err == nil {
+		t.Fatal("expected invalid catalog error")
+	}
+}
+
+func TestPiInputModalities(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		source []string
+		want   []string
+		ok     bool
+	}{
+		{"text", []string{"text"}, []string{"text"}, true},
+		{"image", []string{"text", "image"}, []string{"text", "image"}, true},
+		{"unsupported ignored", []string{"text", "audio"}, []string{"text"}, true},
+		{"no text", []string{"image"}, nil, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := piInputModalities(test.source)
+			if ok != test.ok || !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("piInputModalities(%v) = %v, %v; want %v, %v",
+					test.source, got, ok, test.want, test.ok)
+			}
+		})
+	}
+}

--- a/gateway/cmd/baseten-switch/pi_store.go
+++ b/gateway/cmd/baseten-switch/pi_store.go
@@ -1,0 +1,573 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/basetenlabs/baseten-switch/gateway/internal/piconfig"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/safefile"
+)
+
+type piFileStore struct {
+	backupRoot string
+}
+
+type piBackup struct {
+	Version             int      `json:"version"`
+	ConfigPath          string   `json:"config_path"`
+	ResolvedPath        string   `json:"resolved_path"`
+	Original            []byte   `json:"original,omitempty"`
+	OriginalExists      bool     `json:"original_exists"`
+	OriginalHash        string   `json:"original_hash"`
+	FileHashes          []string `json:"file_hashes"`
+	ProviderHashes      []string `json:"provider_hashes"`
+	PendingFileHash     string   `json:"pending_file_hash,omitempty"`
+	PendingProviderHash string   `json:"pending_provider_hash,omitempty"`
+}
+
+type piProviderJSON struct {
+	Name    string            `json:"name"`
+	BaseURL string            `json:"baseUrl"`
+	API     string            `json:"api"`
+	APIKey  string            `json:"apiKey"`
+	Headers map[string]string `json:"headers"`
+	Models  []piModelJSON     `json:"models"`
+}
+
+type piModelJSON struct {
+	ID            string         `json:"id"`
+	Name          string         `json:"name"`
+	Reasoning     bool           `json:"reasoning"`
+	Input         []string       `json:"input"`
+	ContextWindow int            `json:"contextWindow"`
+	MaxTokens     int            `json:"maxTokens"`
+	Cost          piProviderCost `json:"cost"`
+}
+
+func init() {
+	newPiConfigStore = func() piConfigStore {
+		return &piFileStore{
+			backupRoot: envDefault(
+				"BASETEN_SWITCH_BACKUP_DIR",
+				homeJoin(".config", "baseten-switch", "backups"),
+			),
+		}
+	}
+}
+
+func (s *piFileStore) Install(_ context.Context, req piInstallRequest) (piInstallResult, error) {
+	modelsPath := filepath.Join(req.AgentDir, piModelsFilename)
+	lock, err := s.acquireLock(modelsPath)
+	if err != nil {
+		return piInstallResult{}, err
+	}
+	defer lock.close()
+	snapshot, err := safefile.Read(modelsPath)
+	if err != nil {
+		return piInstallResult{}, err
+	}
+	current := piEditableData(snapshot.Data)
+	provider, err := marshalPiProvider(req.Provider)
+	if err != nil {
+		return piInstallResult{}, err
+	}
+	providerHash := piHash(provider)
+
+	backupPath := s.backupPath(snapshot.RequestedPath)
+	backup, err := loadPiBackup(backupPath)
+	if err != nil {
+		return piInstallResult{}, err
+	}
+	existing, found, err := piconfig.Provider(current, req.Provider.ID)
+	if err != nil {
+		return piInstallResult{}, err
+	}
+
+	if backup == nil {
+		if found {
+			return piInstallResult{}, fmt.Errorf(
+				"%w: provider %q is not managed by Baseten Switch",
+				piconfig.ErrProviderCollision, req.Provider.ID,
+			)
+		}
+		backup = &piBackup{
+			Version:        1,
+			ConfigPath:     snapshot.RequestedPath,
+			ResolvedPath:   snapshot.ResolvedPath,
+			Original:       append([]byte(nil), snapshot.Data...),
+			OriginalExists: snapshot.Exists,
+			OriginalHash:   piHash(snapshot.Data),
+		}
+	} else {
+		if err := backup.validate(snapshot); err != nil {
+			return piInstallResult{}, err
+		}
+		if backup.pending() {
+			currentHash := piHash(current)
+			if found &&
+				currentHash == backup.PendingFileHash &&
+				piHash(existing) == backup.PendingProviderHash {
+				backup.FileHashes = piAppendHash(backup.FileHashes, backup.PendingFileHash)
+				backup.ProviderHashes = piAppendHash(backup.ProviderHashes, backup.PendingProviderHash)
+			} else if found && !piHashKnown(backup.ProviderHashes, piHash(existing)) {
+				return piInstallResult{}, errors.New(
+					"Pi recovery state records an incomplete install and the provider changed; recovery state was retained",
+				)
+			}
+			backup.clearPending()
+			if err := savePiBackup(backupPath, backup); err != nil {
+				return piInstallResult{}, fmt.Errorf("reconcile Pi recovery state: %w", err)
+			}
+		}
+		if found && !piHashKnown(backup.ProviderHashes, piHash(existing)) {
+			return piInstallResult{}, fmt.Errorf(
+				"%w: provider %q changed outside Baseten Switch",
+				piconfig.ErrProviderCollision, req.Provider.ID,
+			)
+		}
+	}
+
+	desired, changed, err := piconfig.UpsertProvider(current, req.Provider.ID, provider, found)
+	if err != nil {
+		return piInstallResult{}, err
+	}
+	backup.PendingProviderHash = providerHash
+	backup.PendingFileHash = piHash(desired)
+	if err := savePiBackup(backupPath, backup); err != nil {
+		return piInstallResult{}, fmt.Errorf("save Pi recovery state: %w", err)
+	}
+	if changed || !snapshot.Exists || !bytes.Equal(snapshot.Data, desired) {
+		if _, err := snapshot.Replace(desired, 0o600); err != nil {
+			return piInstallResult{}, fmt.Errorf("write Pi model configuration: %w", err)
+		}
+	}
+	backup.ProviderHashes = piAppendHash(backup.ProviderHashes, backup.PendingProviderHash)
+	backup.FileHashes = piAppendHash(backup.FileHashes, backup.PendingFileHash)
+	backup.clearPending()
+	if err := savePiBackup(backupPath, backup); err != nil {
+		return piInstallResult{}, fmt.Errorf(
+			"Pi provider was written but recovery state could not be finalized: %w", err,
+		)
+	}
+	return piInstallResult{
+		ModelsPath: snapshot.RequestedPath,
+		ModelCount: len(req.Provider.Models),
+		Changed:    changed || !snapshot.Exists,
+	}, nil
+}
+
+func (s *piFileStore) Status(_ context.Context, agentDir string) (piStatusResult, error) {
+	modelsPath := filepath.Join(agentDir, piModelsFilename)
+	lock, err := s.acquireLock(modelsPath)
+	if err != nil {
+		return piStatusResult{}, err
+	}
+	defer lock.close()
+	snapshot, err := safefile.Read(modelsPath)
+	if err != nil {
+		return piStatusResult{}, err
+	}
+	result := piStatusResult{ModelsPath: snapshot.RequestedPath}
+	if !snapshot.Exists || len(bytes.TrimSpace(snapshot.Data)) == 0 {
+		return result, nil
+	}
+	provider, found, err := piconfig.Provider(snapshot.Data, piProviderID)
+	if err != nil {
+		return piStatusResult{}, err
+	}
+	if !found {
+		return result, nil
+	}
+	result.Installed = true
+
+	backup, err := loadPiBackup(s.backupPath(snapshot.RequestedPath))
+	if err != nil {
+		return piStatusResult{}, err
+	}
+	if backup == nil {
+		result.Detail = "provider exists but has no Baseten Switch ownership state"
+		return result, nil
+	}
+	if err := backup.validate(snapshot); err != nil {
+		result.Detail = err.Error()
+		return result, nil
+	}
+	if backup.pending() {
+		result.Detail = "the previous Pi install did not finalize its recovery state; run 'baseten-switch pi install' again"
+		return result, nil
+	}
+	if !piHashKnown(backup.ProviderHashes, piHash(provider)) {
+		result.Detail = "managed provider changed outside Baseten Switch"
+		return result, nil
+	}
+	result.ModelCount, err = piProviderModelCount(provider)
+	if err != nil {
+		result.Detail = err.Error()
+		return result, nil
+	}
+	result.Healthy = true
+	return result, nil
+}
+
+func (s *piFileStore) Uninstall(_ context.Context, agentDir string) (piUninstallResult, error) {
+	modelsPath := filepath.Join(agentDir, piModelsFilename)
+	lock, err := s.acquireLock(modelsPath)
+	if err != nil {
+		return piUninstallResult{}, err
+	}
+	defer lock.close()
+	snapshot, err := safefile.Read(modelsPath)
+	if err != nil {
+		return piUninstallResult{}, err
+	}
+	result := piUninstallResult{ModelsPath: snapshot.RequestedPath}
+	backupPath := s.backupPath(snapshot.RequestedPath)
+	backup, err := loadPiBackup(backupPath)
+	if err != nil {
+		return result, err
+	}
+
+	current := piEditableData(snapshot.Data)
+	provider, found, err := piconfig.Provider(current, piProviderID)
+	if err != nil {
+		return result, err
+	}
+	if backup == nil {
+		if found {
+			return result, fmt.Errorf(
+				"%w: provider %q is not managed by Baseten Switch",
+				piconfig.ErrProviderCollision, piProviderID,
+			)
+		}
+		return result, nil
+	}
+	if err := backup.validate(snapshot); err != nil {
+		return result, err
+	}
+	if backup.pending() {
+		return result, errors.New(
+			"the previous Pi install did not finalize its recovery state; run 'baseten-switch pi install' again before uninstalling",
+		)
+	}
+	if backup.OriginalExists &&
+		(!snapshot.Exists || len(bytes.TrimSpace(snapshot.Data)) == 0) {
+		return result, errors.New(
+			"Pi model configuration was removed or emptied after install; recovery state was retained",
+		)
+	}
+
+	switch {
+	case piHashKnown(backup.FileHashes, piHash(current)):
+		if backup.OriginalExists {
+			if _, err := snapshot.Replace(backup.Original, 0o600); err != nil {
+				return result, fmt.Errorf("restore Pi model configuration: %w", err)
+			}
+		} else if err := snapshot.Remove(); err != nil {
+			return result, fmt.Errorf("remove created Pi model configuration: %w", err)
+		}
+		result.Changed = true
+	case !found:
+		// The user already removed the managed entry. Only ownership state
+		// remains to clean up.
+	case piHashKnown(backup.ProviderHashes, piHash(provider)):
+		desired, changed, err := piconfig.RemoveProvider(current, piProviderID)
+		if err != nil {
+			return result, err
+		}
+		if changed {
+			if _, err := snapshot.Replace(desired, 0o600); err != nil {
+				return result, fmt.Errorf("remove managed Pi provider: %w", err)
+			}
+			result.Changed = true
+		}
+	default:
+		return result, fmt.Errorf(
+			"%w: provider %q changed outside Baseten Switch; recovery state was retained",
+			piconfig.ErrProviderCollision, piProviderID,
+		)
+	}
+	if err := removePiBackup(backupPath); err != nil {
+		return result, fmt.Errorf("remove Pi recovery state: %w", err)
+	}
+	return result, nil
+}
+
+func marshalPiProvider(spec piProviderSpec) ([]byte, error) {
+	if spec.ID == "" || len(spec.Models) == 0 {
+		return nil, errors.New("Pi provider requires an ID and at least one model")
+	}
+	models := make([]piModelJSON, 0, len(spec.Models))
+	for _, model := range spec.Models {
+		if model.ID == "" ||
+			model.ContextWindow <= 0 ||
+			model.MaxTokens <= 0 ||
+			len(model.Input) == 0 {
+			return nil, fmt.Errorf("invalid Pi model metadata for %q", model.ID)
+		}
+		for _, modality := range model.Input {
+			if modality != "text" && modality != "image" {
+				return nil, fmt.Errorf(
+					"invalid Pi input modality %q for %q",
+					modality,
+					model.ID,
+				)
+			}
+		}
+		models = append(models, piModelJSON{
+			ID:            model.ID,
+			Name:          model.Name,
+			Reasoning:     model.Reasoning,
+			Input:         append([]string(nil), model.Input...),
+			ContextWindow: model.ContextWindow,
+			MaxTokens:     model.MaxTokens,
+			Cost:          model.Cost,
+		})
+	}
+	return json.MarshalIndent(piProviderJSON{
+		Name: spec.Name, BaseURL: spec.BaseURL, API: spec.API,
+		APIKey: spec.APIKey, Headers: spec.Headers, Models: models,
+	}, "", "  ")
+}
+
+func piEditableData(data []byte) []byte {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return []byte("{}\n")
+	}
+	return data
+}
+
+func piProviderModelCount(provider []byte) (int, error) {
+	var value struct {
+		Models []json.RawMessage `json:"models"`
+	}
+	if err := json.Unmarshal(provider, &value); err != nil {
+		return 0, fmt.Errorf("parse managed provider: %w", err)
+	}
+	return len(value.Models), nil
+}
+
+func (b *piBackup) validate(snapshot *safefile.Snapshot) error {
+	if b.Version != 1 {
+		return fmt.Errorf("Pi recovery state has unsupported version %d", b.Version)
+	}
+	if b.ConfigPath != snapshot.RequestedPath {
+		return fmt.Errorf("Pi recovery state belongs to a different configured path")
+	}
+	if b.ResolvedPath != snapshot.ResolvedPath {
+		return fmt.Errorf("Pi model configuration resolves to a different target")
+	}
+	if b.OriginalHash != piHash(b.Original) {
+		return errors.New("Pi recovery state original-content hash is invalid")
+	}
+	if !b.OriginalExists && len(b.Original) != 0 {
+		return errors.New("Pi recovery state records content for a file that did not exist")
+	}
+	for _, hash := range append(append([]string{}, b.FileHashes...), b.ProviderHashes...) {
+		if !piValidHash(hash) {
+			return errors.New("Pi recovery state contains an invalid managed-content hash")
+		}
+	}
+	if (b.PendingFileHash == "") != (b.PendingProviderHash == "") ||
+		(b.PendingFileHash != "" &&
+			(!piValidHash(b.PendingFileHash) || !piValidHash(b.PendingProviderHash))) {
+		return errors.New("Pi recovery state contains an invalid pending mutation")
+	}
+	return nil
+}
+
+func (b *piBackup) pending() bool {
+	return b.PendingFileHash != ""
+}
+
+func (b *piBackup) clearPending() {
+	b.PendingFileHash = ""
+	b.PendingProviderHash = ""
+}
+
+func (s *piFileStore) acquireLock(modelsPath string) (*configMutationLock, error) {
+	absolute, err := filepath.Abs(modelsPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve Pi model path for locking: %w", err)
+	}
+	lockBase := s.backupPath(filepath.Clean(absolute))
+	if err := os.MkdirAll(filepath.Dir(lockBase), 0o700); err != nil {
+		return nil, fmt.Errorf("create Pi state directory: %w", err)
+	}
+	if err := os.Chmod(filepath.Dir(lockBase), 0o700); err != nil {
+		return nil, fmt.Errorf("secure Pi state directory: %w", err)
+	}
+	return acquireConfigMutationLock(lockBase)
+}
+
+func (s *piFileStore) backupPath(modelsPath string) string {
+	sum := sha256.Sum256([]byte(modelsPath))
+	return filepath.Join(s.backupRoot, "pi", "config-backup."+hex.EncodeToString(sum[:])[:16]+".json")
+}
+
+func loadPiBackup(path string) (*piBackup, error) {
+	snapshot, err := safefile.Read(path)
+	if err != nil {
+		return nil, err
+	}
+	if !snapshot.Exists {
+		return nil, nil
+	}
+	if piBackupFinalSymlink(path) {
+		return nil, errors.New("Pi recovery state path must not be a symbolic link")
+	}
+	if snapshot.Mode.Perm() != 0o600 {
+		if err := os.Chmod(snapshot.ResolvedPath, 0o600); err != nil {
+			return nil, fmt.Errorf("secure Pi recovery state: %w", err)
+		}
+		snapshot, err = safefile.Read(path)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if err := rejectDuplicatePiBackupKeys(snapshot.Data); err != nil {
+		return nil, fmt.Errorf("parse Pi recovery state: %w", err)
+	}
+	var backup piBackup
+	if err := json.Unmarshal(snapshot.Data, &backup); err != nil {
+		return nil, fmt.Errorf("parse Pi recovery state: %w", err)
+	}
+	return &backup, nil
+}
+
+func savePiBackup(path string, backup *piBackup) error {
+	data, err := json.MarshalIndent(backup, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	snapshot, err := safefile.Read(path)
+	if err != nil {
+		return err
+	}
+	if piBackupFinalSymlink(path) {
+		return errors.New("Pi recovery state path must not be a symbolic link")
+	}
+	if snapshot.Exists && snapshot.Mode.Perm() != 0o600 {
+		if err := os.Chmod(snapshot.ResolvedPath, 0o600); err != nil {
+			return fmt.Errorf("secure Pi recovery state: %w", err)
+		}
+		snapshot, err = safefile.Read(path)
+		if err != nil {
+			return err
+		}
+	}
+	_, err = snapshot.Replace(data, 0o600)
+	return err
+}
+
+func removePiBackup(path string) error {
+	snapshot, err := safefile.Read(path)
+	if err != nil {
+		return err
+	}
+	if piBackupFinalSymlink(path) {
+		return errors.New("Pi recovery state path must not be a symbolic link")
+	}
+	return snapshot.Remove()
+}
+
+func piBackupFinalSymlink(path string) bool {
+	info, err := os.Lstat(path)
+	return err == nil && info.Mode()&os.ModeSymlink != 0
+}
+
+func piHash(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func piHashKnown(hashes []string, hash string) bool {
+	for _, candidate := range hashes {
+		if candidate == hash {
+			return true
+		}
+	}
+	return false
+}
+
+func piAppendHash(hashes []string, hash string) []string {
+	if piHashKnown(hashes, hash) {
+		return hashes
+	}
+	return append(hashes, hash)
+}
+
+func piValidHash(hash string) bool {
+	if len(hash) != sha256.Size*2 || strings.ToLower(hash) != hash {
+		return false
+	}
+	_, err := hex.DecodeString(hash)
+	return err == nil
+}
+
+func rejectDuplicatePiBackupKeys(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	var walk func() error
+	walk = func() error {
+		token, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		delim, ok := token.(json.Delim)
+		if !ok {
+			return nil
+		}
+		switch delim {
+		case '{':
+			seen := map[string]bool{}
+			for decoder.More() {
+				keyToken, err := decoder.Token()
+				if err != nil {
+					return err
+				}
+				key, ok := keyToken.(string)
+				if !ok {
+					return errors.New("object key is not a string")
+				}
+				if seen[key] {
+					return fmt.Errorf("duplicate key %q", key)
+				}
+				seen[key] = true
+				if err := walk(); err != nil {
+					return err
+				}
+			}
+			_, err = decoder.Token()
+			return err
+		case '[':
+			for decoder.More() {
+				if err := walk(); err != nil {
+					return err
+				}
+			}
+			_, err = decoder.Token()
+			return err
+		default:
+			return fmt.Errorf("unexpected JSON delimiter %q", delim)
+		}
+	}
+	if err := walk(); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("multiple JSON values")
+		}
+		return err
+	}
+	return nil
+}

--- a/gateway/cmd/baseten-switch/pi_store_test.go
+++ b/gateway/cmd/baseten-switch/pi_store_test.go
@@ -1,0 +1,324 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/basetenlabs/baseten-switch/gateway/internal/piconfig"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/safefile"
+)
+
+func testPiInstallRequest(agentDir string) piInstallRequest {
+	return piInstallRequest{
+		AgentDir: agentDir,
+		Provider: piProviderSpec{
+			ID: piProviderID, Name: piProviderName, BaseURL: piProviderBaseURL,
+			API: piProviderAPI, APIKey: piAPIKeyReference,
+			Headers: map[string]string{"Authorization": piAuthHeaderValue},
+			Models: []piProviderModel{{
+				ID: "example/model", Name: "Example Model",
+				ContextWindow: 32000, MaxTokens: 4096,
+				Cost:            piProviderCost{Input: 0.1, Output: 0.2},
+				Reasoning:       true,
+				Input:           []string{"text", "image"},
+				CapabilityKnown: true,
+			}},
+		},
+	}
+}
+
+func TestPiFileStoreInstallStatusAndExactUninstall(t *testing.T) {
+	root := t.TempDir()
+	agentDir := filepath.Join(root, "agent")
+	if err := os.MkdirAll(agentDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	modelsPath := filepath.Join(agentDir, piModelsFilename)
+	original := []byte("{\n  // retained\n  \"providers\": {\"other\": {\"baseUrl\": \"https://example.invalid\"}},\n}\n")
+	if err := os.WriteFile(modelsPath, original, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	store := &piFileStore{backupRoot: filepath.Join(root, "backups")}
+
+	installed, err := store.Install(context.Background(), testPiInstallRequest(agentDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !installed.Changed || installed.ModelCount != 1 {
+		t.Fatalf("install result = %+v", installed)
+	}
+	data, err := os.ReadFile(modelsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`"baseten"`, `"baseUrl": "https://inference.baseten.co/v1"`,
+		`"Authorization": "Api-Key $BASETEN_API_KEY"`,
+		`"cacheRead": 0`, `"cacheWrite": 0`, "// retained",
+	} {
+		if !bytes.Contains(data, []byte(want)) {
+			t.Errorf("installed config missing %q:\n%s", want, data)
+		}
+	}
+	info, err := os.Stat(modelsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o640 {
+		t.Fatalf("mode = %04o, want 0640", info.Mode().Perm())
+	}
+
+	status, err := store.Status(context.Background(), agentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.Installed || !status.Healthy || status.ModelCount != 1 {
+		t.Fatalf("status = %+v", status)
+	}
+
+	uninstalled, err := store.Uninstall(context.Background(), agentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !uninstalled.Changed {
+		t.Fatal("uninstall reported no change")
+	}
+	restored, err := os.ReadFile(modelsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(restored, original) {
+		t.Fatalf("restored bytes differ:\n%s", restored)
+	}
+}
+
+func TestPiFileStoreMissingFileIsRemovedOnUninstall(t *testing.T) {
+	root := t.TempDir()
+	agentDir := filepath.Join(root, "agent")
+	store := &piFileStore{backupRoot: filepath.Join(root, "backups")}
+
+	if _, err := store.Install(context.Background(), testPiInstallRequest(agentDir)); err != nil {
+		t.Fatal(err)
+	}
+	modelsPath := filepath.Join(agentDir, piModelsFilename)
+	if _, err := os.Stat(modelsPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Uninstall(context.Background(), agentDir); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(modelsPath); !os.IsNotExist(err) {
+		t.Fatalf("created models file remains after uninstall: %v", err)
+	}
+}
+
+func TestPiFileStoreDriftRemovesOnlyRecognizedProvider(t *testing.T) {
+	root := t.TempDir()
+	agentDir := filepath.Join(root, "agent")
+	store := &piFileStore{backupRoot: filepath.Join(root, "backups")}
+	if _, err := store.Install(context.Background(), testPiInstallRequest(agentDir)); err != nil {
+		t.Fatal(err)
+	}
+	modelsPath := filepath.Join(agentDir, piModelsFilename)
+	managed, err := os.ReadFile(modelsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	close := bytes.LastIndexByte(managed, '}')
+	drifted := append([]byte(nil), managed[:close]...)
+	drifted = append(drifted, []byte(",\n  \"userSetting\": true\n}\n")...)
+	if err := os.WriteFile(modelsPath, drifted, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.Uninstall(context.Background(), agentDir); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(modelsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(after, []byte(`"baseten"`)) {
+		t.Fatalf("managed provider remains:\n%s", after)
+	}
+	if !bytes.Contains(after, []byte(`"userSetting": true`)) {
+		t.Fatalf("unrelated drift was lost:\n%s", after)
+	}
+}
+
+func TestPiFileStoreRefusesForeignOrChangedProvider(t *testing.T) {
+	t.Run("foreign before install", func(t *testing.T) {
+		root := t.TempDir()
+		agentDir := filepath.Join(root, "agent")
+		if err := os.MkdirAll(agentDir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(agentDir, piModelsFilename)
+		foreign := []byte(`{"providers":{"baseten":{"name":"User entry"}}}` + "\n")
+		if err := os.WriteFile(path, foreign, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		store := &piFileStore{backupRoot: filepath.Join(root, "backups")}
+		_, err := store.Install(context.Background(), testPiInstallRequest(agentDir))
+		if !errors.Is(err, piconfig.ErrProviderCollision) {
+			t.Fatalf("install error = %v", err)
+		}
+		after, _ := os.ReadFile(path)
+		if !bytes.Equal(after, foreign) {
+			t.Fatal("foreign provider was changed")
+		}
+	})
+
+	t.Run("changed after install", func(t *testing.T) {
+		root := t.TempDir()
+		agentDir := filepath.Join(root, "agent")
+		store := &piFileStore{backupRoot: filepath.Join(root, "backups")}
+		if _, err := store.Install(context.Background(), testPiInstallRequest(agentDir)); err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(agentDir, piModelsFilename)
+		data, _ := os.ReadFile(path)
+		changed, _, err := piconfig.UpsertProvider(data, piProviderID, []byte(`{"name":"User replacement"}`), true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, changed, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err = store.Uninstall(context.Background(), agentDir)
+		if !errors.Is(err, piconfig.ErrProviderCollision) {
+			t.Fatalf("uninstall error = %v", err)
+		}
+		after, _ := os.ReadFile(path)
+		if !bytes.Contains(after, []byte("User replacement")) {
+			t.Fatal("changed provider was overwritten")
+		}
+	})
+}
+
+func TestPiFileStorePreservesSymlinkAndNeverPersistsSecret(t *testing.T) {
+	root := t.TempDir()
+	agentDir := filepath.Join(root, "agent")
+	targetDir := filepath.Join(root, "target")
+	if err := os.MkdirAll(agentDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(targetDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(targetDir, "models.json")
+	original := []byte("{}\n")
+	if err := os.WriteFile(target, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configured := filepath.Join(agentDir, piModelsFilename)
+	if err := os.Symlink(filepath.Join("..", "target", "models.json"), configured); err != nil {
+		t.Fatal(err)
+	}
+	store := &piFileStore{backupRoot: filepath.Join(root, "backups")}
+	if _, err := store.Install(context.Background(), testPiInstallRequest(agentDir)); err != nil {
+		t.Fatal(err)
+	}
+	if info, err := os.Lstat(configured); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("configured path is not a preserved symlink: %v", err)
+	}
+	secret := "secret-value-that-must-not-persist"
+	for _, path := range []string{target, store.backupPath(configured)} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(data), secret) {
+			t.Fatalf("secret persisted in %s", path)
+		}
+	}
+	if _, err := store.Uninstall(context.Background(), agentDir); err != nil {
+		t.Fatal(err)
+	}
+	if info, err := os.Lstat(configured); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("configured path is not a preserved symlink after uninstall: %v", err)
+	}
+}
+
+func TestPiFileStoreSecuresExistingBackup(t *testing.T) {
+	root := t.TempDir()
+	agentDir := filepath.Join(root, "agent")
+	store := &piFileStore{backupRoot: filepath.Join(root, "backups")}
+	modelsPath, err := filepath.Abs(filepath.Join(agentDir, piModelsFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	backupPath := store.backupPath(modelsPath)
+	if err := os.MkdirAll(filepath.Dir(backupPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := safefile.Read(modelsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale := &piBackup{
+		Version: 1, ConfigPath: snapshot.RequestedPath, ResolvedPath: snapshot.ResolvedPath,
+		OriginalHash: piHash(nil),
+	}
+	data, err := json.Marshal(stale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(backupPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.Install(context.Background(), testPiInstallRequest(agentDir)); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(backupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("backup mode = %04o, want 0600", info.Mode().Perm())
+	}
+	dirInfo, err := os.Stat(filepath.Dir(backupPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dirInfo.Mode().Perm() != 0o700 {
+		t.Fatalf("backup directory mode = %04o, want 0700", dirInfo.Mode().Perm())
+	}
+}
+
+func TestPiFileStoreRetainsRecoveryWhenOriginalConfigIsLost(t *testing.T) {
+	root := t.TempDir()
+	agentDir := filepath.Join(root, "agent")
+	if err := os.MkdirAll(agentDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	modelsPath := filepath.Join(agentDir, piModelsFilename)
+	if err := os.WriteFile(modelsPath, []byte(`{"providers":{"other":{}}}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := &piFileStore{backupRoot: filepath.Join(root, "backups")}
+	if _, err := store.Install(context.Background(), testPiInstallRequest(agentDir)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(modelsPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.Uninstall(context.Background(), agentDir); err == nil {
+		t.Fatal("uninstall succeeded after the original config was lost")
+	}
+	absolute, err := filepath.Abs(modelsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(store.backupPath(absolute)); err != nil {
+		t.Fatalf("recovery state was not retained: %v", err)
+	}
+}

--- a/gateway/cmd/gateway/admin_model_catalog_test.go
+++ b/gateway/cmd/gateway/admin_model_catalog_test.go
@@ -365,6 +365,9 @@ func TestAdminModelCatalogIgnoresNonSelectionFieldsAndUsesMetadataFallback(t *te
 
 func TestModelCatalogReasoningProjectionUsesExactBasetenRecord(t *testing.T) {
 	capturedAt := time.Date(2026, time.July, 26, 12, 0, 0, 0, time.UTC)
+	originalNow := modelCatalogNow
+	modelCatalogNow = func() time.Time { return capturedAt }
+	t.Cleanup(func() { modelCatalogNow = originalNow })
 	p := pricing.New()
 	if err := p.ReplaceModelsDev(
 		[]byte(publicCatalogGatewayFixture),

--- a/gateway/cmd/gateway/public_catalog_refresh.go
+++ b/gateway/cmd/gateway/public_catalog_refresh.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,15 +20,15 @@ import (
 const (
 	publicCatalogRefreshMinDelay = 6 * time.Hour
 	publicCatalogRefreshMaxDelay = 24 * time.Hour
-	publicCatalogRefreshTimeout  = 10 * time.Second
-	publicCatalogResponseMaxSize = 8 << 20
+	publicCatalogRefreshTimeout  = pricing.ModelsDevFetchTimeout
+	publicCatalogResponseMaxSize = pricing.ModelsDevMaxResponseBytes
 	providerCatalogCacheMaxSize  = 16 << 20
 	publicCatalogStaleAfter      = 48 * time.Hour
 	publicCatalogMissRetryAfter  = 5 * time.Minute
 )
 
 var (
-	publicCatalogURL       = "https://models.dev/api.json"
+	publicCatalogURL       = pricing.ModelsDevURL
 	publicCatalogNow       = time.Now
 	publicCatalogNextDelay = randomPublicCatalogRefreshDelay
 )
@@ -185,14 +184,7 @@ func (g *Gateway) refreshPublicCatalogOnce(parent context.Context) {
 
 	ctx, cancel := context.WithTimeout(parent, publicCatalogRefreshTimeout)
 	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, publicCatalogURL, nil)
-	if err == nil {
-		req.Header.Set("Accept", "application/json")
-		if etag := g.pricing.Capture().ModelsDevRootETag(); etag != "" {
-			req.Header.Set("If-None-Match", etag)
-		}
-		err = g.fetchAndPublishPublicCatalog(req)
-	}
+	err := g.fetchAndPublishPublicCatalog(ctx)
 	if err != nil {
 		message := err.Error()
 		if errors.Is(err, context.Canceled) {
@@ -215,18 +207,18 @@ func (g *Gateway) refreshPublicCatalogOnce(parent context.Context) {
 	manager.mu.Unlock()
 }
 
-func (g *Gateway) fetchAndPublishPublicCatalog(req *http.Request) error {
-	clientCopy := *g.client
-	clientCopy.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
-		return http.ErrUseLastResponse
-	}
-	resp, err := clientCopy.Do(req)
+func (g *Gateway) fetchAndPublishPublicCatalog(ctx context.Context) error {
+	result, err := pricing.FetchModelsDev(
+		ctx,
+		g.client,
+		publicCatalogURL,
+		g.pricing.Capture().ModelsDevRootETag(),
+		publicCatalogResponseMaxSize,
+	)
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode == http.StatusNotModified {
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64<<10))
+	if result.NotModified {
 		if err := g.pricing.RevalidateModelsDev(
 			publicCatalogNow().UTC(),
 		); err != nil {
@@ -234,26 +226,10 @@ func (g *Gateway) fetchAndPublishPublicCatalog(req *http.Request) error {
 		}
 		return g.persistProviderCatalogCaches()
 	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64<<10))
-		return fmt.Errorf("models.dev returned %d", resp.StatusCode)
-	}
-	body, err := io.ReadAll(
-		io.LimitReader(resp.Body, publicCatalogResponseMaxSize+1),
-	)
-	if err != nil {
-		return err
-	}
-	if len(body) > publicCatalogResponseMaxSize {
-		return fmt.Errorf(
-			"models.dev response exceeds %d bytes",
-			publicCatalogResponseMaxSize,
-		)
-	}
 	if err := g.pricing.ReplaceModelsDev(
-		body,
+		result.Body,
 		publicCatalogNow().UTC(),
-		resp.Header.Get("ETag"),
+		result.ETag,
 	); err != nil {
 		return err
 	}

--- a/gateway/internal/piconfig/editor.go
+++ b/gateway/internal/piconfig/editor.go
@@ -1,0 +1,333 @@
+// Package piconfig updates one provider entry in Pi's JSONC model
+// configuration while preserving all unrelated bytes.
+package piconfig
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"unicode/utf8"
+)
+
+// ErrProviderCollision is returned when UpsertProvider finds an existing
+// provider entry and replacement was not explicitly allowed.
+var ErrProviderCollision = errors.New("provider entry already exists")
+
+type edit struct {
+	start int
+	end   int
+	text  []byte
+}
+
+// Provider returns the exact bytes of providerID's value from the top-level
+// "providers" object. The returned slice does not alias input.
+func Provider(input []byte, providerID string) (raw []byte, found bool, err error) {
+	if err := validateProviderID(providerID); err != nil {
+		return nil, false, err
+	}
+	root, err := parseJSONCDocument(input)
+	if err != nil {
+		return nil, false, err
+	}
+	if root.kind != kindObject {
+		return nil, false, errors.New("Pi model configuration must be a top-level object")
+	}
+	providersIndex, duplicate := duplicateMember(root, "providers")
+	if duplicate {
+		return nil, false, errors.New(`Pi model configuration contains duplicate top-level "providers" keys`)
+	}
+	if providersIndex < 0 {
+		return nil, false, nil
+	}
+	providers := root.members[providersIndex].value
+	if providers.kind != kindObject {
+		return nil, false, errors.New(`top-level "providers" value must be an object`)
+	}
+	targetIndex, duplicate := duplicateMember(providers, providerID)
+	if duplicate {
+		return nil, false, fmt.Errorf("Pi model configuration contains duplicate provider key %q", providerID)
+	}
+	if targetIndex < 0 {
+		return nil, false, nil
+	}
+	value := providers.members[targetIndex].value
+	return append([]byte(nil), input[value.start:value.end]...), true, nil
+}
+
+// UpsertProvider adds or replaces providerID under the top-level "providers"
+// object. providerJSON must contain exactly one strict JSON object value.
+//
+// Existing providers are replaced only when allowReplace is true. The returned
+// bool reports whether the output differs from input.
+func UpsertProvider(input []byte, providerID string, providerJSON []byte, allowReplace bool) ([]byte, bool, error) {
+	if err := validateProviderID(providerID); err != nil {
+		return nil, false, err
+	}
+	rawProvider, err := parseProviderJSON(providerJSON)
+	if err != nil {
+		return nil, false, err
+	}
+
+	root, err := parseJSONCDocument(input)
+	if err != nil {
+		return nil, false, err
+	}
+	if root.kind != kindObject {
+		return nil, false, errors.New("Pi model configuration must be a top-level object")
+	}
+
+	providersIndex, duplicate := duplicateMember(root, "providers")
+	if duplicate {
+		return nil, false, errors.New(`Pi model configuration contains duplicate top-level "providers" keys`)
+	}
+	if providersIndex < 0 {
+		key, _ := json.Marshal("providers")
+		providerKey, _ := json.Marshal(providerID)
+		value := make([]byte, 0, len(providerKey)+len(rawProvider)+6)
+		value = append(value, '{')
+		value = append(value, providerKey...)
+		value = append(value, ':', ' ')
+		value = append(value, rawProvider...)
+		value = append(value, '}')
+		edits := objectInsertEdits(input, root, key, value)
+		return applyAndValidate(input, edits)
+	}
+
+	providers := root.members[providersIndex].value
+	if providers.kind != kindObject {
+		return nil, false, errors.New(`top-level "providers" value must be an object`)
+	}
+	targetIndex, duplicate := duplicateMember(providers, providerID)
+	if duplicate {
+		return nil, false, fmt.Errorf("Pi model configuration contains duplicate provider key %q", providerID)
+	}
+	if targetIndex >= 0 {
+		if !allowReplace {
+			return nil, false, fmt.Errorf("%w: %q", ErrProviderCollision, providerID)
+		}
+		current := input[providers.members[targetIndex].value.start:providers.members[targetIndex].value.end]
+		if bytes.Equal(current, rawProvider) {
+			return append([]byte(nil), input...), false, nil
+		}
+		return applyAndValidate(input, []edit{{
+			start: providers.members[targetIndex].value.start,
+			end:   providers.members[targetIndex].value.end,
+			text:  rawProvider,
+		}})
+	}
+
+	key, _ := json.Marshal(providerID)
+	edits := objectInsertEdits(input, providers, key, rawProvider)
+	return applyAndValidate(input, edits)
+}
+
+// RemoveProvider removes providerID from the top-level "providers" object.
+// It leaves the providers object and all unrelated bytes in place.
+func RemoveProvider(input []byte, providerID string) ([]byte, bool, error) {
+	if err := validateProviderID(providerID); err != nil {
+		return nil, false, err
+	}
+	root, err := parseJSONCDocument(input)
+	if err != nil {
+		return nil, false, err
+	}
+	if root.kind != kindObject {
+		return nil, false, errors.New("Pi model configuration must be a top-level object")
+	}
+	providersIndex, duplicate := duplicateMember(root, "providers")
+	if duplicate {
+		return nil, false, errors.New(`Pi model configuration contains duplicate top-level "providers" keys`)
+	}
+	if providersIndex < 0 {
+		return append([]byte(nil), input...), false, nil
+	}
+	providers := root.members[providersIndex].value
+	if providers.kind != kindObject {
+		return nil, false, errors.New(`top-level "providers" value must be an object`)
+	}
+	targetIndex, duplicate := duplicateMember(providers, providerID)
+	if duplicate {
+		return nil, false, fmt.Errorf("Pi model configuration contains duplicate provider key %q", providerID)
+	}
+	if targetIndex < 0 {
+		return append([]byte(nil), input...), false, nil
+	}
+
+	target := providers.members[targetIndex]
+	edits := []edit{{start: target.keyStart, end: target.value.end}}
+	switch {
+	case target.comma >= 0:
+		edits = append(edits, edit{start: target.comma, end: target.comma + 1})
+	case targetIndex > 0:
+		previousComma := providers.members[targetIndex-1].comma
+		if previousComma < 0 {
+			return nil, false, errors.New("invalid providers object separator")
+		}
+		edits = append(edits, edit{start: previousComma, end: previousComma + 1})
+	}
+	return applyAndValidate(input, edits)
+}
+
+func validateProviderID(providerID string) error {
+	if providerID == "" {
+		return errors.New("provider ID must not be empty")
+	}
+	if !utf8.ValidString(providerID) {
+		return errors.New("provider ID must be valid UTF-8")
+	}
+	return nil
+}
+
+func parseProviderJSON(input []byte) ([]byte, error) {
+	trimmed := bytes.TrimSpace(input)
+	if !json.Valid(trimmed) {
+		return nil, errors.New("provider JSON must be valid strict JSON")
+	}
+	value, err := parseJSONCDocument(trimmed)
+	if err != nil {
+		return nil, fmt.Errorf("provider JSON: %w", err)
+	}
+	if value.kind != kindObject {
+		return nil, errors.New("provider JSON must be an object")
+	}
+	if err := validateUniqueObjectKeys(value); err != nil {
+		return nil, err
+	}
+	return append([]byte(nil), trimmed...), nil
+}
+
+func objectInsertEdits(src []byte, object jsonValue, keyJSON, value []byte) []edit {
+	member := make([]byte, 0, len(keyJSON)+len(value)+2)
+	member = append(member, keyJSON...)
+	member = append(member, ':', ' ')
+	member = append(member, value...)
+
+	edits := make([]edit, 0, 2)
+	if len(object.members) > 0 {
+		last := object.members[len(object.members)-1]
+		if last.comma < 0 {
+			edits = append(edits, edit{
+				start: last.value.end,
+				end:   last.value.end,
+				text:  []byte{','},
+			})
+		}
+	}
+
+	if bytes.IndexByte(src[object.open+1:object.close], '\n') < 0 {
+		prefix := []byte(nil)
+		if object.close > object.open+1 &&
+			(len(object.members) > 0 || !isJSONCWhitespace(src[object.close-1])) {
+			prefix = []byte{' '}
+		}
+		edits = append(edits, edit{
+			start: object.close,
+			end:   object.close,
+			text:  append(prefix, member...),
+		})
+		return edits
+	}
+
+	insertAt, closeIndent, closeOnOwnLine := lineIndentBefore(src, object.close)
+	memberIndent := objectMemberIndent(src, object, closeIndent)
+	newline := objectNewline(src[object.open+1 : object.close])
+	text := make([]byte, 0, len(memberIndent)+len(member)+len(closeIndent)+2*len(newline))
+	if !closeOnOwnLine {
+		text = append(text, newline...)
+	}
+	text = append(text, memberIndent...)
+	text = append(text, member...)
+	text = append(text, newline...)
+	if !closeOnOwnLine {
+		text = append(text, closeIndent...)
+	}
+	edits = append(edits, edit{start: insertAt, end: insertAt, text: text})
+	return edits
+}
+
+func objectNewline(body []byte) []byte {
+	index := bytes.IndexByte(body, '\n')
+	if index > 0 && body[index-1] == '\r' {
+		return []byte{'\r', '\n'}
+	}
+	return []byte{'\n'}
+}
+
+func isJSONCWhitespace(b byte) bool {
+	switch b {
+	case ' ', '\t', '\r', '\n':
+		return true
+	default:
+		return false
+	}
+}
+
+func lineIndentBefore(src []byte, pos int) (int, []byte, bool) {
+	lineStart := bytes.LastIndexByte(src[:pos], '\n') + 1
+	indent := src[lineStart:pos]
+	for _, b := range indent {
+		if b != ' ' && b != '\t' {
+			return pos, objectLineIndent(src, pos), false
+		}
+	}
+	return lineStart, append([]byte(nil), indent...), true
+}
+
+func objectLineIndent(src []byte, pos int) []byte {
+	lineStart := bytes.LastIndexByte(src[:pos], '\n') + 1
+	end := lineStart
+	for end < pos && (src[end] == ' ' || src[end] == '\t') {
+		end++
+	}
+	return append([]byte(nil), src[lineStart:end]...)
+}
+
+func objectMemberIndent(src []byte, object jsonValue, closeIndent []byte) []byte {
+	if len(object.members) > 0 {
+		first := object.members[0]
+		lineStart := bytes.LastIndexByte(src[:first.keyStart], '\n') + 1
+		indent := src[lineStart:first.keyStart]
+		valid := true
+		for _, b := range indent {
+			if b != ' ' && b != '\t' {
+				valid = false
+				break
+			}
+		}
+		if valid {
+			return append([]byte(nil), indent...)
+		}
+	}
+	indent := append([]byte(nil), closeIndent...)
+	return append(indent, ' ', ' ')
+}
+
+func applyAndValidate(input []byte, edits []edit) ([]byte, bool, error) {
+	if len(edits) == 0 {
+		return append([]byte(nil), input...), false, nil
+	}
+	sort.SliceStable(edits, func(i, j int) bool {
+		if edits[i].start != edits[j].start {
+			return edits[i].start < edits[j].start
+		}
+		return edits[i].end < edits[j].end
+	})
+	var output bytes.Buffer
+	cursor := 0
+	for _, change := range edits {
+		if change.start < cursor || change.start < 0 || change.end < change.start || change.end > len(input) {
+			return nil, false, errors.New("overlapping or invalid JSONC edit")
+		}
+		output.Write(input[cursor:change.start])
+		output.Write(change.text)
+		cursor = change.end
+	}
+	output.Write(input[cursor:])
+	result := output.Bytes()
+	if _, err := parseJSONCDocument(result); err != nil {
+		return nil, false, fmt.Errorf("edited Pi model configuration is invalid: %w", err)
+	}
+	return result, !bytes.Equal(input, result), nil
+}

--- a/gateway/internal/piconfig/editor_test.go
+++ b/gateway/internal/piconfig/editor_test.go
@@ -1,0 +1,454 @@
+package piconfig
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+const testProvider = `{"name":"Example","baseUrl":"https://example.invalid/v1","models":[{"id":"example/model"}]}`
+
+func TestProviderReturnsExactValueCopy(t *testing.T) {
+	input := []byte(`{
+  "providers": {
+    "exam\u0070le": {
+      // Formatting inside the value is significant to ownership.
+      "name": "Example",
+    } /* outside value */
+  }
+}`)
+	got, found, err := Provider(input, "example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("Provider did not find escaped provider key")
+	}
+	want := `{
+      // Formatting inside the value is significant to ownership.
+      "name": "Example",
+    }`
+	if string(got) != want {
+		t.Fatalf("Provider returned %q, want %q", got, want)
+	}
+	got[0] = '['
+	if input[bytes.Index(input, []byte(want))] != '{' {
+		t.Fatal("Provider result aliases its input")
+	}
+}
+
+func TestProviderAbsent(t *testing.T) {
+	for _, input := range []string{
+		`{}`,
+		`{"providers":{}}`,
+		`{"providers":{"other":{}}}`,
+	} {
+		got, found, err := Provider([]byte(input), "example")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if found || got != nil {
+			t.Fatalf("Provider(%q) returned %q, found=%v", input, got, found)
+		}
+	}
+}
+
+func TestProviderRejectsInvalidOrAmbiguousInput(t *testing.T) {
+	inputs := []string{
+		`[]`,
+		`{"providers":`,
+		`{"providers":[]}`,
+		`{"providers":{},"providers":{}}`,
+		`{"providers":{"example":{},"example":{}}}`,
+	}
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			if _, _, err := Provider([]byte(input), "example"); err == nil {
+				t.Fatal("Provider accepted invalid or ambiguous input")
+			}
+		})
+	}
+}
+
+func TestUpsertProviderCreatesProvidersObject(t *testing.T) {
+	input := []byte("{\n  // Existing settings stay byte-for-byte.\n  \"setting\": true,\n}\n")
+	got, changed, err := UpsertProvider(input, "example", []byte(testProvider), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("UpsertProvider reported no change")
+	}
+	want := "{\n  // Existing settings stay byte-for-byte.\n  \"setting\": true,\n  \"providers\": {\"example\": " + testProvider + "}\n}\n"
+	if string(got) != want {
+		t.Fatalf("output:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestUpsertProviderPreservesJSONCAndTrailingComma(t *testing.T) {
+	input := []byte(`{
+  "before": [1, 2,],
+  "providers": {
+    // This provider is unrelated.
+    "other": {"enabled": true,},
+  },
+  "after": "unchanged",
+}
+`)
+	got, changed, err := UpsertProvider(input, "example", []byte(testProvider), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("UpsertProvider reported no change")
+	}
+	for _, preserved := range []string{
+		`"before": [1, 2,],`,
+		"// This provider is unrelated.",
+		`"other": {"enabled": true,},`,
+		`"after": "unchanged",`,
+	} {
+		if !strings.Contains(string(got), preserved) {
+			t.Errorf("output did not preserve %q:\n%s", preserved, got)
+		}
+	}
+	if !strings.Contains(string(got), `"example": `+testProvider) {
+		t.Fatalf("output omitted provider:\n%s", got)
+	}
+}
+
+func TestUpsertProviderIntoOneLineObjectWithoutTrailingComma(t *testing.T) {
+	input := []byte(`{"providers":{"other":{}}}`)
+	got, changed, err := UpsertProvider(input, "example", []byte(testProvider), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("UpsertProvider reported no change")
+	}
+	want := `{"providers":{"other":{}, "example": ` + testProvider + `}}`
+	if string(got) != want {
+		t.Fatalf("output %q, want %q", got, want)
+	}
+}
+
+func TestUpsertProviderRefusesCollision(t *testing.T) {
+	input := []byte(`{"providers":{"example":{"name":"User value"}}}`)
+	got, changed, err := UpsertProvider(input, "example", []byte(testProvider), false)
+	if !errors.Is(err, ErrProviderCollision) {
+		t.Fatalf("error = %v, want ErrProviderCollision", err)
+	}
+	if got != nil || changed {
+		t.Fatalf("collision returned output %q, changed=%v", got, changed)
+	}
+}
+
+func TestUpsertProviderReplacesOnlyValue(t *testing.T) {
+	input := []byte(`{
+  "providers": {
+    "example" /* key note */ : /* value note */ {"name":"Old"} /* after note */,
+    "other": {"keep":true}
+  }
+}`)
+	got, changed, err := UpsertProvider(input, "example", []byte(testProvider), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("UpsertProvider reported no change")
+	}
+	want := `{
+  "providers": {
+    "example" /* key note */ : /* value note */ ` + testProvider + ` /* after note */,
+    "other": {"keep":true}
+  }
+}`
+	if string(got) != want {
+		t.Fatalf("output:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestUpsertProviderIdenticalValueIsNoop(t *testing.T) {
+	input := []byte(`{"providers":{"example":` + testProvider + `}}`)
+	got, changed, err := UpsertProvider(input, "example", []byte(" \n"+testProvider+"\n"), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatal("identical provider reported a change")
+	}
+	if !bytes.Equal(got, input) {
+		t.Fatalf("no-op changed bytes: %q", got)
+	}
+}
+
+func TestRemoveProviderPreservesNeighborsAndComments(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "first",
+			input: `{"providers":{"example":{} /* keep comment */, "other":{}}}`,
+			want:  `{"providers":{ /* keep comment */ "other":{}}}`,
+		},
+		{
+			name:  "middle",
+			input: `{"providers":{"one":{}, "example":{} /* keep comment */, "two":{}}}`,
+			want:  `{"providers":{"one":{},  /* keep comment */ "two":{}}}`,
+		},
+		{
+			name:  "last",
+			input: `{"providers":{"other":{}, /* keep comment */ "example":{}}}`,
+			want:  `{"providers":{"other":{} /* keep comment */ }}`,
+		},
+		{
+			name:  "only with trailing comma",
+			input: `{"providers":{"example":{} /* keep comment */,}}`,
+			want:  `{"providers":{ /* keep comment */}}`,
+		},
+		{
+			name:  "only without comma",
+			input: `{"providers":{/* before */"example":{}/* after */}}`,
+			want:  `{"providers":{/* before *//* after */}}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, changed, err := RemoveProvider([]byte(test.input), "example")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !changed {
+				t.Fatal("RemoveProvider reported no change")
+			}
+			if string(got) != test.want {
+				t.Fatalf("output %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestRemoveProviderAbsentIsByteExactNoop(t *testing.T) {
+	for _, input := range []string{
+		"{/* no providers */}\n",
+		`{"providers":{"other":{}}}`,
+	} {
+		got, changed, err := RemoveProvider([]byte(input), "example")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if changed {
+			t.Fatalf("RemoveProvider(%q) reported a change", input)
+		}
+		if string(got) != input {
+			t.Fatalf("no-op output %q, want %q", got, input)
+		}
+	}
+}
+
+func TestRejectsMalformedJSONC(t *testing.T) {
+	inputs := []string{
+		"",
+		`[]`,
+		`{"providers":`,
+		`{"providers":{/* unterminated`,
+		`{"providers":{"example": tru}}`,
+		`{"providers":{"example":{}}, trailing}`,
+		`{"providers":{"example":{}},} extra`,
+		`{"providers":{"example":"\x"}}`,
+		`{"providers":[1,2]}`,
+		string([]byte{'{', '"', 'x', '"', ':', '"', 0xff, '"', '}'}),
+	}
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			if _, _, err := UpsertProvider([]byte(input), "example", []byte(testProvider), true); err == nil {
+				t.Fatal("UpsertProvider accepted malformed or unsupported input")
+			}
+			if _, _, err := RemoveProvider([]byte(input), "example"); err == nil {
+				t.Fatal("RemoveProvider accepted malformed or unsupported input")
+			}
+		})
+	}
+}
+
+func TestRejectsDuplicateRelevantKeys(t *testing.T) {
+	inputs := []string{
+		`{"providers":{},"providers":{}}`,
+		`{"providers":{},"pro\u0076iders":{}}`,
+		`{"providers":{"example":{},"example":{}}}`,
+		`{"providers":{"example":{},"exam\u0070le":{}}}`,
+	}
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			if _, _, err := UpsertProvider([]byte(input), "example", []byte(testProvider), true); err == nil {
+				t.Fatal("UpsertProvider accepted duplicate relevant key")
+			}
+			if _, _, err := RemoveProvider([]byte(input), "example"); err == nil {
+				t.Fatal("RemoveProvider accepted duplicate relevant key")
+			}
+		})
+	}
+}
+
+func TestUpsertProviderWithNestedMultilineValue(t *testing.T) {
+	input := []byte("{\"providers\":{\"other\":{\"list\":[\n1,\n2\n]}}}")
+	got, changed, err := UpsertProvider(input, "example", []byte(testProvider), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("UpsertProvider reported no change")
+	}
+	raw, found, err := Provider(got, "example")
+	if err != nil || !found || string(raw) != testProvider {
+		t.Fatalf("inserted provider = %q, found=%v, err=%v", raw, found, err)
+	}
+	if !bytes.Contains(got, []byte("\"other\":{\"list\":[\n1,\n2\n]}")) {
+		t.Fatalf("nested multiline value changed:\n%s", got)
+	}
+}
+
+func TestRemoveProviderPreservesCRLFLineComment(t *testing.T) {
+	input := []byte("{\r\n  \"providers\": {\r\n    \"example\": {} // keep comment\r\n    , \"other\": {}\r\n  }\r\n}\r\n")
+	got, changed, err := RemoveProvider(input, "example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("RemoveProvider reported no change")
+	}
+	want := "{\r\n  \"providers\": {\r\n     // keep comment\r\n     \"other\": {}\r\n  }\r\n}\r\n"
+	if string(got) != want {
+		t.Fatalf("output %q, want %q", got, want)
+	}
+}
+
+func TestAllowsDuplicateUnrelatedKeys(t *testing.T) {
+	input := []byte(`{"note":1,"note":2,"providers":{"other":{},"other":{}}}`)
+	if _, _, err := UpsertProvider(input, "example", []byte(testProvider), false); err != nil {
+		t.Fatalf("unrelated duplicate prevented update: %v", err)
+	}
+}
+
+func TestRejectsInvalidProviderJSON(t *testing.T) {
+	input := []byte(`{"providers":{}}`)
+	providers := []string{
+		"",
+		"null",
+		"[]",
+		`{"name":"bad",}`,
+		`{/* comment */"name":"bad"}`,
+		`{"name":"one","name":"two"}`,
+		`{"nested":{"key":1,"key":2}}`,
+	}
+	for _, provider := range providers {
+		t.Run(provider, func(t *testing.T) {
+			if _, _, err := UpsertProvider(input, "example", []byte(provider), false); err == nil {
+				t.Fatal("UpsertProvider accepted invalid provider JSON")
+			}
+		})
+	}
+}
+
+func TestEscapedKeysAreDecodedForOwnership(t *testing.T) {
+	input := []byte(`{"pro\u0076iders":{"exam\u0070le":{"name":"old"}}}`)
+	if _, _, err := UpsertProvider(input, "example", []byte(testProvider), false); !errors.Is(err, ErrProviderCollision) {
+		t.Fatalf("error = %v, want escaped-key collision", err)
+	}
+	got, changed, err := RemoveProvider(input, "example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed || string(got) != `{"pro\u0076iders":{}}` {
+		t.Fatalf("RemoveProvider output = %q, changed=%v", got, changed)
+	}
+}
+
+func TestRejectsInvalidProviderID(t *testing.T) {
+	for _, providerID := range []string{"", string([]byte{0xff})} {
+		if _, _, err := UpsertProvider([]byte(`{}`), providerID, []byte(testProvider), false); err == nil {
+			t.Fatalf("UpsertProvider accepted provider ID %q", providerID)
+		}
+		if _, _, err := RemoveProvider([]byte(`{}`), providerID); err == nil {
+			t.Fatalf("RemoveProvider accepted provider ID %q", providerID)
+		}
+	}
+}
+
+func TestEmptyObjectFormatting(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{`{}`, `{"providers": {"example": ` + testProvider + `}}`},
+		{`{ }`, `{ "providers": {"example": ` + testProvider + `}}`},
+		{"{\n}\n", "{\n  \"providers\": {\"example\": " + testProvider + "}\n}\n"},
+		{"{\n  /* note */\n}\n", "{\n  /* note */\n  \"providers\": {\"example\": " + testProvider + "}\n}\n"},
+	}
+	for _, test := range tests {
+		got, _, err := UpsertProvider([]byte(test.input), "example", []byte(testProvider), false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != test.want {
+			t.Errorf("input %q produced %q, want %q", test.input, got, test.want)
+		}
+	}
+}
+
+func TestUpsertProviderPreservesCRLFStyle(t *testing.T) {
+	input := []byte("{\r\n  \"setting\": true,\r\n}\r\n")
+	got, changed, err := UpsertProvider(input, "example", []byte(testProvider), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("UpsertProvider reported no change")
+	}
+	want := "{\r\n  \"setting\": true,\r\n  \"providers\": {\"example\": " + testProvider + "}\r\n}\r\n"
+	if string(got) != want {
+		t.Fatalf("output %q, want %q", got, want)
+	}
+	if bytes.Contains(bytes.ReplaceAll(got, []byte("\r\n"), nil), []byte("\n")) {
+		t.Fatalf("output introduced a bare line feed: %q", got)
+	}
+}
+
+func FuzzProviderEditsRemainValidJSONC(f *testing.F) {
+	for _, input := range []string{
+		`{}`,
+		`{"providers":{}}`,
+		`{"providers":{"other":{}}}`,
+		"{\n// note\n\"providers\":{\"other\":{\"list\":[1,2,],},},\n}\n",
+		`{"providers":{"example":{"old":true}}}`,
+		`not JSON`,
+	} {
+		f.Add([]byte(input))
+	}
+	f.Fuzz(func(t *testing.T, input []byte) {
+		got, _, err := UpsertProvider(input, "example", []byte(testProvider), true)
+		if err != nil {
+			return
+		}
+		if _, err := parseJSONCDocument(got); err != nil {
+			t.Fatalf("successful upsert returned invalid JSONC: %v", err)
+		}
+		raw, found, err := Provider(got, "example")
+		if err != nil {
+			t.Fatalf("read after successful upsert failed: %v", err)
+		}
+		if !found || string(raw) != testProvider {
+			t.Fatalf("read after successful upsert returned %q, found=%v", raw, found)
+		}
+		removed, _, err := RemoveProvider(got, "example")
+		if err != nil {
+			t.Fatalf("remove after successful upsert failed: %v", err)
+		}
+		if _, err := parseJSONCDocument(removed); err != nil {
+			t.Fatalf("successful removal returned invalid JSONC: %v", err)
+		}
+	})
+}

--- a/gateway/internal/piconfig/parser.go
+++ b/gateway/internal/piconfig/parser.go
@@ -1,0 +1,331 @@
+package piconfig
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"unicode/utf8"
+)
+
+type valueKind byte
+
+const (
+	kindObject valueKind = '{'
+	kindArray  valueKind = '['
+	kindScalar valueKind = 's'
+)
+
+type jsonValue struct {
+	kind    valueKind
+	start   int
+	end     int
+	open    int
+	close   int
+	members []jsonMember
+	items   []jsonValue
+}
+
+type jsonMember struct {
+	key      string
+	keyStart int
+	value    jsonValue
+	comma    int
+}
+
+type jsoncParser struct {
+	src []byte
+	pos int
+}
+
+func parseJSONCDocument(src []byte) (jsonValue, error) {
+	if !utf8.Valid(src) {
+		return jsonValue{}, fmt.Errorf("invalid JSONC: input is not valid UTF-8")
+	}
+	p := jsoncParser{src: src}
+	if err := p.skipTrivia(); err != nil {
+		return jsonValue{}, err
+	}
+	if p.pos == len(src) {
+		return jsonValue{}, p.errorf("expected a JSON value")
+	}
+	value, err := p.parseValue()
+	if err != nil {
+		return jsonValue{}, err
+	}
+	if err := p.skipTrivia(); err != nil {
+		return jsonValue{}, err
+	}
+	if p.pos != len(src) {
+		return jsonValue{}, p.errorf("unexpected content after the JSON value")
+	}
+	return value, nil
+}
+
+func (p *jsoncParser) parseValue() (jsonValue, error) {
+	if err := p.skipTrivia(); err != nil {
+		return jsonValue{}, err
+	}
+	if p.pos >= len(p.src) {
+		return jsonValue{}, p.errorf("expected a JSON value")
+	}
+	switch p.src[p.pos] {
+	case '{':
+		return p.parseObject()
+	case '[':
+		return p.parseArray()
+	case '"':
+		start := p.pos
+		if _, err := p.parseString(); err != nil {
+			return jsonValue{}, err
+		}
+		return jsonValue{kind: kindScalar, start: start, end: p.pos}, nil
+	default:
+		return p.parseScalar()
+	}
+}
+
+func (p *jsoncParser) parseObject() (jsonValue, error) {
+	start := p.pos
+	p.pos++
+	object := jsonValue{
+		kind:  kindObject,
+		start: start,
+		open:  start,
+	}
+	if err := p.skipTrivia(); err != nil {
+		return jsonValue{}, err
+	}
+	if p.consume('}') {
+		object.close = p.pos - 1
+		object.end = p.pos
+		return object, nil
+	}
+
+	for {
+		if p.pos >= len(p.src) || p.src[p.pos] != '"' {
+			return jsonValue{}, p.errorf("expected an object key")
+		}
+		keyStart := p.pos
+		key, err := p.parseString()
+		if err != nil {
+			return jsonValue{}, err
+		}
+		if err := p.skipTrivia(); err != nil {
+			return jsonValue{}, err
+		}
+		if !p.consume(':') {
+			return jsonValue{}, p.errorf("expected ':' after object key")
+		}
+		value, err := p.parseValue()
+		if err != nil {
+			return jsonValue{}, err
+		}
+		member := jsonMember{
+			key:      key,
+			keyStart: keyStart,
+			value:    value,
+			comma:    -1,
+		}
+		if err := p.skipTrivia(); err != nil {
+			return jsonValue{}, err
+		}
+		if p.consume(',') {
+			member.comma = p.pos - 1
+			object.members = append(object.members, member)
+			if err := p.skipTrivia(); err != nil {
+				return jsonValue{}, err
+			}
+			if p.consume('}') {
+				object.close = p.pos - 1
+				object.end = p.pos
+				return object, nil
+			}
+			continue
+		}
+		object.members = append(object.members, member)
+		if !p.consume('}') {
+			return jsonValue{}, p.errorf("expected ',' or '}' after object member")
+		}
+		object.close = p.pos - 1
+		object.end = p.pos
+		return object, nil
+	}
+}
+
+func (p *jsoncParser) parseArray() (jsonValue, error) {
+	start := p.pos
+	p.pos++
+	array := jsonValue{
+		kind:  kindArray,
+		start: start,
+		open:  start,
+	}
+	if err := p.skipTrivia(); err != nil {
+		return jsonValue{}, err
+	}
+	if p.consume(']') {
+		array.close = p.pos - 1
+		array.end = p.pos
+		return array, nil
+	}
+
+	for {
+		item, err := p.parseValue()
+		if err != nil {
+			return jsonValue{}, err
+		}
+		array.items = append(array.items, item)
+		if err := p.skipTrivia(); err != nil {
+			return jsonValue{}, err
+		}
+		if p.consume(',') {
+			if err := p.skipTrivia(); err != nil {
+				return jsonValue{}, err
+			}
+			if p.consume(']') {
+				array.close = p.pos - 1
+				array.end = p.pos
+				return array, nil
+			}
+			continue
+		}
+		if !p.consume(']') {
+			return jsonValue{}, p.errorf("expected ',' or ']' after array element")
+		}
+		array.close = p.pos - 1
+		array.end = p.pos
+		return array, nil
+	}
+}
+
+func (p *jsoncParser) parseScalar() (jsonValue, error) {
+	start := p.pos
+	for p.pos < len(p.src) && !isValueDelimiter(p.src[p.pos]) {
+		p.pos++
+	}
+	if start == p.pos {
+		return jsonValue{}, p.errorf("expected a JSON value")
+	}
+	token := p.src[start:p.pos]
+	if !json.Valid(token) {
+		return jsonValue{}, fmt.Errorf("invalid JSONC at byte %d: invalid scalar", start)
+	}
+	return jsonValue{kind: kindScalar, start: start, end: p.pos}, nil
+}
+
+func (p *jsoncParser) parseString() (string, error) {
+	start := p.pos
+	p.pos++
+	escaped := false
+	for p.pos < len(p.src) {
+		b := p.src[p.pos]
+		p.pos++
+		if escaped {
+			escaped = false
+			continue
+		}
+		if b == '\\' {
+			escaped = true
+			continue
+		}
+		if b == '"' {
+			var value string
+			if err := json.Unmarshal(p.src[start:p.pos], &value); err != nil {
+				return "", fmt.Errorf("invalid JSONC at byte %d: invalid string", start)
+			}
+			return value, nil
+		}
+	}
+	return "", fmt.Errorf("invalid JSONC at byte %d: unterminated string", start)
+}
+
+func (p *jsoncParser) skipTrivia() error {
+	for p.pos < len(p.src) {
+		switch p.src[p.pos] {
+		case ' ', '\t', '\r', '\n':
+			p.pos++
+		case '/':
+			if p.pos+1 >= len(p.src) {
+				return p.errorf("unexpected '/'")
+			}
+			switch p.src[p.pos+1] {
+			case '/':
+				p.pos += 2
+				for p.pos < len(p.src) && p.src[p.pos] != '\n' {
+					p.pos++
+				}
+			case '*':
+				start := p.pos
+				p.pos += 2
+				end := bytes.Index(p.src[p.pos:], []byte("*/"))
+				if end < 0 {
+					return fmt.Errorf("invalid JSONC at byte %d: unterminated block comment", start)
+				}
+				p.pos += end + 2
+			default:
+				return p.errorf("unexpected '/'")
+			}
+		default:
+			return nil
+		}
+	}
+	return nil
+}
+
+func (p *jsoncParser) consume(want byte) bool {
+	if p.pos >= len(p.src) || p.src[p.pos] != want {
+		return false
+	}
+	p.pos++
+	return true
+}
+
+func (p *jsoncParser) errorf(format string, args ...any) error {
+	return fmt.Errorf("invalid JSONC at byte %d: %s", p.pos, fmt.Sprintf(format, args...))
+}
+
+func isValueDelimiter(b byte) bool {
+	switch b {
+	case ' ', '\t', '\r', '\n', ',', ']', '}', '/':
+		return true
+	default:
+		return false
+	}
+}
+
+func duplicateMember(object jsonValue, key string) (int, bool) {
+	index := -1
+	for i, member := range object.members {
+		if member.key != key {
+			continue
+		}
+		if index >= 0 {
+			return -1, true
+		}
+		index = i
+	}
+	return index, false
+}
+
+func validateUniqueObjectKeys(value jsonValue) error {
+	switch value.kind {
+	case kindObject:
+		seen := make(map[string]struct{}, len(value.members))
+		for _, member := range value.members {
+			if _, exists := seen[member.key]; exists {
+				return fmt.Errorf("provider JSON contains duplicate object key %q", member.key)
+			}
+			seen[member.key] = struct{}{}
+			if err := validateUniqueObjectKeys(member.value); err != nil {
+				return err
+			}
+		}
+	case kindArray:
+		for _, item := range value.items {
+			if err := validateUniqueObjectKeys(item); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/gateway/internal/pricing/cache.go
+++ b/gateway/internal/pricing/cache.go
@@ -340,6 +340,10 @@ func cachedModelsContainModelsDev(
 			record.Reasoning.Provenance.Source == modelsDevSource {
 			return true
 		}
+		if record.Modalities != nil &&
+			record.Modalities.Provenance.Source == modelsDevSource {
+			return true
+		}
 		for _, definition := range record.Profiles {
 			if definition.Provenance.Source == modelsDevSource {
 				return true
@@ -391,6 +395,9 @@ func markModelLoadedFrom(record ModelRecord, loadedFrom LoadedFrom) ModelRecord 
 	}
 	if record.Reasoning != nil {
 		record.Reasoning.Provenance.LoadedFrom = loadedFrom
+	}
+	if record.Modalities != nil {
+		record.Modalities.Provenance.LoadedFrom = loadedFrom
 	}
 	return record
 }

--- a/gateway/internal/pricing/catalog.go
+++ b/gateway/internal/pricing/catalog.go
@@ -133,6 +133,14 @@ type ReasoningCapability struct {
 	Provenance Provenance        `json:"provenance"`
 }
 
+// ModelModalities records provider-declared input and output modalities.
+// Harness projections select only the values their own schema can represent.
+type ModelModalities struct {
+	Input      []string   `json:"input"`
+	Output     []string   `json:"output"`
+	Provenance Provenance `json:"provenance"`
+}
+
 // ModelRecord is the provider-scoped normalized catalog identity.
 type ModelRecord struct {
 	Provider         string                                 `json:"provider"`
@@ -145,6 +153,7 @@ type ModelRecord struct {
 	Profiles         map[ExecutionProfile]ProfileDefinition `json:"profiles"`
 	Prices           map[ExecutionProfile]PriceProfile      `json:"prices"`
 	Reasoning        *ReasoningCapability                   `json:"reasoning,omitempty"`
+	Modalities       *ModelModalities                       `json:"modalities,omitempty"`
 	Provenance       Provenance                             `json:"provenance"`
 }
 
@@ -287,6 +296,41 @@ func validateModelRecord(record ModelRecord) error {
 	if record.Reasoning != nil {
 		if err := validateReasoningCapability(*record.Reasoning); err != nil {
 			return fmt.Errorf("reasoning capability: %w", err)
+		}
+	}
+	if record.Modalities != nil {
+		if err := validateModelModalities(*record.Modalities); err != nil {
+			return fmt.Errorf("model modalities: %w", err)
+		}
+	}
+	return nil
+}
+
+func validateModelModalities(modalities ModelModalities) error {
+	if err := validateProvenance(modalities.Provenance); err != nil {
+		return fmt.Errorf("provenance: %w", err)
+	}
+	if modalities.Provenance.Source != modelsDevSource {
+		return fmt.Errorf(
+			"source %q is not the modality authority",
+			modalities.Provenance.Source,
+		)
+	}
+	if modalities.Input == nil || modalities.Output == nil {
+		return fmt.Errorf("input and output are required")
+	}
+	for label, values := range map[string][]string{
+		"input": modalities.Input, "output": modalities.Output,
+	} {
+		seen := make(map[string]struct{}, len(values))
+		for index, value := range values {
+			if value == "" || strings.TrimSpace(value) != value {
+				return fmt.Errorf("%s modality %d is invalid", label, index)
+			}
+			if _, duplicate := seen[value]; duplicate {
+				return fmt.Errorf("%s modality %q is duplicated", label, value)
+			}
+			seen[value] = struct{}{}
 		}
 	}
 	return nil
@@ -729,6 +773,29 @@ func cloneModelRecord(record ModelRecord) ModelRecord {
 		capability := cloneReasoningCapability(*record.Reasoning)
 		out.Reasoning = &capability
 	}
+	if record.Modalities != nil {
+		modalities := cloneModelModalities(*record.Modalities)
+		out.Modalities = &modalities
+	}
+	return out
+}
+
+func cloneModelModalities(modalities ModelModalities) ModelModalities {
+	out := modalities
+	out.Provenance = cloneProvenance(modalities.Provenance)
+	out.Input = cloneStrings(modalities.Input)
+	out.Output = cloneStrings(modalities.Output)
+	return out
+}
+
+func cloneStrings(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	out := make([]string, len(values))
+	for index, value := range values {
+		out[index] = strings.Clone(value)
+	}
 	return out
 }
 
@@ -1001,6 +1068,10 @@ func mergeModelRecord(lower, higher ModelRecord) ModelRecord {
 		capability := cloneReasoningCapability(*higher.Reasoning)
 		out.Reasoning = &capability
 	}
+	if higher.Modalities != nil {
+		modalities := cloneModelModalities(*higher.Modalities)
+		out.Modalities = &modalities
+	}
 	if providerMetadataWins {
 		out.Provenance = higher.Provenance
 	}
@@ -1084,6 +1155,26 @@ func (s *Snapshot) ModelReasoning(
 		return ReasoningCapability{}, false
 	}
 	return cloneReasoningCapability(*record.Reasoning), true
+}
+
+// ModelInputModalities returns an owned copy of exact provider-scoped input
+// modalities. Callers must not infer capabilities from a model family.
+func (s *Snapshot) ModelInputModalities(
+	provider string,
+	canonicalID string,
+) ([]string, bool) {
+	if s == nil {
+		return nil, false
+	}
+	catalog, ok := s.providerCatalogs[provider]
+	if !ok {
+		return nil, false
+	}
+	record, ok := lookupModelRecord(catalog.models, canonicalID)
+	if !ok || record.Modalities == nil {
+		return nil, false
+	}
+	return cloneStrings(record.Modalities.Input), true
 }
 
 // DisplayName returns presentation metadata for one provider-scoped canonical

--- a/gateway/internal/pricing/modelsdev.go
+++ b/gateway/internal/pricing/modelsdev.go
@@ -34,6 +34,7 @@ type modelsDevModel struct {
 	Status           string          `json:"status"`
 	Reasoning        json.RawMessage `json:"reasoning"`
 	ReasoningOptions json.RawMessage `json:"reasoning_options"`
+	Modalities       json.RawMessage `json:"modalities"`
 	Cost             json.RawMessage `json:"cost"`
 	Limit            struct {
 		Context int64 `json:"context"`
@@ -115,6 +116,10 @@ func withoutCachedModelsDev(catalog providerCatalog) (providerCatalog, bool) {
 		if record.Reasoning != nil &&
 			record.Reasoning.Provenance.Source == modelsDevSource {
 			record.Reasoning = nil
+		}
+		if record.Modalities != nil &&
+			record.Modalities.Provenance.Source == modelsDevSource {
+			record.Modalities = nil
 		}
 		// Family currently has record-level rather than field-level provenance.
 		// models.dev is the only runtime-cache source that supplies it.
@@ -383,6 +388,14 @@ func parseModelsDevModel(
 		return ModelRecord{}, fmt.Errorf("reasoning: %w", err)
 	}
 	record.Reasoning = reasoning
+	modalities, err := parseModelsDevModalities(
+		source.Modalities,
+		provenance,
+	)
+	if err != nil {
+		return ModelRecord{}, fmt.Errorf("modalities: %w", err)
+	}
+	record.Modalities = modalities
 	if provider != ProviderBaseten {
 		if price, ratePresence, present, err := parseModelsDevCost(source.Cost); err != nil {
 			return ModelRecord{}, fmt.Errorf("standard cost: %w", err)
@@ -444,6 +457,35 @@ func parseModelsDevModel(
 		return ModelRecord{}, err
 	}
 	return record, nil
+}
+
+func parseModelsDevModalities(
+	raw json.RawMessage,
+	provenance Provenance,
+) (*ModelModalities, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return nil, fmt.Errorf("modalities is not an object")
+	}
+	var source struct {
+		Input  []string `json:"input"`
+		Output []string `json:"output"`
+	}
+	if err := json.Unmarshal(trimmed, &source); err != nil {
+		return nil, fmt.Errorf("modalities is not an object")
+	}
+	modalities := &ModelModalities{
+		Input:      source.Input,
+		Output:     source.Output,
+		Provenance: provenance,
+	}
+	if err := validateModelModalities(*modalities); err != nil {
+		return nil, err
+	}
+	return modalities, nil
 }
 
 func includeModelsDevModel(

--- a/gateway/internal/pricing/modelsdev_fetch.go
+++ b/gateway/internal/pricing/modelsdev_fetch.go
@@ -1,0 +1,90 @@
+package pricing
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	ModelsDevURL              = "https://models.dev/api.json"
+	ModelsDevFetchTimeout     = 10 * time.Second
+	ModelsDevMaxResponseBytes = 8 << 20
+)
+
+// ModelsDevFetchResult is one bounded public-catalog response. A not-modified
+// response carries no body and preserves the caller's prior ETag.
+type ModelsDevFetchResult struct {
+	Body        []byte
+	ETag        string
+	NotModified bool
+}
+
+// FetchModelsDev performs one credential-free models.dev request. Scheduling,
+// persistence, and publication remain the caller's responsibility.
+func FetchModelsDev(
+	ctx context.Context,
+	client *http.Client,
+	endpoint string,
+	etag string,
+	maxResponseBytes int64,
+) (ModelsDevFetchResult, error) {
+	if client == nil {
+		return ModelsDevFetchResult{}, fmt.Errorf("models.dev HTTP client is nil")
+	}
+	if strings.TrimSpace(endpoint) == "" {
+		return ModelsDevFetchResult{}, fmt.Errorf("models.dev endpoint is empty")
+	}
+	if maxResponseBytes <= 0 {
+		return ModelsDevFetchResult{}, fmt.Errorf("models.dev response limit must be positive")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return ModelsDevFetchResult{}, err
+	}
+	req.Header.Set("Accept", "application/json")
+	if etag != "" {
+		req.Header.Set("If-None-Match", etag)
+	}
+
+	clientCopy := *client
+	clientCopy.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	resp, err := clientCopy.Do(req)
+	if err != nil {
+		return ModelsDevFetchResult{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotModified {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64<<10))
+		return ModelsDevFetchResult{
+			ETag:        etag,
+			NotModified: true,
+		}, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64<<10))
+		return ModelsDevFetchResult{}, fmt.Errorf(
+			"models.dev returned %d",
+			resp.StatusCode,
+		)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
+	if err != nil {
+		return ModelsDevFetchResult{}, err
+	}
+	if int64(len(body)) > maxResponseBytes {
+		return ModelsDevFetchResult{}, fmt.Errorf(
+			"models.dev response exceeds %d bytes",
+			maxResponseBytes,
+		)
+	}
+	return ModelsDevFetchResult{
+		Body: body,
+		ETag: resp.Header.Get("ETag"),
+	}, nil
+}

--- a/gateway/internal/pricing/modelsdev_fetch_test.go
+++ b/gateway/internal/pricing/modelsdev_fetch_test.go
@@ -1,0 +1,109 @@
+package pricing
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestFetchModelsDevUsesCredentialFreeBoundedRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q", r.Method)
+		}
+		if r.Header.Get("Accept") != "application/json" {
+			t.Errorf("Accept = %q", r.Header.Get("Accept"))
+		}
+		if r.Header.Get("If-None-Match") != `"catalog-v1"` {
+			t.Errorf("If-None-Match = %q", r.Header.Get("If-None-Match"))
+		}
+		if r.Header.Get("Authorization") != "" {
+			t.Error("models.dev request included authorization")
+		}
+		w.Header().Set("ETag", `"catalog-v2"`)
+		_, _ = io.WriteString(w, `{"baseten":{"id":"baseten","models":{}}}`)
+	}))
+	defer server.Close()
+
+	result, err := FetchModelsDev(
+		context.Background(),
+		server.Client(),
+		server.URL,
+		`"catalog-v1"`,
+		1024,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.NotModified || result.ETag != `"catalog-v2"` ||
+		!strings.Contains(string(result.Body), `"baseten"`) {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestFetchModelsDevHandlesNotModified(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter,
+		_ *http.Request,
+	) {
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	defer server.Close()
+
+	result, err := FetchModelsDev(
+		context.Background(),
+		server.Client(),
+		server.URL,
+		`"catalog-v1"`,
+		1024,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.NotModified || result.ETag != `"catalog-v1"` ||
+		result.Body != nil {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestFetchModelsDevRejectsRedirectAndOversizedResponse(t *testing.T) {
+	large := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter,
+		_ *http.Request,
+	) {
+		_, _ = io.WriteString(w, "12345")
+	}))
+	defer large.Close()
+	redirect := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		http.Redirect(w, r, large.URL, http.StatusFound)
+	}))
+	defer redirect.Close()
+
+	if _, err := FetchModelsDev(
+		context.Background(),
+		redirect.Client(),
+		redirect.URL,
+		"",
+		1024,
+	); err == nil || !strings.Contains(err.Error(), "returned 302") {
+		t.Fatalf("redirect error = %v", err)
+	}
+	if _, err := FetchModelsDev(
+		context.Background(),
+		large.Client(),
+		large.URL,
+		"",
+		4,
+	); err == nil || !strings.Contains(err.Error(), "exceeds 4 bytes") {
+		t.Fatalf("oversize error = %v", err)
+	}
+}

--- a/gateway/internal/pricing/modelsdev_test.go
+++ b/gateway/internal/pricing/modelsdev_test.go
@@ -60,6 +60,10 @@ const modelsDevFixture = `{
         "family": "glm",
         "reasoning": true,
         "reasoning_options": [{"type": "toggle"}],
+        "modalities": {
+          "input": ["text", "image", "audio"],
+          "output": ["text"]
+        },
         "limit": {"context": 200000, "output": 100000},
         "cost": {"input": 0.3, "output": 0.75, "cache_read": 0.06}
       },
@@ -411,6 +415,46 @@ func TestModelsDevReasoningPreservesProviderScopedOptions(t *testing.T) {
 	}
 }
 
+func TestModelsDevModalitiesPreserveExactProviderScopedValues(t *testing.T) {
+	p := New()
+	if err := p.ReplaceModelsDev(
+		[]byte(modelsDevFixture),
+		time.Date(2026, time.July, 26, 12, 0, 0, 0, time.UTC),
+		`"modalities-etag"`,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	input, ok := p.Capture().ModelInputModalities(
+		ProviderBaseten,
+		"zai-org/GLM-Test",
+	)
+	if !ok || len(input) != 3 ||
+		input[0] != "text" || input[1] != "image" || input[2] != "audio" {
+		t.Fatalf("GLM input modalities = %#v, found=%t", input, ok)
+	}
+	input[0] = "changed"
+	again, ok := p.Capture().ModelInputModalities(
+		ProviderBaseten,
+		"zai-org/GLM-Test",
+	)
+	if !ok || again[0] != "text" {
+		t.Fatalf("caller mutated input modalities: %#v, found=%t", again, ok)
+	}
+	if _, ok := p.Capture().ModelInputModalities(
+		ProviderBaseten,
+		"plain/Model-Test",
+	); ok {
+		t.Fatal("model without modality metadata reported a capability")
+	}
+	if _, ok := p.Capture().ModelInputModalities(
+		ProviderBaseten,
+		"zai-org/GLM-Test-Variant",
+	); ok {
+		t.Fatal("inexact model id inherited modalities")
+	}
+}
+
 func TestReasoningEffortTokenValidationIsForwardCompatible(t *testing.T) {
 	for _, value := range []string{
 		"none",
@@ -729,6 +773,12 @@ func TestNormalizedCatalogReadResultsAreOwnedCopies(t *testing.T) {
 	)
 	*deepseek.Reasoning.Options[0].Values[0] = "changed"
 	*deepseek.Reasoning.Options[1].Max = 1
+	glm, _ := p.Capture().Model(
+		ProviderBaseten,
+		"zai-org/GLM-Test",
+	)
+	glm.Modalities.Input[0] = "changed"
+	glm.Modalities.Output[0] = "changed"
 
 	again, _ := p.Capture().Model(ProviderAnthropic, "claude-opus-5")
 	if again.Profiles[ProfileFast].RequestBody["speed"] != "fast" ||
@@ -748,6 +798,14 @@ func TestNormalizedCatalogReadResultsAreOwnedCopies(t *testing.T) {
 	if *deepseekAgain.Reasoning.Options[0].Values[0] != "low" ||
 		*deepseekAgain.Reasoning.Options[1].Max != 32_000 {
 		t.Fatal("reasoning result retained snapshot memory")
+	}
+	glmAgain, _ := p.Capture().Model(
+		ProviderBaseten,
+		"zai-org/GLM-Test",
+	)
+	if glmAgain.Modalities.Input[0] != "text" ||
+		glmAgain.Modalities.Output[0] != "text" {
+		t.Fatal("modality result retained snapshot memory")
 	}
 }
 
@@ -842,6 +900,13 @@ func TestProviderCacheSchema1RoundTripsReasoningAndRejectsOtherSchemas(
 		len(deepseek.Options) != 2 ||
 		deepseek.Options[0].Values[1] != nil {
 		t.Fatalf("restored reasoning = %+v, found=%t", deepseek, ok)
+	}
+	modalities, ok := restored.Capture().ModelInputModalities(
+		ProviderBaseten,
+		"zai-org/GLM-Test",
+	)
+	if !ok || len(modalities) != 3 || modalities[1] != "image" {
+		t.Fatalf("restored modalities = %#v, found=%t", modalities, ok)
 	}
 	metadata := restored.Capture().ProviderMetadata(ProviderBaseten)
 	if metadata.ModelsDevValidatedAt != capturedAt {

--- a/gateway/internal/safefile/identity_other.go
+++ b/gateway/internal/safefile/identity_other.go
@@ -1,0 +1,14 @@
+//go:build !darwin && !linux
+
+package safefile
+
+import (
+	"errors"
+	"os"
+)
+
+const platformSupportsIdentity = false
+
+func identityFromInfo(os.FileInfo) (Identity, error) {
+	return Identity{}, errors.New("file identity is unsupported")
+}

--- a/gateway/internal/safefile/identity_unix.go
+++ b/gateway/internal/safefile/identity_unix.go
@@ -1,0 +1,25 @@
+//go:build darwin || linux
+
+package safefile
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+const platformSupportsIdentity = true
+
+func identityFromInfo(info os.FileInfo) (Identity, error) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return Identity{}, fmt.Errorf("unsupported file identity type %T", info.Sys())
+	}
+	return Identity{
+		Device:          uint64(stat.Dev),
+		Inode:           uint64(stat.Ino),
+		Links:           uint64(stat.Nlink),
+		Size:            info.Size(),
+		ModTimeUnixNano: info.ModTime().UnixNano(),
+	}, nil
+}

--- a/gateway/internal/safefile/safefile.go
+++ b/gateway/internal/safefile/safefile.go
@@ -1,0 +1,406 @@
+// Package safefile replaces user-owned configuration files without severing
+// symbolic links or overwriting a file that changed after it was read.
+package safefile
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	// ErrConflict means the configured path or its target changed after Read.
+	ErrConflict = errors.New("safefile: preimage changed")
+	// ErrUnsafeTarget means the configured path cannot be replaced safely.
+	ErrUnsafeTarget = errors.New("safefile: unsafe target")
+	// ErrHardLinked means replacement would detach another hard link.
+	ErrHardLinked = errors.New("safefile: target has multiple hard links")
+)
+
+// CommitError reports an error discovered after the requested replacement was
+// made. Callers can use Applied to decide whether recovery state must be kept.
+type CommitError struct {
+	Err     error
+	Applied bool
+}
+
+func (e *CommitError) Error() string { return e.Err.Error() }
+func (e *CommitError) Unwrap() error { return e.Err }
+
+// CommitApplied reports whether err followed a successful filesystem commit.
+func CommitApplied(err error) bool {
+	var commitErr *CommitError
+	return errors.As(err, &commitErr) && commitErr.Applied
+}
+
+// Identity describes the file generation captured by a Snapshot.
+type Identity struct {
+	Device          uint64
+	Inode           uint64
+	Links           uint64
+	Size            int64
+	ModTimeUnixNano int64
+}
+
+// Snapshot binds file bytes to the configured path, resolved target, mode, and
+// identity observed by Read.
+type Snapshot struct {
+	RequestedPath string
+	ResolvedPath  string
+	Exists        bool
+	Linked        bool
+	Data          []byte
+	Mode          fs.FileMode
+	Identity      Identity
+
+	preimageData     []byte
+	preimageMode     fs.FileMode
+	preimageIdentity Identity
+	preimageExists   bool
+	preimageLinked   bool
+	preimageResolved string
+}
+
+// beforeCommitHook is a test seam for changes between staging and validation.
+var beforeCommitHook func()
+
+// Read resolves path and returns a stable snapshot of its regular-file target.
+// An ordinary missing path is a valid snapshot. Dangling or cyclic links,
+// non-regular targets, and multiply hard-linked files are rejected.
+func Read(path string) (*Snapshot, error) {
+	if !platformSupportsIdentity {
+		return nil, fmt.Errorf("%w: file identity checks are unsupported on this platform", ErrUnsafeTarget)
+	}
+	if strings.TrimSpace(path) == "" {
+		return nil, fmt.Errorf("%w: configured path is empty", ErrUnsafeTarget)
+	}
+
+	requested, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("%w: make %q absolute: %v", ErrUnsafeTarget, path, err)
+	}
+	requested = filepath.Clean(requested)
+
+	resolved, exists, linked, err := resolveConfiguredPath(requested)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return &Snapshot{
+			RequestedPath:    requested,
+			ResolvedPath:     resolved,
+			Linked:           linked,
+			preimageLinked:   linked,
+			preimageResolved: resolved,
+		}, nil
+	}
+
+	file, err := os.Open(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("open resolved target %s: %w", resolved, err)
+	}
+	defer file.Close()
+
+	before, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat resolved target %s: %w", resolved, err)
+	}
+	if !before.Mode().IsRegular() {
+		return nil, fmt.Errorf("%w: %s resolves to a non-regular file", ErrUnsafeTarget, requested)
+	}
+	beforeIdentity, err := identityFromInfo(before)
+	if err != nil {
+		return nil, fmt.Errorf("%w: inspect %s: %v", ErrUnsafeTarget, requested, err)
+	}
+	if beforeIdentity.Links > 1 {
+		return nil, fmt.Errorf("%w: %s resolves to %s with %d links", ErrHardLinked, requested, resolved, beforeIdentity.Links)
+	}
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("read resolved target %s: %w", resolved, err)
+	}
+	afterOpen, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("%w: restat opened target %s: %v", ErrConflict, requested, err)
+	}
+	afterOpenIdentity, err := identityFromInfo(afterOpen)
+	if err != nil {
+		return nil, fmt.Errorf("%w: reinspect %s: %v", ErrUnsafeTarget, requested, err)
+	}
+	if beforeIdentity != afterOpenIdentity || before.Mode().Perm() != afterOpen.Mode().Perm() {
+		return nil, fmt.Errorf("%w: %s changed while it was read", ErrConflict, requested)
+	}
+	afterPath, err := os.Stat(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("%w: target disappeared while reading %s: %v", ErrConflict, requested, err)
+	}
+	afterPathIdentity, err := identityFromInfo(afterPath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: reinspect path %s: %v", ErrUnsafeTarget, requested, err)
+	}
+	if afterOpenIdentity != afterPathIdentity || afterOpen.Mode().Perm() != afterPath.Mode().Perm() {
+		return nil, fmt.Errorf("%w: %s was replaced while it was read", ErrConflict, requested)
+	}
+
+	checkResolved, checkExists, checkLinked, err := resolveConfiguredPath(requested)
+	if err != nil {
+		return nil, err
+	}
+	if !checkExists || checkResolved != resolved || checkLinked != linked {
+		return nil, fmt.Errorf("%w: %s changed while it was resolved", ErrConflict, requested)
+	}
+
+	return &Snapshot{
+		RequestedPath:    requested,
+		ResolvedPath:     resolved,
+		Exists:           true,
+		Linked:           linked,
+		Data:             bytes.Clone(data),
+		Mode:             afterPath.Mode().Perm(),
+		Identity:         afterPathIdentity,
+		preimageData:     bytes.Clone(data),
+		preimageMode:     afterPath.Mode().Perm(),
+		preimageIdentity: afterPathIdentity,
+		preimageExists:   true,
+		preimageLinked:   linked,
+		preimageResolved: resolved,
+	}, nil
+}
+
+// Replace atomically installs data beside the resolved target. Existing files
+// retain their mode. Missing files use createMode.
+func (s *Snapshot) Replace(data []byte, createMode fs.FileMode) (*Snapshot, error) {
+	if s == nil {
+		return nil, fmt.Errorf("%w: nil snapshot", ErrUnsafeTarget)
+	}
+	if s.preimageExists && s.preimageIdentity.Links > 1 {
+		return nil, fmt.Errorf("%w: %s", ErrHardLinked, s.RequestedPath)
+	}
+
+	targetDir := filepath.Dir(s.preimageResolved)
+	if err := os.MkdirAll(targetDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create target directory %s: %w", targetDir, err)
+	}
+	mode := createMode.Perm()
+	if s.preimageExists {
+		mode = s.preimageMode.Perm()
+	}
+	if mode == 0 {
+		mode = 0o600
+	}
+
+	temp, err := os.CreateTemp(targetDir, "."+filepath.Base(s.preimageResolved)+".safefile-*")
+	if err != nil {
+		return nil, fmt.Errorf("create staged file beside %s: %w", s.preimageResolved, err)
+	}
+	tempPath := temp.Name()
+	removeTemp := true
+	defer func() {
+		_ = temp.Close()
+		if removeTemp {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	if err := temp.Chmod(mode); err != nil {
+		return nil, fmt.Errorf("set staged file mode: %w", err)
+	}
+	if _, err := temp.Write(data); err != nil {
+		return nil, fmt.Errorf("write staged file: %w", err)
+	}
+	if err := temp.Sync(); err != nil {
+		return nil, fmt.Errorf("sync staged file: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return nil, fmt.Errorf("close staged file: %w", err)
+	}
+
+	if beforeCommitHook != nil {
+		beforeCommitHook()
+	}
+	if err := s.verifyCurrent(); err != nil {
+		return nil, err
+	}
+
+	if s.preimageExists {
+		if err := os.Rename(tempPath, s.preimageResolved); err != nil {
+			return nil, fmt.Errorf("replace %s: %w", s.preimageResolved, err)
+		}
+		removeTemp = false
+	} else {
+		// Linking is an atomic, no-clobber creation because the staged file is
+		// on the same filesystem as the destination.
+		if err := os.Link(tempPath, s.preimageResolved); err != nil {
+			if errors.Is(err, fs.ErrExist) {
+				return nil, fmt.Errorf("%w: %s appeared before creation", ErrConflict, s.RequestedPath)
+			}
+			return nil, fmt.Errorf("create %s: %w", s.preimageResolved, err)
+		}
+		if err := os.Remove(tempPath); err != nil {
+			return nil, &CommitError{
+				Err:     fmt.Errorf("created %s but could not remove staged link: %w", s.preimageResolved, err),
+				Applied: true,
+			}
+		}
+		removeTemp = false
+	}
+
+	if err := syncDirectory(targetDir); err != nil {
+		return nil, &CommitError{
+			Err:     fmt.Errorf("replacement committed but directory sync failed for %s: %w", targetDir, err),
+			Applied: true,
+		}
+	}
+	committed, err := Read(s.RequestedPath)
+	if err != nil {
+		return nil, &CommitError{
+			Err:     fmt.Errorf("replacement committed but could not be verified: %w", err),
+			Applied: true,
+		}
+	}
+	if !committed.Exists || !bytes.Equal(committed.Data, data) {
+		return nil, &CommitError{
+			Err:     fmt.Errorf("%w: committed bytes at %s do not match", ErrConflict, s.RequestedPath),
+			Applied: true,
+		}
+	}
+	return committed, nil
+}
+
+// Remove deletes the resolved regular target after confirming that the
+// configured path still identifies this snapshot. A configured symbolic link
+// is left in place. Removing an already-missing snapshot is a verified no-op.
+func (s *Snapshot) Remove() error {
+	if s == nil {
+		return fmt.Errorf("%w: nil snapshot", ErrUnsafeTarget)
+	}
+	if s.preimageExists && s.preimageIdentity.Links > 1 {
+		return fmt.Errorf("%w: %s", ErrHardLinked, s.RequestedPath)
+	}
+
+	if beforeCommitHook != nil {
+		beforeCommitHook()
+	}
+	if err := s.verifyCurrent(); err != nil {
+		return err
+	}
+	if !s.preimageExists {
+		return nil
+	}
+
+	targetDir := filepath.Dir(s.preimageResolved)
+	if err := os.Remove(s.preimageResolved); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("%w: %s disappeared before removal", ErrConflict, s.RequestedPath)
+		}
+		return fmt.Errorf("remove resolved target %s: %w", s.preimageResolved, err)
+	}
+	if err := syncDirectory(targetDir); err != nil {
+		return &CommitError{
+			Err:     fmt.Errorf("removal committed but directory sync failed for %s: %w", targetDir, err),
+			Applied: true,
+		}
+	}
+	if _, err := os.Lstat(s.preimageResolved); err == nil {
+		return &CommitError{
+			Err:     fmt.Errorf("%w: removed target %s is still present", ErrConflict, s.preimageResolved),
+			Applied: true,
+		}
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return &CommitError{
+			Err:     fmt.Errorf("removal committed but target absence could not be verified: %w", err),
+			Applied: true,
+		}
+	}
+	return nil
+}
+
+func (s *Snapshot) verifyCurrent() error {
+	current, err := Read(s.RequestedPath)
+	if err != nil {
+		if errors.Is(err, ErrHardLinked) || errors.Is(err, ErrUnsafeTarget) {
+			return fmt.Errorf("%w: %s is no longer the snapshotted target: %w", ErrConflict, s.RequestedPath, err)
+		}
+		return err
+	}
+	if current.ResolvedPath != s.preimageResolved ||
+		current.Exists != s.preimageExists ||
+		current.Linked != s.preimageLinked {
+		return fmt.Errorf("%w: %s resolves differently", ErrConflict, s.RequestedPath)
+	}
+	if !s.preimageExists {
+		return nil
+	}
+	if current.Identity != s.preimageIdentity ||
+		current.Mode.Perm() != s.preimageMode.Perm() ||
+		!bytes.Equal(current.Data, s.preimageData) {
+		return fmt.Errorf("%w: %s no longer matches its snapshot", ErrConflict, s.RequestedPath)
+	}
+	return nil
+}
+
+func resolveConfiguredPath(requested string) (resolved string, exists, linked bool, err error) {
+	if _, lstatErr := os.Lstat(requested); lstatErr == nil {
+		target, evalErr := filepath.EvalSymlinks(requested)
+		if evalErr != nil {
+			return "", false, false, fmt.Errorf("%w: resolve %s: %v", ErrUnsafeTarget, requested, evalErr)
+		}
+		target, evalErr = filepath.Abs(target)
+		if evalErr != nil {
+			return "", false, false, fmt.Errorf("%w: make resolved target absolute: %v", ErrUnsafeTarget, evalErr)
+		}
+		return filepath.Clean(target), true, filepath.Clean(target) != requested, nil
+	} else if !errors.Is(lstatErr, fs.ErrNotExist) {
+		return "", false, false, fmt.Errorf("%w: inspect %s: %v", ErrUnsafeTarget, requested, lstatErr)
+	}
+
+	probe := requested
+	var missing []string
+	for {
+		if _, lstatErr := os.Lstat(probe); lstatErr == nil {
+			break
+		} else if !errors.Is(lstatErr, fs.ErrNotExist) {
+			return "", false, false, fmt.Errorf("%w: inspect ancestor %s: %v", ErrUnsafeTarget, probe, lstatErr)
+		}
+		parent := filepath.Dir(probe)
+		if parent == probe {
+			return "", false, false, fmt.Errorf("%w: no existing ancestor for %s", ErrUnsafeTarget, requested)
+		}
+		missing = append([]string{filepath.Base(probe)}, missing...)
+		probe = parent
+	}
+
+	ancestor, evalErr := filepath.EvalSymlinks(probe)
+	if evalErr != nil {
+		return "", false, false, fmt.Errorf("%w: resolve ancestor %s: %v", ErrUnsafeTarget, probe, evalErr)
+	}
+	ancestor, evalErr = filepath.Abs(ancestor)
+	if evalErr != nil {
+		return "", false, false, fmt.Errorf("%w: make resolved ancestor absolute: %v", ErrUnsafeTarget, evalErr)
+	}
+	info, statErr := os.Stat(ancestor)
+	if statErr != nil {
+		return "", false, false, fmt.Errorf("%w: inspect resolved ancestor %s: %v", ErrUnsafeTarget, ancestor, statErr)
+	}
+	if !info.IsDir() {
+		return "", false, false, fmt.Errorf("%w: ancestor %s is not a directory", ErrUnsafeTarget, ancestor)
+	}
+	target := filepath.Join(append([]string{ancestor}, missing...)...)
+	target = filepath.Clean(target)
+	return target, false, filepath.Clean(probe) != filepath.Clean(ancestor), nil
+}
+
+func syncDirectory(path string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	return dir.Sync()
+}

--- a/gateway/internal/safefile/safefile_test.go
+++ b/gateway/internal/safefile/safefile_test.go
@@ -1,0 +1,364 @@
+package safefile
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestReplaceCreatesMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "settings.json")
+	snapshot, err := Read(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Exists {
+		t.Fatal("missing path reported as existing")
+	}
+
+	committed, err := snapshot.Replace([]byte("created\n"), 0o640)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !committed.Exists || string(committed.Data) != "created\n" {
+		t.Fatalf("committed snapshot = %+v", committed)
+	}
+	if got := committed.Mode.Perm(); got != 0o640 {
+		t.Fatalf("created mode = %o, want 640", got)
+	}
+}
+
+func TestReplacePreservesExistingMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	writeFile(t, path, []byte("before\n"), 0o644)
+
+	snapshot, err := Read(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	committed, err := snapshot.Replace([]byte("after\n"), 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := committed.Mode.Perm(); got != 0o644 {
+		t.Fatalf("replacement mode = %o, want 644", got)
+	}
+}
+
+func TestReplacePreservesRelativeMultihopSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symbolic-link test requires link privileges")
+	}
+	root := t.TempDir()
+	target := filepath.Join(root, "store", "settings.json")
+	writeFile(t, target, []byte("before\n"), 0o600)
+	if err := os.Symlink(filepath.Join("store", "settings.json"), filepath.Join(root, "middle")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("middle", filepath.Join(root, "configured")); err != nil {
+		t.Fatal(err)
+	}
+
+	configured := filepath.Join(root, "configured")
+	snapshot, err := Read(configured)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolvedTarget, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !snapshot.Linked || snapshot.ResolvedPath != resolvedTarget {
+		t.Fatalf("snapshot path = %+v", snapshot)
+	}
+	if _, err := snapshot.Replace([]byte("after\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if info, err := os.Lstat(configured); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("configured symlink was replaced: info=%v err=%v", info, err)
+	}
+	if got, err := os.ReadFile(target); err != nil || string(got) != "after\n" {
+		t.Fatalf("target = %q, err=%v", got, err)
+	}
+}
+
+func TestReplaceCreatesThroughSymlinkedParent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symbolic-link test requires link privileges")
+	}
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	if err := os.Mkdir(realDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real", filepath.Join(root, "configured")); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, "configured", "nested", "settings.json")
+
+	snapshot, err := Read(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Exists || !snapshot.Linked {
+		t.Fatalf("snapshot = %+v", snapshot)
+	}
+	if _, err := snapshot.Replace([]byte("created\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(realDir, "nested", "settings.json"))
+	if err != nil || string(got) != "created\n" {
+		t.Fatalf("resolved target = %q, err=%v", got, err)
+	}
+}
+
+func TestReplaceRejectsSymlinkRetargetRaceAndCleansStage(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symbolic-link test requires link privileges")
+	}
+	root := t.TempDir()
+	first := filepath.Join(root, "first.json")
+	second := filepath.Join(root, "second.json")
+	writeFile(t, first, []byte("first\n"), 0o600)
+	writeFile(t, second, []byte("second\n"), 0o600)
+	configured := filepath.Join(root, "configured")
+	if err := os.Symlink("first.json", configured); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot, err := Read(configured)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeCommitHook = func() {
+		if err := os.Remove(configured); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink("second.json", configured); err != nil {
+			t.Fatal(err)
+		}
+	}
+	defer func() { beforeCommitHook = nil }()
+
+	if _, err := snapshot.Replace([]byte("replacement\n"), 0o600); !errors.Is(err, ErrConflict) {
+		t.Fatalf("Replace error = %v, want ErrConflict", err)
+	}
+	assertFile(t, first, "first\n")
+	assertFile(t, second, "second\n")
+	assertNoStages(t, root)
+}
+
+func TestReplaceRejectsPreimageRaceAndCleansStage(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "settings.json")
+	writeFile(t, path, []byte("before\n"), 0o600)
+	snapshot, err := Read(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeCommitHook = func() {
+		writeFile(t, path, []byte("concurrent\n"), 0o600)
+	}
+	defer func() { beforeCommitHook = nil }()
+
+	if _, err := snapshot.Replace([]byte("replacement\n"), 0o600); !errors.Is(err, ErrConflict) {
+		t.Fatalf("Replace error = %v, want ErrConflict", err)
+	}
+	assertFile(t, path, "concurrent\n")
+	assertNoStages(t, root)
+}
+
+func TestReadRejectsMultiplyHardLinkedFile(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "settings.json")
+	alias := filepath.Join(root, "alias.json")
+	writeFile(t, path, []byte("value\n"), 0o600)
+	if err := os.Link(path, alias); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Read(path); !errors.Is(err, ErrHardLinked) {
+		t.Fatalf("Read error = %v, want ErrHardLinked", err)
+	}
+}
+
+func TestReadRejectsDanglingAndCyclicLinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symbolic-link test requires link privileges")
+	}
+	t.Run("dangling", func(t *testing.T) {
+		root := t.TempDir()
+		path := filepath.Join(root, "configured")
+		if err := os.Symlink("missing.json", path); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := Read(path); !errors.Is(err, ErrUnsafeTarget) {
+			t.Fatalf("Read error = %v, want ErrUnsafeTarget", err)
+		}
+	})
+	t.Run("cyclic", func(t *testing.T) {
+		root := t.TempDir()
+		first := filepath.Join(root, "first")
+		second := filepath.Join(root, "second")
+		if err := os.Symlink("second", first); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink("first", second); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := Read(first); !errors.Is(err, ErrUnsafeTarget) {
+			t.Fatalf("Read error = %v, want ErrUnsafeTarget", err)
+		}
+	})
+}
+
+func TestReadRejectsNonRegularTarget(t *testing.T) {
+	if _, err := Read(t.TempDir()); !errors.Is(err, ErrUnsafeTarget) {
+		t.Fatalf("Read error = %v, want ErrUnsafeTarget", err)
+	}
+}
+
+func TestMissingTargetDoesNotClobberConcurrentCreation(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "settings.json")
+	snapshot, err := Read(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeCommitHook = func() {
+		writeFile(t, path, []byte("concurrent\n"), 0o600)
+	}
+	defer func() { beforeCommitHook = nil }()
+
+	if _, err := snapshot.Replace([]byte("replacement\n"), 0o600); !errors.Is(err, ErrConflict) {
+		t.Fatalf("Replace error = %v, want ErrConflict", err)
+	}
+	assertFile(t, path, "concurrent\n")
+	assertNoStages(t, root)
+}
+
+func TestRemoveCreatedRegularFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	missing, err := Read(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := missing.Replace([]byte("created\n"), 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := created.Remove(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(path); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("removed path still exists or returned wrong error: %v", err)
+	}
+}
+
+func TestRemoveThroughSymlinkPreservesConfiguredLink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symbolic-link test requires link privileges")
+	}
+	root := t.TempDir()
+	target := filepath.Join(root, "target.json")
+	configured := filepath.Join(root, "configured")
+	writeFile(t, target, []byte("value\n"), 0o600)
+	if err := os.Symlink("target.json", configured); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := Read(configured)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := snapshot.Remove(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(target); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("resolved target still exists or returned wrong error: %v", err)
+	}
+	info, err := os.Lstat(configured)
+	if err != nil {
+		t.Fatalf("configured symlink was removed: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("configured path mode = %v, want symbolic link", info.Mode())
+	}
+}
+
+func TestRemoveRefusesPreimageConflict(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	writeFile(t, path, []byte("before\n"), 0o600)
+	snapshot, err := Read(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, path, []byte("concurrent\n"), 0o600)
+
+	if err := snapshot.Remove(); !errors.Is(err, ErrConflict) {
+		t.Fatalf("Remove error = %v, want ErrConflict", err)
+	}
+	assertFile(t, path, "concurrent\n")
+}
+
+func TestRemoveRefusesHardLinkAddedAfterSnapshot(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "settings.json")
+	alias := filepath.Join(root, "alias.json")
+	writeFile(t, path, []byte("value\n"), 0o600)
+	snapshot, err := Read(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(path, alias); err != nil {
+		t.Fatal(err)
+	}
+
+	err = snapshot.Remove()
+	if !errors.Is(err, ErrConflict) || !errors.Is(err, ErrHardLinked) {
+		t.Fatalf("Remove error = %v, want ErrConflict and ErrHardLinked", err)
+	}
+	assertFile(t, path, "value\n")
+	assertFile(t, alias, "value\n")
+}
+
+func writeFile(t *testing.T, path string, data []byte, mode fs.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, mode); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertFile(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Fatalf("%s = %q, want %q", path, got, want)
+	}
+}
+
+func assertNoStages(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.Contains(entry.Name(), ".safefile-") {
+			t.Fatalf("staged file was not removed: %s", entry.Name())
+		}
+	}
+}

--- a/scripts/tests/test_port_contract.sh
+++ b/scripts/tests/test_port_contract.sh
@@ -28,6 +28,9 @@ public_shipping_files=(
     gateway/cmd/baseten-switch/codex_adapter.go
     gateway/cmd/baseten-switch/doctor.go
     gateway/cmd/baseten-switch/main.go
+    gateway/cmd/baseten-switch/pi_adapter.go
+    gateway/cmd/baseten-switch/pi_catalog.go
+    gateway/cmd/baseten-switch/pi_store.go
     gateway/cmd/gateway/gateway.go
     gateway/internal/config/gateway.example.yaml
     gateway/internal/config/inittemplate.go


### PR DESCRIPTION
## Summary

- add `baseten-switch pi install|status|uninstall` for a direct Baseten provider that does not start the gateway or install the Mac app
- populate account-visible models through the Baseten CLI, then enrich exact model IDs with reasoning and text/image capabilities from `models.dev`
- preserve unrelated Pi JSONC, symlinks, and file modes, with collision, drift, recovery, and uninstall safeguards
- share the bounded `models.dev` fetch and normalized modality metadata with the existing gateway catalog
- pin the catalog freshness test to its fixture time so the repository gate remains deterministic

## Testing

- `scripts/check.sh`
- focused race tests for Pi configuration, safe-file handling, and catalog parsing
- scratch install, status, `pi --list-models baseten`, reinstall, and uninstall with the live account-visible catalog

Addresses #14.
