### PR TITLE
doctor/uninstall: keep new success paths fail-closed

### DIFF
--- a/gateway/cmd/baseten-switch/doctor.go
+++ b/gateway/cmd/baseten-switch/doctor.go
@@ -1472,11 +1472,16 @@ func doctorE2EChecks(add addCheck, o doctorOpts, doorSpecs []door.Config, doorUp
 // the harness path end to end. The probe deliberately carries no
 // provider credential, so on a native-configured route (routing off, or
 // a model_routes native pin for the probe's model) the provider's own
-// 401/403 is the expected answer: it could only have come back through
-// a working door→router→provider relay. Only an HTTP response from the
-// far end qualifies — a transport error (status 0) still fails.
+// 401/403 is the expected answer when the door confirms that the router
+// served it. The explicit router stamp prevents the door's native
+// failover from making a broken router path look healthy. Only an HTTP
+// response from the far end qualifies; a transport error (status 0)
+// still fails.
 func doctorProbeNativeAuthOK(f *config.File, routerTarget, shape string, p *doctorProbeResult) bool {
 	if p.Status != http.StatusUnauthorized && p.Status != http.StatusForbidden {
+		return false
+	}
+	if p.DoorVia != "router" {
 		return false
 	}
 	cli, ok := doctorClientFor(f, routerTarget, shape)

--- a/gateway/cmd/baseten-switch/doctor_test.go
+++ b/gateway/cmd/baseten-switch/doctor_test.go
@@ -2099,6 +2099,43 @@ func TestDoctorProbePinnedNativeRouteAuthRejectionOK(t *testing.T) {
 	}
 }
 
+// TestDoctorProbeNativeRouteAuthRejectionDoorFallbackFails ensures a
+// provider rejection cannot prove the router path when the door's native
+// failover served the request instead.
+func TestDoctorProbeNativeRouteAuthRejectionDoorFallbackFails(t *testing.T) {
+	fx := newDoctorFixture(t, func(c *doctorFixtureCfg) {
+		c.routingOff = true
+		c.clientRoute = "anthropic"
+		c.doorProbe = "fallback"
+		c.probeStatus = http.StatusUnauthorized
+	})
+	rep := runDoctor(doctorOpts{probe: true, yes: true, timeoutSec: 5})
+	if c := findCheck(t, rep, "e2e", "probe:"+fx.doorPort); c.Status != docFail {
+		t.Fatalf("probe = %s (%s), want fail when native failover bypasses the router", c.Status, c.Finding)
+	}
+	if rep.ExitCode != 1 {
+		t.Errorf("exit = %d, want 1", rep.ExitCode)
+	}
+}
+
+// TestDoctorProbeNativeRouteAuthRejectionUnstampedFails ensures an
+// unstamped provider rejection cannot be attributed to the router path.
+func TestDoctorProbeNativeRouteAuthRejectionUnstampedFails(t *testing.T) {
+	fx := newDoctorFixture(t, func(c *doctorFixtureCfg) {
+		c.routingOff = true
+		c.clientRoute = "anthropic"
+		c.doorProbe = "none"
+		c.probeStatus = http.StatusForbidden
+	})
+	rep := runDoctor(doctorOpts{probe: true, yes: true, timeoutSec: 5})
+	if c := findCheck(t, rep, "e2e", "probe:"+fx.doorPort); c.Status != docFail {
+		t.Fatalf("probe = %s (%s), want fail without router provenance", c.Status, c.Finding)
+	}
+	if rep.ExitCode != 1 {
+		t.Errorf("exit = %d, want 1", rep.ExitCode)
+	}
+}
+
 // TestDoctorProbeBasetenRouteAuthRejectionFails guards the boundary of
 // the native allowance: on the baseten route a 401 means the Baseten
 // credential itself is broken, which must keep failing doctor.

--- a/gateway/cmd/baseten-switch/uninstall.go
+++ b/gateway/cmd/baseten-switch/uninstall.go
@@ -328,6 +328,12 @@ func uninstallManagedApp() error {
 	if out, err := runManagedAppCLI(appPath, menubarLoginItemCLIFlag); err != nil {
 		return manualAppRemovalError(appPath, fmt.Sprintf("the app's login-item unregister failed (%v %s)", err, out))
 	}
+	// The executable we just ran is part of the bundle being removed.
+	// Revalidate after it exits so a modified bundle is never deleted
+	// under the managed-app identity established before execution.
+	if err := verifyManagedAppBundle(appPath); err != nil {
+		return err
+	}
 	if err := os.RemoveAll(appPath); err != nil {
 		return fmt.Errorf("remove %s: %w", appPath, err)
 	}
@@ -339,25 +345,14 @@ func manualAppRemovalError(appPath, reason string) error {
 	return fmt.Errorf("manual action required: %s; open %s, turn off Start at Login, quit the app, then remove it by hand", reason, appPath)
 }
 
-// verifyManagedAppBundle proves the bundle at appPath is the Baseten
-// Switch app before the CLI drives its executable or removes it: the
-// identity fields must match the managed install (the same contract
-// validateMaterializedMenubarApp enforces at install time). Anything
-// else at the managed path is left for manual removal.
+// verifyManagedAppBundle proves the bundle at appPath satisfies the
+// same complete integrity contract used at install time before the CLI
+// drives its executable or removes it. Anything else at the managed
+// path is left for manual removal.
 func verifyManagedAppBundle(appPath string) error {
-	plistPath := filepath.Join(appPath, "Contents", "Info.plist")
-	fields := []struct {
-		key, want string
-	}{
-		{"CFBundleIdentifier", menubarBundleID},
-		{"CFBundleExecutable", menubarProcName},
-	}
-	for _, field := range fields {
-		out, err := runCmd("/usr/bin/plutil", "-extract", field.key, "raw", plistPath)
-		if err != nil || out != field.want {
-			return manualAppRemovalError(appPath,
-				fmt.Sprintf("%s does not present the managed identity (%s is %q)", appPath, field.key, out))
-		}
+	if err := validateMaterializedMenubarApp(appPath); err != nil {
+		return manualAppRemovalError(appPath,
+			fmt.Sprintf("%s does not pass managed app validation (%v)", appPath, err))
 	}
 	return nil
 }

--- a/gateway/cmd/baseten-switch/uninstall_test.go
+++ b/gateway/cmd/baseten-switch/uninstall_test.go
@@ -209,28 +209,46 @@ func TestUninstallLeavesAppWhenLoginItemCannotBeSafelyUnregistered(t *testing.T)
 	}
 }
 
-// stubManagedAppPlist points the runCmd seam at a plutil answer table
-// for the bundle's Info.plist keys (missing keys error, like plutil on
-// an absent entry); pgrep finds no running menubar process.
-func stubManagedAppPlist(t *testing.T, plist map[string]string) {
+// stubManagedAppCommands points the runCmd seam at a plutil answer
+// table, a code-signature result, and a pgrep result that finds no
+// running menubar process.
+func stubManagedAppCommands(t *testing.T, plist map[string]string, codesignErr error) {
 	t.Helper()
+	fields := map[string]string{
+		"CFBundleIdentifier":         menubarBundleID,
+		"CFBundleDisplayName":        "Baseten Switch",
+		"CFBundleExecutable":         menubarProcName,
+		"CFBundleShortVersionString": "0.2.0",
+	}
+	for key, value := range plist {
+		fields[key] = value
+	}
 	old := runCmd
 	runCmd = func(name string, args ...string) (string, error) {
 		switch {
 		case strings.HasSuffix(name, "plutil"):
 			// plutil -extract <key> raw <path>
 			if len(args) >= 4 {
-				if v, ok := plist[args[1]]; ok {
+				if v, ok := fields[args[1]]; ok {
 					return v, nil
 				}
 			}
 			return "", errors.New("plist key not found")
+		case strings.HasSuffix(name, "codesign"):
+			return "", codesignErr
 		case strings.HasSuffix(name, "pgrep"):
 			return "", errors.New("no processes matched")
 		}
 		return "", fmt.Errorf("unexpected command %s %v", name, args)
 	}
 	t.Cleanup(func() { runCmd = old })
+}
+
+// stubManagedAppPlist installs the valid command results shared by
+// the managed-app removal tests.
+func stubManagedAppPlist(t *testing.T, plist map[string]string) {
+	t.Helper()
+	stubManagedAppCommands(t, plist, nil)
 }
 
 func managedAppFixture(t *testing.T) string {
@@ -241,7 +259,13 @@ func managedAppFixture(t *testing.T) string {
 	menubarGOOS = "darwin"
 	t.Cleanup(func() { menubarGOOS = oldGOOS })
 	app := filepath.Join(home, "Applications", menubarAppName)
-	if err := os.MkdirAll(app, 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(app, "Contents", "MacOS"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, filepath.Join(app, "Contents", "Info.plist"), "plist\n")
+	executable := filepath.Join(app, "Contents", "MacOS", menubarProcName)
+	writeTestFile(t, executable, "executable\n")
+	if err := os.Chmod(executable, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	return app
@@ -329,6 +353,120 @@ func TestUninstallAppManualRemovalWhenUnregisterFails(t *testing.T) {
 	}
 	if _, statErr := os.Stat(app); statErr != nil {
 		t.Fatalf("app was removed despite the failed unregister: %v", statErr)
+	}
+}
+
+func TestUninstallAppRefusesInvalidBundleBeforeExecution(t *testing.T) {
+	tests := []struct {
+		name        string
+		codesignErr error
+		breakBundle func(*testing.T, string)
+	}{
+		{
+			name:        "invalid code signature",
+			codesignErr: errors.New("code object is not signed at all"),
+		},
+		{
+			name: "symlink executable",
+			breakBundle: func(t *testing.T, app string) {
+				t.Helper()
+				executable := filepath.Join(app, "Contents", "MacOS", menubarProcName)
+				if err := os.Remove(executable); err != nil {
+					t.Fatal(err)
+				}
+				target := filepath.Join(t.TempDir(), "replacement")
+				writeTestFile(t, target, "replacement\n")
+				if err := os.Symlink(target, executable); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := managedAppFixture(t)
+			if tt.breakBundle != nil {
+				tt.breakBundle(t, app)
+			}
+			stubManagedAppCommands(t, map[string]string{
+				"BasetenSwitchLoginItemCLI": "true",
+			}, tt.codesignErr)
+			driven := false
+			oldCLI := runManagedAppCLI
+			runManagedAppCLI = func(appPath string, args ...string) (string, error) {
+				driven = true
+				return "", nil
+			}
+			t.Cleanup(func() { runManagedAppCLI = oldCLI })
+
+			err := uninstallManagedApp()
+			if err == nil || !strings.Contains(err.Error(), "manual action required") ||
+				!strings.Contains(err.Error(), "managed app validation") {
+				t.Fatalf("app cleanup error = %v", err)
+			}
+			if driven {
+				t.Error("an invalid bundle must never be exec'd")
+			}
+			if _, statErr := os.Lstat(app); statErr != nil {
+				t.Fatalf("invalid bundle was removed: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestUninstallAppRevalidatesBundleBeforeRemoval(t *testing.T) {
+	app := managedAppFixture(t)
+	fields := map[string]string{
+		"CFBundleIdentifier":         menubarBundleID,
+		"CFBundleDisplayName":        "Baseten Switch",
+		"CFBundleExecutable":         menubarProcName,
+		"CFBundleShortVersionString": "0.2.0",
+		"BasetenSwitchLoginItemCLI":  "true",
+	}
+	codesignCalls := 0
+	oldRunCmd := runCmd
+	runCmd = func(name string, args ...string) (string, error) {
+		switch {
+		case strings.HasSuffix(name, "plutil"):
+			if len(args) >= 4 {
+				if value, ok := fields[args[1]]; ok {
+					return value, nil
+				}
+			}
+			return "", errors.New("plist key not found")
+		case strings.HasSuffix(name, "codesign"):
+			codesignCalls++
+			if codesignCalls == 2 {
+				return "", errors.New("bundle changed after execution")
+			}
+			return "", nil
+		case strings.HasSuffix(name, "pgrep"):
+			return "", errors.New("no processes matched")
+		}
+		return "", fmt.Errorf("unexpected command %s %v", name, args)
+	}
+	t.Cleanup(func() { runCmd = oldRunCmd })
+	driven := false
+	oldCLI := runManagedAppCLI
+	runManagedAppCLI = func(appPath string, args ...string) (string, error) {
+		driven = true
+		return "Start at Login enabled -> notRegistered", nil
+	}
+	t.Cleanup(func() { runManagedAppCLI = oldCLI })
+
+	err := uninstallManagedApp()
+	if err == nil || !strings.Contains(err.Error(), "manual action required") ||
+		!strings.Contains(err.Error(), "code signature is invalid") {
+		t.Fatalf("app cleanup error = %v", err)
+	}
+	if !driven {
+		t.Fatal("the login-item CLI was not driven")
+	}
+	if codesignCalls != 2 {
+		t.Fatalf("codesign validation calls = %d, want 2", codesignCalls)
+	}
+	if _, statErr := os.Lstat(app); statErr != nil {
+		t.Fatalf("bundle was removed after failing revalidation: %v", statErr)
 	}
 }
 

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/LoginItem.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/LoginItem.swift
@@ -181,14 +181,15 @@ enum LoginItem {
 /// Whether a post-unregister status counts as removed for the CLI
 /// uninstall path. Pure so the decision table is unit-testable; the
 /// SMAppService calls stay in LoginItemCLI.run (the LoginItem pattern).
-/// .notFound qualifies: macOS reports it when no live registration can
-/// be tied to this bundle (never registered, or a superseded signing
-/// identity), which is exactly the desired end state for uninstall.
+/// Only .notRegistered confirms the desired end state. Apple's public
+/// contract describes .notFound as an error in which the service could
+/// not be found, not as confirmation that unregister completed, so the
+/// destructive uninstall path must fail closed on that status.
 func loginItemUnregisterAccepted(_ status: SMAppService.Status) -> Bool {
     switch status {
-    case .notRegistered, .notFound:
+    case .notRegistered:
         return true
-    case .enabled, .requiresApproval:
+    case .enabled, .requiresApproval, .notFound:
         return false
     @unknown default:
         return false
@@ -209,17 +210,16 @@ enum LoginItemCLI {
         CommandLine.arguments.contains(flag)
     }
 
-    /// Unregisters and exits: 0 when no live registration remains
-    /// (never-registered and stale .notFound both qualify), 1 when a
-    /// live or pending registration survives. Never returns.
+    /// Unregisters and exits: 0 only when the post-call status confirms
+    /// .notRegistered, 1 when removal is not confirmed. Never returns.
     static func run() -> Never {
         let before = LoginItem.status
         do {
             try SMAppService.mainApp.unregister()
         } catch {
-            // unregister() throws when no entry can be tied to this
-            // bundle; that is the desired end state, so the status
-            // re-read below — not the throw — decides the outcome.
+            // The status re-read below decides the outcome. A thrown
+            // call followed by .notFound is not accepted because
+            // neither result confirms that unregistration completed.
             FileHandle.standardError.write(Data(
                 "[BasetenSwitch] unregister threw (deciding by status): \(error)\n".utf8))
         }

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/LoginItemTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/LoginItemTests.swift
@@ -109,15 +109,13 @@ final class LoginItemTests: XCTestCase {
 
     // MARK: - CLI uninstall acceptance
 
-    // The headless --unregister-login-item mode exits 0 exactly when no
-    // live registration can remain: never-registered and the stale
-    // .notFound both qualify (nothing points at the about-to-be-deleted
-    // bundle), while a live or pending registration fails the run so
-    // the CLI keeps the bundle and prints the manual path. An unknown
-    // future status fails closed.
+    // The headless --unregister-login-item mode exits 0 only when
+    // .notRegistered confirms removal. Apple's public contract defines
+    // .notFound as a lookup error, not successful unregistration, so it
+    // fails closed along with live, pending, and unknown future states.
     func testLoginItemUnregisterAccepted() throws {
         XCTAssertTrue(loginItemUnregisterAccepted(.notRegistered))
-        XCTAssertTrue(loginItemUnregisterAccepted(.notFound))
+        XCTAssertFalse(loginItemUnregisterAccepted(.notFound))
         XCTAssertFalse(loginItemUnregisterAccepted(.enabled))
         XCTAssertFalse(loginItemUnregisterAccepted(.requiresApproval))
         let future = try XCTUnwrap(SMAppService.Status(rawValue: 999))


### PR DESCRIPTION
## Summary

- Require `X-Baseten-Switch-Door: router` before a native-route 401 or 403 counts as a healthy probe.
- Treat `SMAppService.Status.notFound` as unconfirmed removal and keep the app bundle in place.
- Reuse the complete installed-app validation before executing the login-item helper and before deleting the bundle.
- Add regressions for fallback and unstamped auth responses, invalid signatures, symlinked executables, and post-helper bundle changes.

## Why

This keeps the new success paths in #13 fail-closed. Door fallback cannot prove router health, and uninstall does not execute or delete a bundle without positive integrity and registration evidence.

[Apple documents `.notFound`](https://developer.apple.com/documentation/servicemanagement/smappservice/status-swift.enum/notfound) as an error in which the framework could not find the service, not as confirmation that unregistration succeeded.

## Testing

- `go test ./cmd/baseten-switch -count=1`
- `swift test` (212 tests)
- `go build ./...`
- `go vet ./...`
- `git diff --check`
- Candidate source secret scan, no leaks found

`./scripts/check.sh --offline` reaches the target branch's pre-existing `TestModelCatalogReasoningProjectionUsesExactBasetenRecord` date failure. Current `main` contains the separate clock-pinning fix; this follow-up does not duplicate that unrelated change.
