### PR TITLE
uninstall: accept .notFound only when nothing was registered going in

### DIFF
--- a/mac/BasetenSwitch/Sources/BasetenSwitch/LoginItem.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/LoginItem.swift
@@ -178,18 +178,47 @@ enum LoginItem {
 
 // MARK: - Headless CLI one-shot mode
 
-/// Whether a post-unregister status counts as removed for the CLI
+/// Whether an unregister attempt counts as removed for the CLI
 /// uninstall path. Pure so the decision table is unit-testable; the
 /// SMAppService calls stay in LoginItemCLI.run (the LoginItem pattern).
-/// Only .notRegistered confirms the desired end state. Apple's public
-/// contract describes .notFound as an error in which the service could
-/// not be found, not as confirmation that unregister completed, so the
-/// destructive uninstall path must fail closed on that status.
-func loginItemUnregisterAccepted(_ status: SMAppService.Status) -> Bool {
-    switch status {
+///
+/// Only .notRegistered confirms unregistration completed. Apple's
+/// public contract describes .notFound as an error in which the service
+/// could not be found, not as confirmation, so a registration that was
+/// live or pending before the call and reads .notFound after it fails
+/// closed: something went wrong and deleting the bundle could strand a
+/// login item macOS still tries to launch.
+///
+/// .notFound is accepted only when the status before the call already
+/// ruled out a live registration, which is the separate never-resolvable
+/// case. Beta builds are ad-hoc signed (scripts/build-menubar.sh), so an
+/// upgrade gives the bundle a new code identity and macOS stops
+/// resolving any registration for it. No unregister() this bundle can
+/// make will ever move that status, so failing closed does not protect
+/// the user — it strands the app bundle on disk on top of a registration
+/// we already cannot reach, and `uninstall` can never succeed. Removing
+/// a bundle that had no live registration going in cannot take down a
+/// login item that was reachable in the first place.
+func loginItemUnregisterAccepted(before: SMAppService.Status, after: SMAppService.Status) -> Bool {
+    switch after {
     case .notRegistered:
         return true
-    case .enabled, .requiresApproval, .notFound:
+    case .notFound:
+        return loginItemRegistrationAbsent(before)
+    case .enabled, .requiresApproval:
+        return false
+    @unknown default:
+        return false
+    }
+}
+
+/// Whether a status rules out a live or pending login-item registration.
+/// An unknown future status does not, so it fails closed.
+func loginItemRegistrationAbsent(_ status: SMAppService.Status) -> Bool {
+    switch status {
+    case .notRegistered, .notFound:
+        return true
+    case .enabled, .requiresApproval:
         return false
     @unknown default:
         return false
@@ -210,23 +239,22 @@ enum LoginItemCLI {
         CommandLine.arguments.contains(flag)
     }
 
-    /// Unregisters and exits: 0 only when the post-call status confirms
-    /// .notRegistered, 1 when removal is not confirmed. Never returns.
+    /// Unregisters and exits: 0 when the status pair confirms no live
+    /// registration is left behind, 1 when removal is not confirmed.
+    /// Never returns.
     static func run() -> Never {
         let before = LoginItem.status
         do {
             try SMAppService.mainApp.unregister()
         } catch {
-            // The status re-read below decides the outcome. A thrown
-            // call followed by .notFound is not accepted because
-            // neither result confirms that unregistration completed.
+            // The status pair below decides the outcome, not the throw.
             FileHandle.standardError.write(Data(
                 "[BasetenSwitch] unregister threw (deciding by status): \(error)\n".utf8))
         }
         let after = LoginItem.status
-        guard loginItemUnregisterAccepted(after) else {
+        guard loginItemUnregisterAccepted(before: before, after: after) else {
             FileHandle.standardError.write(Data(
-                "[BasetenSwitch] Start at Login still \(loginItemStatusName(after)) after unregister\n".utf8))
+                "[BasetenSwitch] Start at Login \(loginItemStatusName(before)) -> \(loginItemStatusName(after)); removal not confirmed\n".utf8))
             exit(1)
         }
         FileHandle.standardOutput.write(Data(

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/LoginItemTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/LoginItemTests.swift
@@ -109,17 +109,43 @@ final class LoginItemTests: XCTestCase {
 
     // MARK: - CLI uninstall acceptance
 
-    // The headless --unregister-login-item mode exits 0 only when
-    // .notRegistered confirms removal. Apple's public contract defines
-    // .notFound as a lookup error, not successful unregistration, so it
-    // fails closed along with live, pending, and unknown future states.
+    // The headless --unregister-login-item mode exits 0 when
+    // .notRegistered confirms removal, whatever the prior status. Live,
+    // pending, and unknown future end states fail closed.
     func testLoginItemUnregisterAccepted() throws {
-        XCTAssertTrue(loginItemUnregisterAccepted(.notRegistered))
-        XCTAssertFalse(loginItemUnregisterAccepted(.notFound))
-        XCTAssertFalse(loginItemUnregisterAccepted(.enabled))
-        XCTAssertFalse(loginItemUnregisterAccepted(.requiresApproval))
+        XCTAssertTrue(loginItemUnregisterAccepted(before: .enabled, after: .notRegistered))
+        XCTAssertTrue(loginItemUnregisterAccepted(before: .notFound, after: .notRegistered))
+        XCTAssertFalse(loginItemUnregisterAccepted(before: .enabled, after: .enabled))
+        XCTAssertFalse(loginItemUnregisterAccepted(before: .enabled, after: .requiresApproval))
         let future = try XCTUnwrap(SMAppService.Status(rawValue: 999))
-        XCTAssertFalse(loginItemUnregisterAccepted(future))
+        XCTAssertFalse(loginItemUnregisterAccepted(before: .enabled, after: future))
+    }
+
+    // .notFound is a lookup error, not confirmation of unregistration,
+    // so a registration that was live or pending before the call and is
+    // .notFound after it fails closed. .notFound going in is the
+    // distinct never-resolvable case (an ad-hoc signed bundle whose code
+    // identity changed across an upgrade): no unregister() this bundle
+    // can make will move that status, so refusing would strand the app
+    // forever rather than protect a login item we could still reach.
+    func testLoginItemUnregisterNotFoundDependsOnPriorStatus() throws {
+        XCTAssertTrue(loginItemUnregisterAccepted(before: .notFound, after: .notFound))
+        XCTAssertTrue(loginItemUnregisterAccepted(before: .notRegistered, after: .notFound))
+        XCTAssertFalse(loginItemUnregisterAccepted(before: .enabled, after: .notFound))
+        XCTAssertFalse(loginItemUnregisterAccepted(before: .requiresApproval, after: .notFound))
+        let future = try XCTUnwrap(SMAppService.Status(rawValue: 999))
+        XCTAssertFalse(loginItemUnregisterAccepted(before: future, after: .notFound))
+    }
+
+    // The prior-status gate is the "no live registration going in" test
+    // on its own; an unknown future status fails closed.
+    func testLoginItemRegistrationAbsent() throws {
+        XCTAssertTrue(loginItemRegistrationAbsent(.notRegistered))
+        XCTAssertTrue(loginItemRegistrationAbsent(.notFound))
+        XCTAssertFalse(loginItemRegistrationAbsent(.enabled))
+        XCTAssertFalse(loginItemRegistrationAbsent(.requiresApproval))
+        let future = try XCTUnwrap(SMAppService.Status(rawValue: 999))
+        XCTAssertFalse(loginItemRegistrationAbsent(future))
     }
 
     // Log names stay stable so the reconciliation transition line is


### PR DESCRIPTION
Follow-up to #17, against the same branch (#13).

## Summary

Decide the CLI unregister outcome on the **status pair** (before, after) rather than the end state alone. `.notFound` after the call is accepted only when the status going in already ruled out a live or pending registration.

## Why

#17 is right that `SMAppService.Status.notFound` is [documented as an error](https://developer.apple.com/documentation/servicemanagement/smappservice/status-swift.enum/notfound) — the framework could not find the service — not as confirmation that unregistration completed. For a registration that was `.enabled` or `.requiresApproval` before the call, failing closed is correct: something went wrong, and deleting the bundle could strand a login item macOS still tries to launch.

But it also fails closed on the case that motivated accepting `.notFound` in the first place. Beta builds are ad-hoc signed (`scripts/build-menubar.sh`: `codesign --force --sign -`), so an upgrade gives the bundle a new code identity and macOS stops resolving any registration for it. That bundle reads `.notFound` **both before and after** `unregister()`, and no call it can make will ever move the status — so `baseten-switch uninstall` refuses permanently:

```
manual action required: the app's login-item unregister failed (exit status 1 ...);
open ~/Applications/Baseten Switch.app, turn off Start at Login, quit the app, then remove it by hand
```

Failing closed there does not protect anyone. The registration we are worried about is one we already cannot reach; refusing just leaves the app bundle on disk *as well*, and every subsequent `uninstall` hits the same wall.

## The rule

Accept iff we can prove no live registration is left behind:

| before | after | accepted | why |
|---|---|---|---|
| any | `.notRegistered` | yes | unregistration confirmed |
| `.notRegistered` / `.notFound` | `.notFound` | yes | nothing live going in; the call cannot have created one |
| `.enabled` / `.requiresApproval` | `.notFound` | **no** | a reachable registration became unreachable — fail closed |
| any | `.enabled` / `.requiresApproval` | no | a live or pending registration survives |
| any | unknown future | no | fail closed |

An unknown future status on the `before` side also fails closed, since it cannot rule out a live registration.

The stderr line on the failure path now prints both statuses (`notFound -> notFound; removal not confirmed`) instead of only the end state, so the Go side's `manual action required` message has the transition behind it.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./... -count=1` — green (no Go changes; run to confirm the branch is clean).
- Swift changes are covered by `testLoginItemUnregisterAccepted`, the new `testLoginItemUnregisterNotFoundDependsOnPriorStatus`, and `testLoginItemRegistrationAbsent`. No local Swift toolchain here, so `swift test` needs the `build-darwin` CI job or a local run.

## Not changed, but worth a look

`verifyManagedAppBundle` now runs the full `validateMaterializedMenubarApp` (including `codesign --verify --deep --strict`) **twice** — once before exec'ing the bundle's binary, once before `os.RemoveAll`.

The first call is clearly right: we are about to execute a binary out of a user-writable path.

The second is worth a second opinion. At that point we are only deleting, and a bundle whose signature no longer verifies is arguably *more* deserving of removal, not less. The TOCTOU it defends against is the bundle being swapped between exec and delete — which an identity + non-symlink + same-inode check catches directly, without making a benign signature change strand the app in "manual action required". Happy either way; flagging because it is the same fail-closed-vs-strand tradeoff as above.