### PR TITLE
flake: support home-manager consumption on Linux and macOS

### DIFF
--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -33,6 +33,11 @@ jobs:
       - name: Build and test
         run: nix build -L .#baseten-switch
 
+      # Builds the flake checks: the package plus the full gateway test
+      # suite (the package alone only tests cmd/baseten-switch).
+      - name: Flake checks
+        run: nix flake check -L
+
       - name: Version stamp
         run: ./result/bin/baseten-switch --version
 
@@ -49,6 +54,9 @@ jobs:
 
       - name: Build and test
         run: nix build -L .#baseten-switch
+
+      - name: Flake checks
+        run: nix flake check -L
 
       - name: Version stamp
         run: ./result/bin/baseten-switch --version

--- a/README.md
+++ b/README.md
@@ -256,8 +256,49 @@ See [TESTING.md](TESTING.md) for test layers and isolation requirements.
 
 ## Nix source build
 
-The Nix flake is an alternate source build for Linux and Apple Silicon macOS.
-It does not include the signed Mac app or install the Baseten CLI dependency:
+The Nix flake is an alternate source build of the `baseten-switch` CLI and
+gateway for Linux (x86_64 and aarch64) and Apple Silicon macOS. It does not
+include the signed Mac app or install the Baseten CLI dependency. Homebrew
+is the supported path for the complete macOS product.
+
+### Home Manager
+
+The preferred Nix install is declarative. Add the flake input:
+
+```nix
+inputs.baseten-switch.url = "github:basetenlabs/baseten-switch";
+```
+
+Then reference the package in your Home Manager configuration:
+
+```nix
+home.packages = [
+  inputs.baseten-switch.packages.${pkgs.system}.default
+];
+```
+
+Alternatively, apply the overlay to make `pkgs.baseten-switch` available:
+
+```nix
+nixpkgs.overlays = [ inputs.baseten-switch.overlays.default ];
+home.packages = [ pkgs.baseten-switch ];
+```
+
+The same input and overlay work in NixOS and nix-darwin configurations. The
+flake pins its own `nixpkgs`; adding
+`inputs.baseten-switch.inputs.nixpkgs.follows = "nixpkgs"` avoids a second
+nixpkgs download, but the followed nixpkgs must carry the Go toolchain
+required by `gateway/go.mod`.
+
+After a switch to a new version, restart the locally running components:
+
+```sh
+baseten-switch up
+```
+
+### nix profile
+
+The imperative install without Home Manager:
 
 ```sh
 nix profile install github:basetenlabs/baseten-switch#baseten-switch
@@ -270,7 +311,13 @@ nix profile upgrade --refresh baseten-switch
 baseten-switch up
 ```
 
-Homebrew is the supported path for the complete macOS product.
+### Development shells
+
+`nix develop` provides the Go toolchain for gateway development on every
+supported system. On Apple Silicon macOS, `nix develop .#menubar` provides
+an experimental nixpkgs Swift toolchain for building the menu bar app
+without Xcode; `scripts/build-menubar.sh` with the Xcode toolchain remains
+the supported app build.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -257,9 +257,11 @@ See [TESTING.md](TESTING.md) for test layers and isolation requirements.
 ## Nix source build
 
 The Nix flake is an alternate source build of the `baseten-switch` CLI and
-gateway for Linux (x86_64 and aarch64) and Apple Silicon macOS. It does not
-include the signed Mac app or install the Baseten CLI dependency. Homebrew
-is the supported path for the complete macOS product.
+gateway for Linux (x86_64 and aarch64) and Apple Silicon macOS. On Apple
+Silicon macOS the default package also builds and installs the menu bar
+app (a single-arch, ad-hoc-signed dev build — not the signed universal
+release bundle). The flake does not install the Baseten CLI dependency.
+Homebrew is the supported path for the complete macOS product.
 
 ### Home Manager
 
@@ -277,7 +279,12 @@ home.packages = [
 ];
 ```
 
-Alternatively, apply the overlay to make `pkgs.baseten-switch` available:
+On Apple Silicon macOS this installs the gateway CLI and the menu bar app
+together; Home Manager surfaces the app in `~/Applications/Home Manager
+Apps`. Use `packages.${pkgs.system}.baseten-switch` for the CLI alone.
+
+Alternatively, apply the overlay to make `pkgs.baseten-switch` (and, on
+Apple Silicon macOS, `pkgs.baseten-switch-menubar`) available:
 
 ```nix
 nixpkgs.overlays = [ inputs.baseten-switch.overlays.default ];
@@ -301,8 +308,12 @@ baseten-switch up
 The imperative install without Home Manager:
 
 ```sh
-nix profile install github:basetenlabs/baseten-switch#baseten-switch
+nix profile install github:basetenlabs/baseten-switch
 ```
+
+On Apple Silicon macOS this includes the menu bar app at
+`~/.nix-profile/Applications/Baseten Switch.app`; install
+`...baseten-switch#baseten-switch` instead for the CLI alone.
 
 Upgrade and restart the locally running components:
 
@@ -311,13 +322,29 @@ nix profile upgrade --refresh baseten-switch
 baseten-switch up
 ```
 
+### Menu bar app (Apple Silicon macOS)
+
+The menu bar app is part of the default darwin package and also builds on
+its own with the nixpkgs Swift toolchain — no Xcode required:
+
+```sh
+nix build .#menubar
+open "result/Applications/Baseten Switch.app"
+```
+
+The result is a single-arch dev build with an ad hoc signature (the same
+identity a local `scripts/build-menubar.sh` run produces). Universal,
+release-signed bundles remain the job of `scripts/build-menubar.sh` with
+the Xcode toolchain.
+
 ### Development shells
 
 `nix develop` provides the Go toolchain for gateway development on every
 supported system. On Apple Silicon macOS, `nix develop .#menubar` provides
-an experimental nixpkgs Swift toolchain for building the menu bar app
-without Xcode; `scripts/build-menubar.sh` with the Xcode toolchain remains
-the supported app build.
+the nixpkgs Swift toolchain for the menu bar app: `swift build` and
+`swift build --build-tests` work without Xcode. `swift test` does not —
+nixpkgs swiftpm cannot run XCTest on macOS — so running the suite stays
+with the Xcode toolchain via `scripts/check.sh`.
 
 ## License
 

--- a/flake.nix
+++ b/flake.nix
@@ -18,22 +18,86 @@
       # evaluation can't run git, so stamp the commit hash instead; an
       # unpinned/dirty tree falls back to "dev" like a plain `go build`.
       version = self.shortRev or self.dirtyShortRev or "dev";
-    in
-    {
-      packages = forAllSystems (pkgs: rec {
-        default = baseten-switch;
-        baseten-switch = pkgs.buildGoModule {
+      vendorHash = "sha256-wOrYrtvL+7qecoaFfH75KdxBOFeba0zG09LEIvLpO5o=";
+      ldflags = [
+        "-X github.com/basetenlabs/baseten-switch/gateway/internal/version.Version=${version}"
+      ];
+      mkBasetenSwitch =
+        pkgs:
+        pkgs.buildGoModule {
           pname = "baseten-switch";
-          inherit version;
+          inherit version vendorHash ldflags;
           # The Go module lives in gateway/, but its tests read the
           # repo-level config/gateway.example.yaml (byte-equality pin with
           # the embedded init template), so the whole repo is the source.
           src = self;
           modRoot = "gateway";
           subPackages = [ "cmd/baseten-switch" ];
-          vendorHash = "sha256-wOrYrtvL+7qecoaFfH75KdxBOFeba0zG09LEIvLpO5o=";
-          ldflags = [ "-X github.com/basetenlabs/baseten-switch/gateway/internal/version.Version=${version}" ];
+          meta = {
+            description = "Local gateway routing AI coding harnesses between native providers and Baseten";
+            homepage = "https://github.com/basetenlabs/baseten-switch";
+            license = nixpkgs.lib.licenses.mit;
+            # `nix run` and lib.getExe resolve the binary through this.
+            mainProgram = "baseten-switch";
+            platforms = systems;
+          };
+        };
+    in
+    {
+      packages = forAllSystems (pkgs: rec {
+        default = baseten-switch;
+        baseten-switch = mkBasetenSwitch pkgs;
+      });
+
+      # For consumers that layer packages into nixpkgs (home-manager,
+      # NixOS, nix-darwin) instead of referencing the packages output:
+      #   nixpkgs.overlays = [ baseten-switch.overlays.default ];
+      # The host nixpkgs must carry a Go new enough for gateway/go.mod.
+      overlays.default = final: _prev: {
+        baseten-switch = mkBasetenSwitch final;
+      };
+
+      checks = forAllSystems (pkgs: {
+        # The shipped package; its check phase runs the cmd/baseten-switch
+        # tests because subPackages scopes both build and test.
+        package = mkBasetenSwitch pkgs;
+        # The full gateway test suite: with no subPackages set,
+        # buildGoModule builds and tests every package in the module,
+        # sandboxed (no HOME, no network beyond loopback) — the same
+        # honesty gate CI relies on, extended to the whole tree.
+        gateway-tests = pkgs.buildGoModule {
+          pname = "baseten-switch-gateway-tests";
+          inherit version vendorHash ldflags;
+          src = self;
+          modRoot = "gateway";
         };
       });
+
+      devShells = forAllSystems (
+        pkgs:
+        {
+          # Gateway development: the Go toolchain for gateway/go.mod.
+          default = pkgs.mkShell {
+            packages = [
+              pkgs.go
+              pkgs.gopls
+            ];
+          };
+        }
+        // nixpkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
+          # Experimental: nixpkgs Swift toolchain (5.10+) for building the
+          # menubar app without Xcode. SwiftUI/Charts compilation against
+          # the nixpkgs Apple SDK is unproven; scripts/build-menubar.sh
+          # with the Xcode toolchain remains the supported app build.
+          menubar = pkgs.mkShell {
+            packages = [
+              pkgs.swift
+              pkgs.swiftpm
+            ];
+          };
+        }
+      );
+
+      formatter = forAllSystems (pkgs: pkgs.nixfmt);
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,118 @@
       ldflags = [
         "-X github.com/basetenlabs/baseten-switch/gateway/internal/version.Version=${version}"
       ];
+      # The SwiftUI menubar app, built with the nixpkgs Swift toolchain —
+      # no Xcode. Single-arch with a dev-build identity (version 0.0.0,
+      # ad hoc executable signature from the stdenv fixup, no sealed
+      # bundle resources); universal signed release artifacts remain the
+      # job of scripts/build-menubar.sh with Xcode.
+      menubarInfoPlist =
+        pkgs:
+        pkgs.writeText "Info.plist" ''
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+          	<key>CFBundleIdentifier</key>
+          	<string>co.baseten.switch</string>
+          	<key>CFBundleName</key>
+          	<string>Baseten Switch</string>
+          	<key>CFBundleDisplayName</key>
+          	<string>Baseten Switch</string>
+          	<key>CFBundleExecutable</key>
+          	<string>BasetenSwitch</string>
+          	<key>BasetenSwitchBuildChannel</key>
+          	<string>stable</string>
+          	<key>CFBundlePackageType</key>
+          	<string>APPL</string>
+          	<key>CFBundleInfoDictionaryVersion</key>
+          	<string>6.0</string>
+          	<key>CFBundleShortVersionString</key>
+          	<string>0.0.0</string>
+          	<key>CFBundleVersion</key>
+          	<string>0</string>
+          	<key>LSMinimumSystemVersion</key>
+          	<string>13.0</string>
+          	<key>CFBundleIconFile</key>
+          	<string>AppIcon</string>
+          	<key>LSUIElement</key>
+          	<true/>
+          	<key>NSHighResolutionCapable</key>
+          	<true/>
+          	<!-- The Reauthenticate button sends an Apple event to Terminal via
+          	     osascript; without this key macOS 13+ denies Automation consent
+          	     with no prompt (errAEEventNotPermitted, -1743) in the packaged
+          	     bundle, while a bare dev binary inherits the invoking terminal's
+          	     consent and masks the failure. -->
+          	<key>NSAppleEventsUsageDescription</key>
+          	<string>Baseten Switch opens Terminal to run 'baseten auth login' when the shared Baseten CLI credential needs reauthentication.</string>
+          </dict>
+          </plist>
+        '';
+      mkMenubar =
+        pkgs:
+        pkgs.stdenv.mkDerivation {
+          pname = "baseten-switch-menubar";
+          inherit version;
+          src = self;
+          sourceRoot = "source/mac/BasetenSwitch";
+          nativeBuildInputs = [
+            pkgs.swift
+            pkgs.swiftpm
+            pkgs.rcodesign
+          ];
+          # swiftpm's setup hook supplies the build phase (swift-build -c
+          # release) and swiftpmBinPath; assembly mirrors
+          # scripts/build-menubar.sh minus lipo. rcodesign stands in for
+          # `codesign --force --sign -` (Apple codesign doesn't exist in
+          # the nix sandbox) and must run after fixup: fixup's strip would
+          # invalidate the seal it creates.
+          installPhase = ''
+            runHook preInstall
+            app="$out/Applications/Baseten Switch.app"
+            mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources"
+            install -m 0755 "$(swiftpmBinPath)/BasetenSwitch" "$app/Contents/MacOS/BasetenSwitch"
+            cp Assets/AppIcon.icns "$app/Contents/Resources/AppIcon.icns"
+            cp Assets/baseten-logo-white.svg "$app/Contents/Resources/baseten-logo-white.svg"
+            cp Assets/openai-blossom.svg "$app/Contents/Resources/openai-blossom.svg"
+            cp ${menubarInfoPlist pkgs} "$app/Contents/Info.plist"
+            runHook postInstall
+          '';
+          postFixup = ''
+            rcodesign sign "$out/Applications/Baseten Switch.app"
+          '';
+          meta = {
+            description = "Baseten Switch menubar app (nix dev build; release ships via scripts/build-menubar.sh)";
+            homepage = "https://github.com/basetenlabs/baseten-switch";
+            license = nixpkgs.lib.licenses.mit;
+            platforms = [ "aarch64-darwin" ];
+          };
+        };
+      # The darwin default install: gateway CLI plus the menubar app in
+      # one output, so `home.packages`/`nix profile` consumers get both.
+      # home-manager surfaces the Applications/ entry in
+      # "~/Applications/Home Manager Apps"; the CLI-only install remains
+      # available as packages.baseten-switch.
+      mkDefaultDarwin =
+        pkgs:
+        pkgs.symlinkJoin {
+          # Named like the CLI package so the `nix profile upgrade
+          # baseten-switch` invocation in the README matches either
+          # install.
+          name = "baseten-switch-${version}";
+          paths = [
+            (mkBasetenSwitch pkgs)
+            (mkMenubar pkgs)
+          ];
+          meta = {
+            description = "Baseten Switch gateway and menubar app";
+            homepage = "https://github.com/basetenlabs/baseten-switch";
+            license = nixpkgs.lib.licenses.mit;
+            # `nix run` still resolves to the gateway CLI.
+            mainProgram = "baseten-switch";
+            platforms = [ "aarch64-darwin" ];
+          };
+        };
       mkBasetenSwitch =
         pkgs:
         pkgs.buildGoModule {
@@ -44,10 +156,16 @@
         };
     in
     {
-      packages = forAllSystems (pkgs: rec {
-        default = baseten-switch;
-        baseten-switch = mkBasetenSwitch pkgs;
-      });
+      packages = forAllSystems (
+        pkgs:
+        rec {
+          default = if pkgs.stdenv.isDarwin then mkDefaultDarwin pkgs else baseten-switch;
+          baseten-switch = mkBasetenSwitch pkgs;
+        }
+        // nixpkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
+          menubar = mkMenubar pkgs;
+        }
+      );
 
       # For consumers that layer packages into nixpkgs (home-manager,
       # NixOS, nix-darwin) instead of referencing the packages output:
@@ -55,23 +173,35 @@
       # The host nixpkgs must carry a Go new enough for gateway/go.mod.
       overlays.default = final: _prev: {
         baseten-switch = mkBasetenSwitch final;
+        # darwin-only (lazy, so harmless elsewhere): the menubar app for
+        # consumers that want it as a separate store path.
+        baseten-switch-menubar = mkMenubar final;
       };
 
-      checks = forAllSystems (pkgs: {
-        # The shipped package; its check phase runs the cmd/baseten-switch
-        # tests because subPackages scopes both build and test.
-        package = mkBasetenSwitch pkgs;
-        # The full gateway test suite: with no subPackages set,
-        # buildGoModule builds and tests every package in the module,
-        # sandboxed (no HOME, no network beyond loopback) — the same
-        # honesty gate CI relies on, extended to the whole tree.
-        gateway-tests = pkgs.buildGoModule {
-          pname = "baseten-switch-gateway-tests";
-          inherit version vendorHash ldflags;
-          src = self;
-          modRoot = "gateway";
-        };
-      });
+      checks = forAllSystems (
+        pkgs:
+        {
+          # The shipped package; its check phase runs the cmd/baseten-switch
+          # tests because subPackages scopes both build and test.
+          package = mkBasetenSwitch pkgs;
+          # The full gateway test suite: with no subPackages set,
+          # buildGoModule builds and tests every package in the module,
+          # sandboxed (no HOME, no network beyond loopback) — the same
+          # honesty gate CI relies on, extended to the whole tree.
+          gateway-tests = pkgs.buildGoModule {
+            pname = "baseten-switch-gateway-tests";
+            inherit version vendorHash ldflags;
+            src = self;
+            modRoot = "gateway";
+          };
+        }
+        // nixpkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
+          # Compile gate only: XCTest runs stay on the Xcode toolchain
+          # (scripts/check.sh) — nixpkgs swiftpm has test running patched
+          # out on darwin.
+          menubar = mkMenubar pkgs;
+        }
+      );
 
       devShells = forAllSystems (
         pkgs:
@@ -85,14 +215,21 @@
           };
         }
         // nixpkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
-          # Experimental: nixpkgs Swift toolchain (5.10+) for building the
-          # menubar app without Xcode. SwiftUI/Charts compilation against
-          # the nixpkgs Apple SDK is unproven; scripts/build-menubar.sh
-          # with the Xcode toolchain remains the supported app build.
+          # nixpkgs Swift toolchain (5.10) for building the menubar app
+          # without Xcode: `swift build` works (SwiftUI/Charts compile
+          # against the nixpkgs Apple SDK), and swift-corelibs-xctest lets
+          # `swift build --build-tests` type-check the test target. Running
+          # tests does not work here — nixpkgs swiftpm patches out darwin
+          # test running, and its swift-driver mangles SwiftPM's
+          # `-rpath @loader_path/...` into a response-file read at the test
+          # bundle link. `swift test` stays on the Xcode toolchain via
+          # scripts/check.sh; universal release bundles stay on
+          # scripts/build-menubar.sh.
           menubar = pkgs.mkShell {
             packages = [
               pkgs.swift
               pkgs.swiftpm
+              pkgs.swiftPackages.XCTest
             ];
           };
         }

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/DisplayTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/DisplayTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import XCTest
 @testable import BasetenSwitch
 

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/PopupDisplayTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/PopupDisplayTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import XCTest
 @testable import BasetenSwitch
 

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/ReasoningConfigurationTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/ReasoningConfigurationTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import ServiceManagement
 import XCTest

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/RuntimeCoordinationTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/RuntimeCoordinationTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import ServiceManagement
 import XCTest

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/TrafficTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/TrafficTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import XCTest
 @testable import BasetenSwitch


### PR DESCRIPTION
Now that the repo is public, make the flake directly consumable from
home-manager (and NixOS/nix-darwin) on x86_64-linux, aarch64-linux, and
aarch64-darwin, and prefer that path in the README.

## Flake

- `meta` on the package (MIT license, homepage, platforms,
  `mainProgram`), so `nix run github:basetenlabs/baseten-switch` and
  `lib.getExe` resolve without an `apps` output.
- `overlays.default` for consumers that layer packages into nixpkgs
  (on darwin it also carries `baseten-switch-menubar`).
- `checks`: the shipped package plus a `gateway-tests` derivation that
  runs the full gateway test suite in the sandbox (the package's
  `subPackages` scopes its own check phase to `cmd/baseten-switch`);
  on aarch64-darwin also the menubar app build.
- `devShells.default` (Go toolchain); on aarch64-darwin a `.#menubar`
  shell with the nixpkgs Swift 5.10 toolchain for menubar app
  development without Xcode.
- `formatter` (nixfmt); flake.nix is formatted with it.

## Menubar app on nix (aarch64-darwin)

The nixpkgs Swift toolchain builds the SwiftUI/Charts app — the
"experimental" question this PR originally left open is answered:

- `packages.menubar` builds the .app bundle without Xcode:
  `swift build -c release` via swiftpm's setup hook, bundle assembly
  mirroring `scripts/build-menubar.sh` (Info.plist including the
  Automation usage string, icon, SVG resources), and an ad hoc bundle
  seal via `rcodesign` in postFixup (Apple `codesign --verify --deep
  --strict` accepts the result). Single-arch dev identity; universal
  release-signed bundles remain `scripts/build-menubar.sh` with Xcode.
- On darwin, `packages.default` is now the gateway CLI plus the menubar
  app (symlinkJoin), so home-manager and `nix profile` installs get
  both; home-manager surfaces the app in "~/Applications/Home Manager
  Apps". `packages.baseten-switch` stays CLI-only, and
  `meta.mainProgram` keeps `nix run` resolving to the CLI.
- `swift test` under nix is not possible and is documented as such:
  nixpkgs swiftpm patches out darwin test running, the nix apple-sdk
  ships empty platform framework dirs, and nixpkgs swiftc
  (swift-driver) misparses SwiftPM's mandatory
  `-Xlinker -rpath -Xlinker @loader_path/../../../` as a response file
  at the test-bundle link. The `.#menubar` shell carries
  swift-corelibs-xctest so `swift build --build-tests` type-checks the
  test target; running XCTest stays on the Xcode toolchain via
  `scripts/check.sh`.
- Test files now `import AppKit` explicitly: Apple's XCTest re-exports
  AppKit, swift-corelibs-xctest does not, and the explicit import is
  correct under both toolchains.

## CI

`flake.yml` build jobs now also run `nix flake check -L`, so the full
test suite is built in the sandbox on ubuntu and macos rather than only
evaluated — and the macos job now builds the menubar app.

## README

The Nix section now leads with Home Manager (flake input +
`home.packages`, plus the overlay variant and a `nixpkgs.follows`
caveat about the Go toolchain), keeps the `nix profile` instructions,
documents the darwin default install (CLI + app) and the CLI-only
escape hatch, and documents the menubar package and dev shells.

## Testing

- `nix flake check -L` on aarch64-linux: all checks pass; the full
  24-package gateway suite is green in the sandbox.
- `nix flake check -L` on aarch64-darwin (Apple Silicon, no Xcode
  installed — CommandLineTools only): all checks pass, including the
  menubar app build.
- `nix build .#` on aarch64-darwin: combined output verified
  (`bin/baseten-switch` runs, `Applications/Baseten Switch.app` passes
  `codesign --verify --deep --strict` and launches).
- `nix flake check --all-systems --no-build`: clean evaluation for all
  three systems.
- `scripts/check.sh --offline`: ALL CHECKS PASSED (Linux leg; the
  macOS Xcode leg is covered by CI since this machine has no Xcode).
- Consumed end-to-end from a real home-manager flake (input +
  `home.packages`) on aarch64-linux, both against the published flake
  and via `--override-input` to this branch; `nix run .# -- --version`
  stamps correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
