### PR TITLE
Document and automate beta releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
 permissions: read-all
 
 concurrency:
-  group: release-${{ inputs.release_tag }}
+  group: release
   cancel-in-progress: false
 
 jobs:
@@ -82,10 +82,77 @@ jobs:
           git config gpg.format ssh
           git config gpg.ssh.allowedSignersFile "$allowed_signers"
           git verify-tag "$RELEASE_TAG"
+          git fetch --no-tags origin \
+            +refs/heads/main:refs/remotes/origin/main
           [[ "$(git rev-parse "HEAD^{commit}")" == "$(git rev-parse "${RELEASE_TAG}^{commit}")" ]] \
             || { printf 'checkout is not the selected tag commit\n' >&2; exit 1; }
+          [[ "$(git rev-parse "${RELEASE_TAG}^{commit}")" == "$(git rev-parse "origin/main^{commit}")" ]] \
+            || { printf 'release tag is not the current origin/main commit\n' >&2; exit 1; }
           [[ "$(git describe --tags --exact-match HEAD)" == "$RELEASE_TAG" ]] \
             || { printf 'HEAD is not exactly the selected tag\n' >&2; exit 1; }
+
+      - name: Require an unused version newer than every public release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+
+          published_releases="$RUNNER_TEMP/published-releases.json"
+          tap_formula="$RUNNER_TEMP/public-tap-baseten-switch.rb"
+          gh api --paginate --slurp \
+            'repos/basetenlabs/baseten-switch/releases?per_page=100' \
+            >"$published_releases"
+          curl --fail --silent --show-error --location \
+            https://raw.githubusercontent.com/basetenlabs/homebrew-baseten/main/Formula/baseten-switch.rb \
+            >"$tap_formula"
+
+          ruby -rjson -e '
+            parse = lambda do |tag|
+              match = /\Av([0-9]+)\.([0-9]+)\.([0-9]+)\z/.match(tag)
+              abort "release tag is not strict SemVer: #{tag}" unless match
+              components = match.captures
+              abort "release tag is not strict SemVer: #{tag}" if
+                components.any? { |component| component.length > 1 && component.start_with?("0") }
+              components.map { |component| Integer(component, 10) }
+            end
+            candidate_tag = ARGV.fetch(1)
+            candidate = parse.call(candidate_tag)
+            pages = JSON.parse(File.read(ARGV.fetch(0)))
+            releases = pages.flatten.reject { |release| release.fetch("draft") }
+            releases.each do |release|
+              published_tag = release.fetch("tag_name")
+              abort "release tag is already published: #{candidate_tag}" if published_tag == candidate_tag
+              published = parse.call(published_tag)
+              abort "release tag #{candidate_tag} is not newer than #{published_tag}" unless
+                (candidate <=> published) == 1
+            end
+          ' "$published_releases" "$RELEASE_TAG"
+
+          tap_tag="$(
+            ruby -e '
+              text = File.read(ARGV.fetch(0))
+              pattern = %r{^\s*url "https://github\.com/basetenlabs/baseten-switch/releases/download/(v([0-9]+\.[0-9]+\.[0-9]+))/baseten-switch_([0-9]+\.[0-9]+\.[0-9]+)_darwin_universal\.zip"$}
+              matches = text.scan(pattern)
+              abort "tap formula must contain exactly one canonical release URL" unless matches.length == 1
+              tag, tag_version, archive_version = matches.fetch(0)
+              abort "tap formula release URL has mismatched versions" unless tag_version == archive_version
+              puts tag
+            ' "$tap_formula"
+          )"
+          ruby -e '
+            parse = lambda do |tag|
+              match = /\Av([0-9]+)\.([0-9]+)\.([0-9]+)\z/.match(tag)
+              abort "version is not strict SemVer: #{tag}" unless match
+              components = match.captures
+              abort "version is not strict SemVer: #{tag}" if
+                components.any? { |component| component.length > 1 && component.start_with?("0") }
+              components.map { |component| Integer(component, 10) }
+            end
+            candidate_tag, tap_tag = ARGV
+            abort "release tag #{candidate_tag} is not newer than tap main #{tap_tag}" unless
+              (parse.call(candidate_tag) <=> parse.call(tap_tag)) == 1
+          ' "$RELEASE_TAG" "$tap_tag"
 
       - name: Run repository release gate
         run: scripts/check.sh --offline
@@ -135,6 +202,23 @@ jobs:
             printf 'formula=%s\n' "$formula"
           } >>"$GITHUB_OUTPUT"
 
+      - name: Validate the generated formula before publication
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          GENERATED_FORMULA: ${{ steps.formula.outputs.formula }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          ruby -c "$GENERATED_FORMULA" >/dev/null
+          derived_version="$(
+            brew ruby -e \
+              'require "formulary"; path = Pathname(ARGV.fetch(0)); puts Formulary.from_contents("baseten-switch", path, path.read).version' \
+              "$GENERATED_FORMULA"
+          )"
+          [[ "$derived_version" == "$version" ]] \
+            || { printf 'Homebrew derived version %s instead of %s\n' "$derived_version" "$version" >&2; exit 1; }
+          brew style "$GENERATED_FORMULA"
+
       - name: Attest the exact final ZIP
         uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
         with:
@@ -150,9 +234,19 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
+      - name: Generate a token scoped to release settings
+        id: release-settings-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.APP_RELEASE_SETTINGS_READER_CLIENT_ID }}
+          private-key: ${{ secrets.APP_RELEASE_SETTINGS_READER_PRIVATE_KEY }}
+          owner: basetenlabs
+          repositories: baseten-switch
+          permission-administration: read
+
       - name: Require immutable releases before publication
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.release-settings-token.outputs.token }}
         run: |
           set -euo pipefail
           immutable_releases_enabled="$(
@@ -170,11 +264,24 @@ jobs:
           RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            printf 'release already exists for %s; refusing to replace or add assets\n' \
-              "$RELEASE_TAG" >&2
-            exit 1
-          fi
+          releases="$RUNNER_TEMP/releases-before-publication.json"
+          gh api --paginate --slurp \
+            'repos/basetenlabs/baseten-switch/releases?per_page=100' \
+            >"$releases"
+          ruby -rjson -e '
+            tag = ARGV.fetch(1)
+            matches = JSON.parse(File.read(ARGV.fetch(0))).flatten.select do |release|
+              release.fetch("tag_name") == tag
+            end
+            abort "multiple releases already use #{tag}" if matches.length > 1
+            unless matches.empty?
+              release = matches.fetch(0)
+              if release.fetch("draft")
+                abort "unpublished draft exists for #{tag}; inspect and remove only that draft before retrying"
+              end
+              abort "published release already exists for #{tag}; refusing to replace or add assets"
+            end
+          ' "$releases" "$RELEASE_TAG"
           version="${RELEASE_TAG#v}"
           gh release create "$RELEASE_TAG" \
             "dist/baseten-switch_${version}_darwin_universal.zip" \
@@ -297,81 +404,69 @@ jobs:
             --repo basetenlabs/baseten-switch \
             --signer-workflow basetenlabs/baseten-switch/.github/workflows/release.yml
 
-      - name: Generate a token scoped to homebrew-baseten
-        id: tap-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ secrets.APP_HOMEBREW_UPDATER_CLIENT_ID }}
-          private-key: ${{ secrets.APP_HOMEBREW_UPDATER_PRIVATE_KEY }}
-          owner: basetenlabs
-          repositories: homebrew-baseten
-          permission-contents: write
-          permission-pull-requests: write
-
-      - name: Open or reuse the Homebrew formula pull request
+      - name: Prepare the exact tap commit without credentials
+        id: tap-prepare
         env:
-          GH_TOKEN: ${{ steps.tap-token.outputs.token }}
           RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
 
-          tap_repository="basetenlabs/homebrew-baseten"
+          [[ -z "${GH_TOKEN:-}" ]] \
+            || { printf 'tap preparation must not have a GitHub token\n' >&2; exit 1; }
           tap_branch="baseten-switch-${RELEASE_TAG}"
           formula_path="Formula/baseten-switch.rb"
           handoff="$RUNNER_TEMP/baseten-switch-homebrew"
           generated_formula="$handoff/homebrew-tap/$formula_path"
-          checksums="$handoff/checksums.txt"
           tap_checkout="$RUNNER_TEMP/homebrew-baseten"
-          version="${RELEASE_TAG#v}"
 
           [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] \
             || { printf 'release tag must match v<major>.<minor>.<patch>\n' >&2; exit 1; }
-          [[ -f "$generated_formula" && -f "$checksums" ]] \
-            || { printf 'Homebrew handoff artifact is incomplete\n' >&2; exit 1; }
+          [[ -f "$generated_formula" ]] \
+            || { printf 'Homebrew formula handoff is missing\n' >&2; exit 1; }
 
-          gh auth setup-git
-          gh repo clone "$tap_repository" "$tap_checkout" -- --branch main --single-branch
+          git clone --branch main --single-branch \
+            https://github.com/basetenlabs/homebrew-baseten.git \
+            "$tap_checkout"
           cd "$tap_checkout"
 
           if cmp -s "$generated_formula" "$formula_path"; then
+            {
+              printf 'operation=noop\n'
+              printf 'tap_branch=%s\n' "$tap_branch"
+              printf 'tap_checkout=%s\n' "$tap_checkout"
+              printf 'expected_commit=\n'
+              printf 'expected_remote=\n'
+            } >>"$GITHUB_OUTPUT"
             printf 'Homebrew tap main already contains Baseten Switch %s\n' "$RELEASE_TAG"
             exit 0
           fi
 
-          tap_main_version="$(
-            brew ruby -e \
-              'require "formulary"; path = Pathname(ARGV.fetch(0)); puts Formulary.from_contents("baseten-switch", path, path.read).version' \
-              "$formula_path"
-          )"
-          version_order="$(
+          tap_tag="$(
             ruby -e '
-              desired = ARGV.fetch(0).split(".").map { |value| Integer(value, 10) }
-              current = ARGV.fetch(1).split(".").map { |value| Integer(value, 10) }
-              puts desired <=> current
-            ' "$version" "$tap_main_version"
+              text = File.read(ARGV.fetch(0))
+              pattern = %r{^\s*url "https://github\.com/basetenlabs/baseten-switch/releases/download/(v([0-9]+\.[0-9]+\.[0-9]+))/baseten-switch_([0-9]+\.[0-9]+\.[0-9]+)_darwin_universal\.zip"$}
+              matches = text.scan(pattern)
+              abort "tap formula must contain exactly one canonical release URL" unless matches.length == 1
+              tag, tag_version, archive_version = matches.fetch(0)
+              abort "tap formula release URL has mismatched versions" unless tag_version == archive_version
+              puts tag
+            ' "$formula_path"
           )"
-          [[ "$version_order" == 1 ]] \
-            || { printf 'refusing tap downgrade or conflicting version: release %s, tap main %s\n' \
-              "$version" "$tap_main_version" >&2; exit 1; }
+          ruby -e '
+            parse = lambda do |tag|
+              match = /\Av([0-9]+)\.([0-9]+)\.([0-9]+)\z/.match(tag)
+              abort "version is not strict SemVer: #{tag}" unless match
+              components = match.captures
+              abort "version is not strict SemVer: #{tag}" if
+                components.any? { |component| component.length > 1 && component.start_with?("0") }
+              components.map { |component| Integer(component, 10) }
+            end
+            candidate_tag, tap_tag = ARGV
+            abort "refusing tap downgrade or conflicting version: release #{candidate_tag}, tap main #{tap_tag}" unless
+              (parse.call(candidate_tag) <=> parse.call(tap_tag)) == 1
+          ' "$RELEASE_TAG" "$tap_tag"
 
           remote_branch="$(git ls-remote --heads origin "refs/heads/$tap_branch")"
-          open_pr_count="$(
-            gh pr list \
-              --repo "$tap_repository" \
-              --state open \
-              --head "$tap_branch" \
-              --json number \
-              --jq 'length'
-          )"
-          all_pr_count="$(
-            gh pr list \
-              --repo "$tap_repository" \
-              --state all \
-              --head "$tap_branch" \
-              --json number \
-              --jq 'length'
-          )"
-
           if [[ -n "$remote_branch" ]]; then
             git fetch --no-tags origin \
               "refs/heads/$tap_branch:refs/remotes/origin/$tap_branch"
@@ -383,10 +478,8 @@ jobs:
             changed_paths="$(git diff --name-only "origin/main...origin/$tap_branch")"
             [[ "$changed_paths" == "$formula_path" ]] \
               || { printf 'existing tap branch %s changes files outside the generated formula\n' "$tap_branch" >&2; exit 1; }
-          elif [[ "$all_pr_count" != 0 ]]; then
-            printf 'tap branch %s is missing but a prior pull request uses that branch\n' \
-              "$tap_branch" >&2
-            exit 1
+            expected_commit="$(git rev-parse "origin/$tap_branch^{commit}")"
+            expected_remote="$expected_commit"
           else
             git switch --create "$tap_branch" origin/main
             install -m 0644 "$generated_formula" "$formula_path"
@@ -400,15 +493,92 @@ jobs:
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add -- "$formula_path"
             git commit -m "Update Baseten Switch to $RELEASE_TAG"
-            git push origin "HEAD:refs/heads/$tap_branch"
+            expected_commit="$(git rev-parse "HEAD^{commit}")"
+            expected_remote=""
           fi
+
+          {
+            printf 'operation=publish\n'
+            printf 'tap_branch=%s\n' "$tap_branch"
+            printf 'tap_checkout=%s\n' "$tap_checkout"
+            printf 'expected_commit=%s\n' "$expected_commit"
+            printf 'expected_remote=%s\n' "$expected_remote"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Generate a token scoped to homebrew-baseten
+        if: steps.tap-prepare.outputs.operation == 'publish'
+        id: tap-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.APP_HOMEBREW_UPDATER_CLIENT_ID }}
+          private-key: ${{ secrets.APP_HOMEBREW_UPDATER_PRIVATE_KEY }}
+          owner: basetenlabs
+          repositories: homebrew-baseten
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Push the prepared commit and open or reuse its pull request
+        if: steps.tap-prepare.outputs.operation == 'publish'
+        env:
+          GH_TOKEN: ${{ steps.tap-token.outputs.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          TAP_BRANCH: ${{ steps.tap-prepare.outputs.tap_branch }}
+          TAP_CHECKOUT: ${{ steps.tap-prepare.outputs.tap_checkout }}
+          EXPECTED_COMMIT: ${{ steps.tap-prepare.outputs.expected_commit }}
+          EXPECTED_REMOTE: ${{ steps.tap-prepare.outputs.expected_remote }}
+        run: |
+          set -euo pipefail
+
+          tap_repository="basetenlabs/homebrew-baseten"
+          cd "$TAP_CHECKOUT"
+          [[ -n "$EXPECTED_COMMIT" && "$(git rev-parse "$EXPECTED_COMMIT^{commit}")" == "$EXPECTED_COMMIT" ]] \
+            || { printf 'prepared tap commit is missing or changed\n' >&2; exit 1; }
+          [[ -z "$(git status --porcelain)" ]] \
+            || { printf 'prepared tap checkout changed after validation\n' >&2; exit 1; }
+
+          open_pr_count="$(
+            gh pr list \
+              --repo "$tap_repository" \
+              --state open \
+              --head "$TAP_BRANCH" \
+              --json number \
+              --jq 'length'
+          )"
+          all_pr_count="$(
+            gh pr list \
+              --repo "$tap_repository" \
+              --state all \
+              --head "$TAP_BRANCH" \
+              --json number \
+              --jq 'length'
+          )"
+          if [[ "$open_pr_count" == 0 && "$all_pr_count" != 0 ]]; then
+            printf 'conflicting closed pull request exists for tap branch %s\n' \
+              "$TAP_BRANCH" >&2
+            exit 1
+          fi
+          [[ "$open_pr_count" == 0 || "$open_pr_count" == 1 ]] \
+            || { printf 'multiple open pull requests use tap branch %s\n' "$TAP_BRANCH" >&2; exit 1; }
+
+          gh auth setup-git
+          remote_ref="$(git ls-remote --heads origin "refs/heads/$TAP_BRANCH")"
+          remote_commit="${remote_ref%%$'\t'*}"
+          [[ "$remote_commit" == "$EXPECTED_REMOTE" ]] \
+            || { printf 'tap branch changed after credentialless validation\n' >&2; exit 1; }
+          if [[ -z "$EXPECTED_REMOTE" ]]; then
+            git push origin "$EXPECTED_COMMIT:refs/heads/$TAP_BRANCH"
+          fi
+          remote_ref="$(git ls-remote --heads origin "refs/heads/$TAP_BRANCH")"
+          remote_commit="${remote_ref%%$'\t'*}"
+          [[ "$remote_commit" == "$EXPECTED_COMMIT" ]] \
+            || { printf 'published tap branch does not match the prepared commit\n' >&2; exit 1; }
 
           if [[ "$open_pr_count" == 1 ]]; then
             pr_url="$(
               gh pr list \
                 --repo "$tap_repository" \
                 --state open \
-                --head "$tap_branch" \
+                --head "$TAP_BRANCH" \
                 --base main \
                 --json url \
                 --jq '.[0].url // empty'
@@ -416,10 +586,6 @@ jobs:
             [[ -n "$pr_url" ]] \
               || { printf 'existing tap pull request does not target main\n' >&2; exit 1; }
             printf 'Reusing Homebrew tap pull request %s\n' "$pr_url"
-          elif [[ "$open_pr_count" != 0 || "$all_pr_count" != 0 ]]; then
-            printf 'conflicting pull request state exists for tap branch %s\n' \
-              "$tap_branch" >&2
-            exit 1
           else
             pr_body="$RUNNER_TEMP/homebrew-tap-pr.md"
             {
@@ -434,7 +600,7 @@ jobs:
               gh pr create \
                 --repo "$tap_repository" \
                 --base main \
-                --head "$tap_branch" \
+                --head "$TAP_BRANCH" \
                 --title "Update Baseten Switch to $RELEASE_TAG" \
                 --body-file "$pr_body"
             )"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
           GITLEAKS_MAX_ARCHIVE_DEPTH: "2"
         run: scripts/security/run-gitleaks.sh dist
 
-      - name: Render checksum-pinned Homebrew formula and patch
+      - name: Render checksum-pinned Homebrew formula
         id: formula
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
@@ -125,17 +125,14 @@ jobs:
 
           tap_stage="$GITHUB_WORKSPACE/dist/homebrew-tap"
           formula="$tap_stage/Formula/baseten-switch.rb"
-          patch="dist/baseten-switch_${version}_homebrew.patch"
           scripts/release/render-formula.sh \
             --tag "$RELEASE_TAG" \
             --sha256 "$artifact_sha256" \
             --approved-license-spdx "$APPROVED_LICENSE_SPDX" \
-            --output "$formula" \
-            --patch-output "$patch"
+            --output "$formula"
           {
             printf 'artifact=%s\n' "$artifact"
             printf 'formula=%s\n' "$formula"
-            printf 'patch=%s\n' "$patch"
           } >>"$GITHUB_OUTPUT"
 
       - name: Attest the exact final ZIP
@@ -143,15 +140,29 @@ jobs:
         with:
           subject-path: ${{ steps.formula.outputs.artifact }}
 
-      - name: Preserve formula and tap patch as workflow artifacts
+      - name: Preserve formula and checksums as workflow artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: baseten-switch-${{ inputs.release_tag }}-homebrew
           path: |
             ${{ steps.formula.outputs.formula }}
-            ${{ steps.formula.outputs.patch }}
+            dist/checksums.txt
           if-no-files-found: error
           retention-days: 30
+
+      - name: Require immutable releases before publication
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          immutable_releases_enabled="$(
+            gh api \
+              -H 'X-GitHub-Api-Version: 2026-03-10' \
+              repos/basetenlabs/baseten-switch/immutable-releases \
+              --jq '.enabled == true'
+          )"
+          [[ "$immutable_releases_enabled" == true ]] \
+            || { printf 'repository immutable releases must be enabled before publication\n' >&2; exit 1; }
 
       - name: Create public beta prerelease without replacing assets
         env:
@@ -179,3 +190,253 @@ jobs:
           rm -f \
             "$RUNNER_TEMP/release-tag-signing-key.pub" \
             "$RUNNER_TEMP/release-tag-allowed-signers"
+
+  homebrew:
+    name: Open protected Homebrew tap update
+    needs: prepare
+    runs-on: macos-15
+    environment: release
+    permissions:
+      actions: read
+      attestations: read
+      contents: read
+    steps:
+      - name: Download the generated formula handoff
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: baseten-switch-${{ inputs.release_tag }}-homebrew
+          path: ${{ runner.temp }}/baseten-switch-homebrew
+
+      - name: Verify the immutable release and exact formula handoff
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+
+          handoff="$RUNNER_TEMP/baseten-switch-homebrew"
+          formula_path="Formula/baseten-switch.rb"
+          generated_formula="$handoff/homebrew-tap/$formula_path"
+          checksums="$handoff/checksums.txt"
+          published_release="$RUNNER_TEMP/published-release"
+          release_json="$RUNNER_TEMP/published-release.json"
+          version="${RELEASE_TAG#v}"
+          artifact_name="baseten-switch_${version}_darwin_universal.zip"
+          expected_url="https://github.com/basetenlabs/baseten-switch/releases/download/${RELEASE_TAG}/${artifact_name}"
+
+          [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+            || { printf 'release tag must match v<major>.<minor>.<patch>\n' >&2; exit 1; }
+          gh api \
+            -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/basetenlabs/baseten-switch/releases/tags/$RELEASE_TAG" \
+            >"$release_json"
+          asset_digest="$(
+            ruby -rjson -e '
+              release = JSON.parse(File.read(ARGV.fetch(0)))
+              tag = ARGV.fetch(1)
+              archive = ARGV.fetch(2)
+              abort "published release tag does not match" unless release.fetch("tag_name") == tag
+              abort "published release is a draft" unless release.fetch("draft") == false
+              abort "published release is not a prerelease" unless release.fetch("prerelease") == true
+              abort "published release is not immutable" unless release.fetch("immutable") == true
+              assets = release.fetch("assets")
+              expected_names = [archive, "checksums.txt"]
+              abort "published release must contain exactly the ZIP and checksums" unless
+                assets.map { |asset| asset.fetch("name") }.sort == expected_names.sort
+              selected = assets.find { |asset| asset.fetch("name") == archive }
+              digest = selected.fetch("digest")
+              abort "published release ZIP has no SHA-256 digest" unless
+                digest.is_a?(String) && digest.match?(/\Asha256:[0-9a-f]{64}\z/)
+              puts digest
+            ' "$release_json" "$RELEASE_TAG" "$artifact_name"
+          )"
+          [[ -f "$generated_formula" && -f "$checksums" ]] \
+            || { printf 'Homebrew handoff artifact is incomplete\n' >&2; exit 1; }
+          install -d -m 0755 "$published_release"
+          gh release download "$RELEASE_TAG" \
+            --repo basetenlabs/baseten-switch \
+            --dir "$published_release" \
+            --pattern "$artifact_name" \
+            --pattern checksums.txt
+          cmp -s "$checksums" "$published_release/checksums.txt" \
+            || { printf 'published checksums do not match the formula handoff\n' >&2; exit 1; }
+          checksum_entries="$(
+            awk -v artifact="$artifact_name" '$2 == artifact { count++ } END { print count + 0 }' \
+              "$checksums"
+          )"
+          [[ "$checksum_entries" == 1 ]] \
+            || { printf 'release archive must have exactly one checksum entry\n' >&2; exit 1; }
+          expected_sha256="$(
+            awk -v artifact="$artifact_name" '$2 == artifact { print $1 }' "$checksums"
+          )"
+          [[ "$expected_sha256" =~ ^[[:xdigit:]]{64}$ ]] \
+            || { printf 'release checksum is missing or invalid\n' >&2; exit 1; }
+          published_sha256="$(shasum -a 256 "$published_release/$artifact_name" | awk '{print $1}')"
+          [[ "$published_sha256" == "$expected_sha256" ]] \
+            || { printf 'published release archive does not match checksums.txt\n' >&2; exit 1; }
+          [[ "$asset_digest" == "sha256:$expected_sha256" ]] \
+            || { printf 'published release asset digest does not match checksums.txt\n' >&2; exit 1; }
+          [[ "$(grep -Fxc "  url \"$expected_url\"" "$generated_formula")" == 1 ]] \
+            || { printf 'generated formula does not contain the exact release URL\n' >&2; exit 1; }
+          [[ "$(grep -Fxc "  sha256 \"$expected_sha256\"" "$generated_formula")" == 1 ]] \
+            || { printf 'generated formula does not contain the exact release checksum\n' >&2; exit 1; }
+          [[ "$(grep -Ec '^[[:space:]]*url ' "$generated_formula")" == 1 \
+            && "$(grep -Ec '^[[:space:]]*sha256 ' "$generated_formula")" == 1 ]] \
+            || { printf 'generated formula has an ambiguous URL or checksum\n' >&2; exit 1; }
+          ruby -c "$generated_formula" >/dev/null \
+            || { printf 'generated formula failed Ruby syntax validation\n' >&2; exit 1; }
+          derived_version="$(
+            brew ruby -e \
+              'require "formulary"; path = Pathname(ARGV.fetch(0)); puts Formulary.from_contents("baseten-switch", path, path.read).version' \
+              "$generated_formula"
+          )"
+          [[ "$derived_version" == "$version" ]] \
+            || { printf 'Homebrew derived version %s instead of %s\n' "$derived_version" "$version" >&2; exit 1; }
+          brew style "$generated_formula"
+          gh attestation verify "$published_release/$artifact_name" \
+            --repo basetenlabs/baseten-switch \
+            --signer-workflow basetenlabs/baseten-switch/.github/workflows/release.yml
+
+      - name: Generate a token scoped to homebrew-baseten
+        id: tap-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.APP_HOMEBREW_UPDATER_CLIENT_ID }}
+          private-key: ${{ secrets.APP_HOMEBREW_UPDATER_PRIVATE_KEY }}
+          owner: basetenlabs
+          repositories: homebrew-baseten
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Open or reuse the Homebrew formula pull request
+        env:
+          GH_TOKEN: ${{ steps.tap-token.outputs.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+
+          tap_repository="basetenlabs/homebrew-baseten"
+          tap_branch="baseten-switch-${RELEASE_TAG}"
+          formula_path="Formula/baseten-switch.rb"
+          handoff="$RUNNER_TEMP/baseten-switch-homebrew"
+          generated_formula="$handoff/homebrew-tap/$formula_path"
+          checksums="$handoff/checksums.txt"
+          tap_checkout="$RUNNER_TEMP/homebrew-baseten"
+          version="${RELEASE_TAG#v}"
+
+          [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+            || { printf 'release tag must match v<major>.<minor>.<patch>\n' >&2; exit 1; }
+          [[ -f "$generated_formula" && -f "$checksums" ]] \
+            || { printf 'Homebrew handoff artifact is incomplete\n' >&2; exit 1; }
+
+          gh auth setup-git
+          gh repo clone "$tap_repository" "$tap_checkout" -- --branch main --single-branch
+          cd "$tap_checkout"
+
+          if cmp -s "$generated_formula" "$formula_path"; then
+            printf 'Homebrew tap main already contains Baseten Switch %s\n' "$RELEASE_TAG"
+            exit 0
+          fi
+
+          tap_main_version="$(
+            brew ruby -e \
+              'require "formulary"; path = Pathname(ARGV.fetch(0)); puts Formulary.from_contents("baseten-switch", path, path.read).version' \
+              "$formula_path"
+          )"
+          version_order="$(
+            ruby -e '
+              desired = ARGV.fetch(0).split(".").map { |value| Integer(value, 10) }
+              current = ARGV.fetch(1).split(".").map { |value| Integer(value, 10) }
+              puts desired <=> current
+            ' "$version" "$tap_main_version"
+          )"
+          [[ "$version_order" == 1 ]] \
+            || { printf 'refusing tap downgrade or conflicting version: release %s, tap main %s\n' \
+              "$version" "$tap_main_version" >&2; exit 1; }
+
+          remote_branch="$(git ls-remote --heads origin "refs/heads/$tap_branch")"
+          open_pr_count="$(
+            gh pr list \
+              --repo "$tap_repository" \
+              --state open \
+              --head "$tap_branch" \
+              --json number \
+              --jq 'length'
+          )"
+          all_pr_count="$(
+            gh pr list \
+              --repo "$tap_repository" \
+              --state all \
+              --head "$tap_branch" \
+              --json number \
+              --jq 'length'
+          )"
+
+          if [[ -n "$remote_branch" ]]; then
+            git fetch --no-tags origin \
+              "refs/heads/$tap_branch:refs/remotes/origin/$tap_branch"
+            existing_formula="$RUNNER_TEMP/existing-baseten-switch.rb"
+            git show "origin/$tap_branch:$formula_path" >"$existing_formula" \
+              || { printf 'existing tap branch does not contain %s\n' "$formula_path" >&2; exit 1; }
+            cmp -s "$generated_formula" "$existing_formula" \
+              || { printf 'existing tap branch %s contains a conflicting formula\n' "$tap_branch" >&2; exit 1; }
+            changed_paths="$(git diff --name-only "origin/main...origin/$tap_branch")"
+            [[ "$changed_paths" == "$formula_path" ]] \
+              || { printf 'existing tap branch %s changes files outside the generated formula\n' "$tap_branch" >&2; exit 1; }
+          elif [[ "$all_pr_count" != 0 ]]; then
+            printf 'tap branch %s is missing but a prior pull request uses that branch\n' \
+              "$tap_branch" >&2
+            exit 1
+          else
+            git switch --create "$tap_branch" origin/main
+            install -m 0644 "$generated_formula" "$formula_path"
+            cmp -s "$generated_formula" "$formula_path" \
+              || { printf 'copied tap formula does not match the generated formula\n' >&2; exit 1; }
+            changed_paths="$(git diff --name-only)"
+            [[ "$changed_paths" == "$formula_path" ]] \
+              || { printf 'tap checkout contains changes outside the generated formula\n' >&2; exit 1; }
+            git diff --check
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add -- "$formula_path"
+            git commit -m "Update Baseten Switch to $RELEASE_TAG"
+            git push origin "HEAD:refs/heads/$tap_branch"
+          fi
+
+          if [[ "$open_pr_count" == 1 ]]; then
+            pr_url="$(
+              gh pr list \
+                --repo "$tap_repository" \
+                --state open \
+                --head "$tap_branch" \
+                --base main \
+                --json url \
+                --jq '.[0].url // empty'
+            )"
+            [[ -n "$pr_url" ]] \
+              || { printf 'existing tap pull request does not target main\n' >&2; exit 1; }
+            printf 'Reusing Homebrew tap pull request %s\n' "$pr_url"
+          elif [[ "$open_pr_count" != 0 || "$all_pr_count" != 0 ]]; then
+            printf 'conflicting pull request state exists for tap branch %s\n' \
+              "$tap_branch" >&2
+            exit 1
+          else
+            pr_body="$RUNNER_TEMP/homebrew-tap-pr.md"
+            {
+              printf '## Summary\n\n'
+              printf -- "- Update \`baseten-switch\` to \`%s\`.\n" "$RELEASE_TAG"
+              printf -- '- Pin the formula to the immutable release archive and checksum.\n\n'
+              printf '## Verification\n\n'
+              printf -- '- Generated formula matches the release URL and checksum.\n'
+              printf -- '- Ruby syntax, Homebrew version derivation, and Homebrew style passed.\n'
+            } >"$pr_body"
+            pr_url="$(
+              gh pr create \
+                --repo "$tap_repository" \
+                --base main \
+                --head "$tap_branch" \
+                --title "Update Baseten Switch to $RELEASE_TAG" \
+                --body-file "$pr_body"
+            )"
+            printf 'Opened Homebrew tap pull request %s\n' "$pr_url"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to Baseten Switch appear in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Baseten Switch remains in beta, so interfaces and behavior may change between
+releases.
+
+## [Unreleased]
+
+### Added
+
+- Add direct Pi provider installation, status, and removal commands that do
+  not start the local gateway.
+- Add release automation that opens a formula update pull request in the
+  public Homebrew tap after each beta release.
+
+### Fixed
+
+- Update the Claude Code integration to enable deferred tool loading, omit the
+  attribution block, and preserve unrelated settings.
+
+## [0.1.0] - 2026-07-28
+
+### Added
+
+- Publish the first public beta of the local gateway, CLI, and macOS menu bar
+  app.
+- Support Homebrew installation on Apple Silicon and Intel Macs with a
+  universal, ad hoc signed release artifact.
+- Add managed routing for Claude Code and an opt-in profile for Codex CLI.
+
+[Unreleased]: https://github.com/basetenlabs/baseten-switch/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/basetenlabs/baseten-switch/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,8 @@ full gate includes a live identity refresh against the maintainer's existing
 Baseten CLI credential store. It must not be run with credentials supplied by
 an untrusted pull request.
 
+See [RELEASING.md](RELEASING.md) for the beta release process.
+
 ## Pull requests
 
 Keep changes focused and include tests for user-visible behavior. Describe any

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,219 @@
+# Releasing Baseten Switch
+
+Baseten Switch releases are public beta prereleases. The release workflow
+builds immutable macOS assets, creates the GitHub prerelease, and opens a pull
+request that updates the public Homebrew formula. A human must review and
+merge the Homebrew pull request.
+
+## Protected release configuration
+
+The GitHub `release` environment must require maintainer approval and provide
+these variables:
+
+- `RELEASE_TAG_SIGNING_PUBLIC_KEY`
+- `RELEASE_TAG_SIGNING_PRINCIPAL`
+- `RELEASE_TAG_SIGNING_FINGERPRINT`
+
+It must also provide these GitHub App secrets:
+
+- `APP_HOMEBREW_UPDATER_CLIENT_ID`
+- `APP_HOMEBREW_UPDATER_PRIVATE_KEY`
+
+The GitHub App token is scoped to `basetenlabs/homebrew-baseten`. The app needs
+permission to write repository contents and pull requests in that repository.
+Do not give it access to other repositories.
+
+Enable [immutable releases][github-immutable-releases] in the
+`basetenlabs/baseten-switch` repository settings before dispatching the
+workflow. This setting prevents changes to a release's tag and assets after
+publication.
+
+## Prepare the release
+
+1. Choose an unused tag that matches `v<major>.<minor>.<patch>`. Keep the
+   `v` prefix and do not add a prerelease suffix. The workflow marks the
+   GitHub release as a beta prerelease.
+2. Choose a numeric macOS build number. Each component must contain digits,
+   separated by periods. Increase it from every previous public build. The
+   workflow rejects other formats.
+3. Move the entries for this release from `Unreleased` in `CHANGELOG.md` to a
+   dated version section. Add a new empty `Unreleased` section and update the
+   comparison links.
+4. Merge the changelog and all release content into `main`. Tag the exact
+   `origin/main` commit, not a release branch.
+5. From a clean checkout of that commit, run the full release gate:
+
+   ```sh
+   scripts/check.sh
+   ```
+
+   The full gate uses the maintainer's existing Baseten CLI credential store.
+   Never supply credentials from an untrusted pull request.
+
+## Sign and push the tag
+
+Configure Git to use the approved SSH signing key. Confirm the configuration
+before creating the tag:
+
+```sh
+git config --get gpg.format
+git config --get user.signingkey
+git fetch origin main --tags
+test -z "$(git status --porcelain)"
+test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
+```
+
+The first command must print `ssh`. Create an annotated, SSH-signed tag whose
+message is suitable for the GitHub release notes. The command opens an editor;
+use the title `Baseten Switch vX.Y.Z beta`, followed by a concise summary from
+`CHANGELOG.md`.
+
+```sh
+release_tag=vX.Y.Z
+git tag -s "$release_tag"
+git verify-tag "$release_tag"
+git push origin "refs/tags/$release_tag"
+```
+
+Confirm that the pushed tag resolves to the reviewed `main` commit. Never move
+or replace a pushed release tag.
+
+## Publish the GitHub prerelease
+
+Manually dispatch `.github/workflows/release.yml` from `main`. Supply the
+signed tag, the macOS build number, and the approved repository license:
+
+```sh
+gh workflow run release.yml \
+  --repo basetenlabs/baseten-switch \
+  --ref main \
+  -f release_tag=vX.Y.Z \
+  -f build_number=N \
+  -f approved_license_spdx=MIT
+```
+
+Approve the protected `release` environment when prompted. The release job
+verifies that repository immutable releases are enabled, verifies the signed
+tag, runs `scripts/check.sh --offline`, checks the release contracts, builds
+and scans the universal archive, creates an attestation, and publishes a
+GitHub beta prerelease. It refuses to replace an existing release or its
+assets.
+
+After the job succeeds, verify all of the following on GitHub:
+
+- the release points to the intended signed tag and reviewed commit;
+- the release is a prerelease, not a draft;
+- the title and tag annotation describe the release accurately;
+- the release contains only
+  `baseten-switch_<version>_darwin_universal.zip` and `checksums.txt`;
+- the checksum file contains the published archive's SHA-256 digest;
+- the archive has a successful GitHub artifact attestation.
+
+## Review and merge the Homebrew pull request
+
+After the release job succeeds, the separate `homebrew` job creates a
+short-lived GitHub App token scoped to the public tap. It creates the branch
+`baseten-switch-<release_tag>`, replaces only
+`Formula/baseten-switch.rb`, and opens a pull request against `main`. For
+example, release `v0.2.0` uses branch `baseten-switch-v0.2.0`.
+
+The workflow never pushes directly to the tap's `main` branch and never merges
+the pull request. Its formula validation must confirm that:
+
+- the GitHub release has the selected tag and immutable prerelease metadata;
+- the release contains exactly the universal ZIP and `checksums.txt`;
+- the ZIP's SHA-256 value matches the unique checksum entry, GitHub asset
+  digest, and release-job handoff;
+- the formula's derived version, release URL, and SHA-256 value match the
+  published release;
+- GitHub verifies the ZIP's artifact attestation;
+- the formula passes Ruby syntax and Homebrew style checks;
+- the candidate does not downgrade a newer formula on the tap's `main` branch.
+
+A human reviewer must confirm that the formula changes no unrelated
+installation or lifecycle behavior, and that the tap's required review and
+repository rules pass.
+
+Before merging, rehearse the upgrade from `v0.1.0` on a disposable release
+test Mac. The tap's `main` branch still provides `v0.1.0` at this point:
+
+```sh
+release_tag=vX.Y.Z
+brew update
+brew install basetenlabs/baseten/baseten-switch
+test "$(baseten-switch --version)" = "baseten-switch v0.1.0"
+baseten-switch setup
+baseten-switch up --install
+baseten-switch claude on
+baseten-switch doctor
+
+tap_repo="$(brew --repo basetenlabs/baseten)"
+git -C "$tap_repo" fetch origin "baseten-switch-$release_tag"
+git -C "$tap_repo" switch --detach FETCH_HEAD
+HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade basetenlabs/baseten/baseten-switch
+test "$(baseten-switch --version)" = "baseten-switch $release_tag"
+baseten-switch up
+baseten-switch claude on
+baseten-switch doctor
+
+git -C "$tap_repo" switch main
+```
+
+Confirm that the upgrade preserves configuration and state, moves the managed
+processes and app to the new version, and applies the current Claude Code
+integration settings. Restart Claude Code and verify a new session when the
+release changes that integration. Merge the pull request only after the review
+and upgrade rehearsal pass.
+
+## Verify Homebrew after merge
+
+Run the final checks on a release test Mac, not a machine that must preserve a
+running gateway session:
+
+```sh
+brew update
+brew fetch --force --formula basetenlabs/baseten/baseten-switch
+brew reinstall basetenlabs/baseten/baseten-switch
+brew test basetenlabs/baseten/baseten-switch
+brew style basetenlabs/baseten/baseten-switch
+brew audit --strict --online basetenlabs/baseten/baseten-switch
+baseten-switch --version
+```
+
+Confirm that `baseten-switch --version` prints the new tag. Complete a fresh
+setup smoke test using the public instructions in `README.md` when the release
+changes installation, startup, authentication, or harness integration.
+
+Existing users upgrade with:
+
+```sh
+brew upgrade baseten-switch
+baseten-switch up
+baseten-switch doctor
+```
+
+Users who already route Claude Code through Switch should also run
+`baseten-switch claude on` before `doctor` to adopt the current managed
+integration settings, then restart Claude Code. Other users should omit that
+step. Homebrew preserves Switch configuration and state; `baseten-switch up`
+moves the managed processes and app to the newly installed version.
+
+## Recover from a failed release
+
+Preserve published tags, releases, assets, and checksums.
+
+- If the release job fails before publication because of a transient service
+  or protected-configuration problem, correct the problem and rerun it with
+  the same tag.
+- If tagged source or release content must change, merge the correction and
+  prepare a new version with a new signed tag. Never move the old tag.
+- If the GitHub prerelease succeeds but the `homebrew` job fails, correct the
+  tap permission or transient failure and rerun only the failed `homebrew`
+  job. Its deterministic branch prevents duplicate release pull requests.
+- If a published artifact or generated formula is wrong, leave the release
+  intact, prepare a corrected version, and publish a new release.
+
+Do not delete or edit a public release to reuse its version. Do not replace or
+add assets after publication.
+
+[github-immutable-releases]: https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/establish-provenance-and-integrity/prevent-release-changes

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,12 +16,21 @@ these variables:
 
 It must also provide these GitHub App secrets:
 
+- `APP_RELEASE_SETTINGS_READER_CLIENT_ID`
+- `APP_RELEASE_SETTINGS_READER_PRIVATE_KEY`
 - `APP_HOMEBREW_UPDATER_CLIENT_ID`
 - `APP_HOMEBREW_UPDATER_PRIVATE_KEY`
 
-The GitHub App token is scoped to `basetenlabs/homebrew-baseten`. The app needs
-permission to write repository contents and pull requests in that repository.
-Do not give it access to other repositories.
+The release-settings reader app must be scoped only to
+`basetenlabs/baseten-switch`, with repository Administration permission set to
+read. The workflow mints its token immediately before checking the immutable
+release setting. It must not share credentials with the Homebrew updater.
+
+The Homebrew updater app must be scoped only to
+`basetenlabs/homebrew-baseten`, with permission to write repository contents
+and pull requests. The workflow does not mint this token until it has cloned,
+inspected, and prepared the public tap update without credentials. Do not give
+either app access to other repositories or broader permissions.
 
 Enable [immutable releases][github-immutable-releases] in the
 `basetenlabs/baseten-switch` repository settings before dispatching the
@@ -30,9 +39,10 @@ publication.
 
 ## Prepare the release
 
-1. Choose an unused tag that matches `v<major>.<minor>.<patch>`. Keep the
-   `v` prefix and do not add a prerelease suffix. The workflow marks the
-   GitHub release as a beta prerelease.
+1. Choose an unused tag that matches `v<major>.<minor>.<patch>`. It must be
+   newer than every published Baseten Switch release and the version currently
+   on the public tap. Keep the `v` prefix and do not add a prerelease suffix.
+   The workflow marks the GitHub release as a beta prerelease.
 2. Choose a numeric macOS build number. Each component must contain digits,
    separated by periods. Increase it from every previous public build. The
    workflow rejects other formats.
@@ -94,10 +104,12 @@ gh workflow run release.yml \
 
 Approve the protected `release` environment when prompted. The release job
 verifies that repository immutable releases are enabled, verifies the signed
-tag, runs `scripts/check.sh --offline`, checks the release contracts, builds
-and scans the universal archive, creates an attestation, and publishes a
-GitHub beta prerelease. It refuses to replace an existing release or its
-assets.
+tag is the current `origin/main` commit, and confirms the candidate version is
+unused and newer than every published release and the current tap formula. It
+then runs `scripts/check.sh --offline`, checks the release contracts, builds
+and scans the universal archive, validates the generated formula, creates an
+attestation, and publishes a GitHub beta prerelease. It refuses to replace an
+existing release or its assets.
 
 After the job succeeds, verify all of the following on GitHub:
 
@@ -111,11 +123,14 @@ After the job succeeds, verify all of the following on GitHub:
 
 ## Review and merge the Homebrew pull request
 
-After the release job succeeds, the separate `homebrew` job creates a
-short-lived GitHub App token scoped to the public tap. It creates the branch
-`baseten-switch-<release_tag>`, replaces only
-`Formula/baseten-switch.rb`, and opens a pull request against `main`. For
-example, release `v0.2.0` uses branch `baseten-switch-v0.2.0`.
+After the release job succeeds, the separate `homebrew` job downloads and
+verifies the handoff, clones the public tap without credentials, treats the
+current tap formula as inert text, and prepares the exact local commit. Only
+then does it create a short-lived GitHub App token scoped to the public tap.
+The credentialed step pushes the prepared branch
+`baseten-switch-<release_tag>` and creates or reuses its pull request against
+`main`. For example, release `v0.2.0` uses branch
+`baseten-switch-v0.2.0`.
 
 The workflow never pushes directly to the tap's `main` branch and never merges
 the pull request. Its formula validation must confirm that:
@@ -134,20 +149,34 @@ A human reviewer must confirm that the formula changes no unrelated
 installation or lifecycle behavior, and that the tap's required review and
 repository rules pass.
 
-Before merging, rehearse the upgrade from `v0.1.0` on a disposable release
-test Mac. The tap's `main` branch still provides `v0.1.0` at this point:
+Before merging, derive the previous tag from the current tap formula and
+rehearse the upgrade on a disposable release test Mac. The pull request must
+still be unmerged when deriving `previous_tag`:
 
 ```sh
 release_tag=vX.Y.Z
 brew update
+brew tap basetenlabs/baseten
+tap_repo="$(brew --repo basetenlabs/baseten)"
+tap_formula="$tap_repo/Formula/baseten-switch.rb"
+previous_tag="$(
+  ruby -e '
+    text = File.read(ARGV.fetch(0))
+    pattern = %r{^\s*url "https://github\.com/basetenlabs/baseten-switch/releases/download/(v([0-9]+\.[0-9]+\.[0-9]+))/baseten-switch_([0-9]+\.[0-9]+\.[0-9]+)_darwin_universal\.zip"$}
+    matches = text.scan(pattern)
+    abort "expected one canonical Baseten Switch release URL" unless matches.length == 1
+    tag, tag_version, archive_version = matches.fetch(0)
+    abort "formula URL versions do not match" unless tag_version == archive_version
+    puts tag
+  ' "$tap_formula"
+)"
 brew install basetenlabs/baseten/baseten-switch
-test "$(baseten-switch --version)" = "baseten-switch v0.1.0"
+test "$(baseten-switch --version)" = "baseten-switch $previous_tag"
 baseten-switch setup
 baseten-switch up --install
 baseten-switch claude on
 baseten-switch doctor
 
-tap_repo="$(brew --repo basetenlabs/baseten)"
 git -C "$tap_repo" fetch origin "baseten-switch-$release_tag"
 git -C "$tap_repo" switch --detach FETCH_HEAD
 HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade basetenlabs/baseten/baseten-switch
@@ -205,6 +234,24 @@ Preserve published tags, releases, assets, and checksums.
 - If the release job fails before publication because of a transient service
   or protected-configuration problem, correct the problem and rerun it with
   the same tag.
+- `gh release create` can leave an unpublished draft if asset upload or final
+  publication fails. Before retrying, list releases through the GitHub API and
+  inspect the matching entry's `draft`, `published_at`, and assets. A
+  maintainer may delete it only after confirming it is a never-published draft
+  for this failed attempt. Never delete or mutate a published release.
+
+  ```sh
+  gh api --paginate repos/basetenlabs/baseten-switch/releases \
+    --jq '.[] | {id, tag_name, draft, published_at, assets: [.assets[].name]}'
+
+  release_tag=vX.Y.Z
+  draft_id=N
+  draft_url="repos/basetenlabs/baseten-switch/releases/$draft_id"
+  test "$(gh api "$draft_url" --jq .tag_name)" = "$release_tag"
+  test "$(gh api "$draft_url" --jq '.draft and (.published_at == null)')" = true
+  gh api --method DELETE "$draft_url"
+  ```
+
 - If tagged source or release content must change, merge the correction and
   prepare a new version with a new signed tag. Never move the old tag.
 - If the GitHub prerelease succeeds but the `homebrew` job fails, correct the

--- a/scripts/release/render-formula.sh
+++ b/scripts/release/render-formula.sh
@@ -15,8 +15,7 @@ Usage: scripts/release/render-formula.sh \
   --tag v<major>.<minor>.<patch> \
   --sha256 <64 lowercase or uppercase hex characters> \
   --approved-license-spdx <SPDX-ID> \
-  --output <Formula/baseten-switch.rb path> \
-  --patch-output <patch path>
+  --output <Formula/baseten-switch.rb path>
 
 The license is intentionally mandatory. Pass only the SPDX identifier approved
 for the repository. This script does not infer or select a license.
@@ -27,7 +26,6 @@ tag=""
 sha256=""
 approved_license_spdx=""
 output=""
-patch_output=""
 
 while [[ "$#" -gt 0 ]]; do
     case "$1" in
@@ -56,12 +54,6 @@ while [[ "$#" -gt 0 ]]; do
             output="$2"
             shift 2
             ;;
-        --patch-output)
-            [[ "$#" -ge 2 ]] || fail "--patch-output requires a value"
-            [[ -z "$patch_output" ]] || fail "--patch-output was provided more than once"
-            patch_output="$2"
-            shift 2
-            ;;
         -h|--help)
             usage
             exit 0
@@ -80,23 +72,16 @@ done
     || fail "--approved-license-spdx must be one explicit SPDX identifier"
 [[ -n "$output" ]] || fail "--output is required"
 [[ "$output" != -* ]] || fail "--output may not begin with '-'"
-[[ -n "$patch_output" ]] || fail "--patch-output is required"
-[[ "$patch_output" != -* ]] || fail "--patch-output may not begin with '-'"
-[[ "$patch_output" != "$output" ]] || fail "--output and --patch-output must differ"
 [[ ! -e "$output" ]] || fail "refusing to replace existing output: $output"
-[[ ! -e "$patch_output" ]] || fail "refusing to replace existing output: $patch_output"
 
 version="${tag#v}"
 sha256="$(tr '[:upper:]' '[:lower:]' <<<"$sha256")"
 artifact_name="baseten-switch_${version}_darwin_universal.zip"
 artifact_url="https://github.com/basetenlabs/baseten-switch/releases/download/${tag}/${artifact_name}"
 output_dir="$(dirname "$output")"
-patch_output_dir="$(dirname "$patch_output")"
 mkdir -p "$output_dir"
-mkdir -p "$patch_output_dir"
 tmp="$(mktemp "$output_dir/.baseten-switch-formula.XXXXXX")"
-patch_tmp="$(mktemp "$patch_output_dir/.baseten-switch-formula-patch.XXXXXX")"
-trap 'rm -f "$tmp" "$patch_tmp"' EXIT
+trap 'rm -f "$tmp"' EXIT
 
 cat >"$tmp" <<EOF
 # typed: strict
@@ -148,19 +133,7 @@ if command -v ruby >/dev/null 2>&1; then
         || fail "rendered formula failed Ruby syntax validation"
 fi
 
-formula_lines="$(wc -l <"$tmp" | tr -d '[:space:]')"
-{
-    printf 'diff --git a/Formula/baseten-switch.rb b/Formula/baseten-switch.rb\n'
-    printf 'new file mode 100644\n'
-    printf '%s\n' '--- /dev/null'
-    printf '%s\n' '+++ b/Formula/baseten-switch.rb'
-    printf '@@ -0,0 +1,%s @@\n' "$formula_lines"
-    sed 's/^/+/' "$tmp"
-} >"$patch_tmp"
-
 chmod 0644 "$tmp"
-chmod 0644 "$patch_tmp"
 mv "$tmp" "$output"
-mv "$patch_tmp" "$patch_output"
 trap - EXIT
-printf '%s\n' "$output" "$patch_output"
+printf '%s\n' "$output"

--- a/scripts/release/test-release-workflow.sh
+++ b/scripts/release/test-release-workflow.sh
@@ -59,8 +59,6 @@ grep -Fq 'scripts/release/render-formula.sh' "$WORKFLOW" \
     || fail "workflow does not invoke the canonical formula renderer"
 grep -Fq 'scripts/security/run-gitleaks.sh dist' "$WORKFLOW" \
     || fail "workflow does not scan the release archive for secrets"
-grep -Fq -- "--patch-output \"\$patch\"" "$WORKFLOW" \
-    || fail "workflow does not render the public-tap patch artifact"
 grep -Fq "subject-path: \${{ steps.formula.outputs.artifact }}" "$WORKFLOW" \
     || fail "workflow does not attest the final ZIP"
 grep -Fq "gh release create \"\$RELEASE_TAG\"" "$WORKFLOW" \
@@ -69,13 +67,89 @@ grep -Eq '^[[:space:]]+--prerelease[[:space:]]+\\$' "$WORKFLOW" \
     || fail "release creation is not marked as a prerelease"
 grep -Fq 'release already exists for %s; refusing to replace or add assets' "$WORKFLOW" \
     || fail "workflow does not refuse existing releases"
+grep -Fq 'repos/basetenlabs/baseten-switch/immutable-releases' "$WORKFLOW" \
+    || fail "release publication does not require the repository immutable-release setting"
+grep -Fq -- "--jq '.enabled == true'" "$WORKFLOW" \
+    || fail "release publication does not fail closed on the immutable-release setting"
 grep -Fq '"dist/baseten-switch_${version}_darwin_universal.zip"' "$WORKFLOW" \
     || fail "release does not upload the universal ZIP"
 grep -Fq '"dist/checksums.txt"' "$WORKFLOW" \
     || fail "release does not upload checksums"
-
-if grep -Eiq -- 'APPLE_|NOTARY|NOTARIZ|SBOM|CYCLONEDX|RELEASE_TAG_SIGNING_PUBLIC_KEY_BASE64|gpg --batch|--draft|--clobber|gh release edit|gh release upload|gh release delete|git push|brew tap' "$WORKFLOW"; then
-    fail "workflow contains replacement, publication, tap mutation, or release mutation behavior"
+grep -Fqx '    needs: prepare' "$WORKFLOW" \
+    || fail "Homebrew publication is not isolated behind the immutable release job"
+for homebrew_permission in 'actions: read' 'attestations: read' 'contents: read'; do
+    grep -Fqx "      $homebrew_permission" "$WORKFLOW" \
+        || fail "Homebrew job is missing permission: $homebrew_permission"
+done
+grep -Fq 'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c' "$WORKFLOW" \
+    || fail "Homebrew publication does not download the exact formula handoff"
+grep -Fq 'actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1' "$WORKFLOW" \
+    || fail "Homebrew publication does not use the pinned GitHub App token action"
+for tap_token_value in \
+    'client-id: ${{ secrets.APP_HOMEBREW_UPDATER_CLIENT_ID }}' \
+    'private-key: ${{ secrets.APP_HOMEBREW_UPDATER_PRIVATE_KEY }}' \
+    'owner: basetenlabs' \
+    'repositories: homebrew-baseten' \
+    'permission-contents: write' \
+    'permission-pull-requests: write'; do
+    grep -Fq "$tap_token_value" "$WORKFLOW" \
+        || fail "Homebrew token is not scoped as required: $tap_token_value"
+done
+grep -Fq '"repos/basetenlabs/baseten-switch/releases/tags/$RELEASE_TAG"' "$WORKFLOW" \
+    || fail "Homebrew publication does not inspect the published release"
+for release_fact in \
+    'release.fetch("tag_name") == tag' \
+    'release.fetch("draft") == false' \
+    'release.fetch("prerelease") == true' \
+    'release.fetch("immutable") == true' \
+    'assets.map { |asset| asset.fetch("name") }.sort == expected_names.sort' \
+    'digest.match?(/\Asha256:[0-9a-f]{64}\z/)' \
+    'gh release download "$RELEASE_TAG"' \
+    'cmp -s "$checksums" "$published_release/checksums.txt"' \
+    'published_sha256="$(shasum -a 256' \
+    '"$asset_digest" == "sha256:$expected_sha256"' \
+    'gh attestation verify "$published_release/$artifact_name"' \
+    '--signer-workflow basetenlabs/baseten-switch/.github/workflows/release.yml'; do
+    grep -Fq -- "$release_fact" "$WORKFLOW" \
+        || fail "Homebrew handoff does not verify release fact: $release_fact"
+done
+for tap_contract in \
+    'tap_branch="baseten-switch-${RELEASE_TAG}"' \
+    'generated_formula="$handoff/homebrew-tap/$formula_path"' \
+    'cmp -s "$generated_formula" "$formula_path"' \
+    'brew style "$generated_formula"' \
+    'git push origin "HEAD:refs/heads/$tap_branch"' \
+    'gh pr create' \
+    '--base main' \
+    '--head "$tap_branch"'; do
+    grep -Fq -- "$tap_contract" "$WORKFLOW" \
+        || fail "Homebrew pull request contract is missing: $tap_contract"
+done
+grep -Fq 'Homebrew tap main already contains Baseten Switch %s' "$WORKFLOW" \
+    || fail "Homebrew publication is not idempotent after a merged tap update"
+grep -Fq 'existing tap branch %s contains a conflicting formula' "$WORKFLOW" \
+    || fail "Homebrew publication does not reject a conflicting deterministic branch"
+grep -Fq 'Reusing Homebrew tap pull request %s' "$WORKFLOW" \
+    || fail "Homebrew publication does not reuse a matching pull request"
+grep -Fq 'refusing tap downgrade or conflicting version' "$WORKFLOW" \
+    || fail "Homebrew publication does not prevent an older release from downgrading tap main"
+[[ "$(grep -Ec '^[[:space:]]+git push ' "$WORKFLOW")" == 1 ]] \
+    || fail "workflow must contain exactly one deterministic-branch push"
+if grep -Eq '^[[:space:]]+git push (.*--force|.*refs/heads/main|.*[[:space:]]main([[:space:]]|$))' "$WORKFLOW"; then
+    fail "workflow pushes forcefully or directly to tap main"
 fi
 
-printf 'PASS: pinned manual beta prerelease workflow contract\n'
+immutable_setting_line="$(grep -nF 'repos/basetenlabs/baseten-switch/immutable-releases' "$WORKFLOW" | head -1 | cut -d: -f1)"
+release_create_line="$(grep -nF 'gh release create "$RELEASE_TAG"' "$WORKFLOW" | head -1 | cut -d: -f1)"
+release_verify_line="$(grep -nF 'release.fetch("immutable") == true' "$WORKFLOW" | head -1 | cut -d: -f1)"
+tap_token_line="$(grep -nF 'actions/create-github-app-token@' "$WORKFLOW" | head -1 | cut -d: -f1)"
+[[ "$immutable_setting_line" -lt "$release_create_line" ]] \
+    || fail "immutable-release setting is checked after publication"
+[[ "$release_verify_line" -lt "$tap_token_line" ]] \
+    || fail "tap token is minted before the immutable release is verified"
+
+if grep -Eiq -- 'APPLE_|NOTARY|NOTARIZ|SBOM|CYCLONEDX|RELEASE_TAG_SIGNING_PUBLIC_KEY_BASE64|gpg --batch|--draft|--clobber|gh release edit|gh release upload|gh release delete|gh pr merge' "$WORKFLOW"; then
+    fail "workflow contains replacement, direct-main, auto-merge, or release mutation behavior"
+fi
+
+printf 'PASS: pinned manual beta prerelease and protected tap PR workflow contract\n'

--- a/scripts/release/test-release-workflow.sh
+++ b/scripts/release/test-release-workflow.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 WORKFLOW="$REPO_DIR/.github/workflows/release.yml"
+RELEASING="$REPO_DIR/RELEASING.md"
 
 fail() {
     printf 'FAIL: %s\n' "$*" >&2
@@ -20,6 +21,8 @@ if grep -Eq '^  (push|pull_request|release|schedule):' "$WORKFLOW"; then
 fi
 grep -Fqx 'permissions: read-all' "$WORKFLOW" \
     || fail "workflow does not default to read-only permissions"
+grep -Fqx '  group: release' "$WORKFLOW" \
+    || fail "workflow does not serialize all release versions"
 grep -Fqx '    environment: release' "$WORKFLOW" \
     || fail "release job does not require the protected release environment"
 for permission in 'contents: write' 'id-token: write' 'attestations: write'; do
@@ -33,6 +36,50 @@ while IFS= read -r action; do
 done < <(
     sed -nE 's/^[[:space:]]+uses:[[:space:]]+([^[:space:]#]+).*/\1/p' "$WORKFLOW"
 )
+
+ruby -ryaml -e '
+  workflow = YAML.load_file(ARGV.fetch(0))
+  jobs = workflow.fetch("jobs")
+  prepare_steps = jobs.fetch("prepare").fetch("steps")
+  homebrew_steps = jobs.fetch("homebrew").fetch("steps")
+  release_reader_index = prepare_steps.index { |step| step["id"] == "release-settings-token" }
+  tap_prepare_index = homebrew_steps.index { |step| step["id"] == "tap-prepare" }
+  tap_token_index = homebrew_steps.index { |step| step["id"] == "tap-token" }
+  abort "release-settings token step is missing" unless release_reader_index
+  abort "tap preparation or token step is missing" unless tap_prepare_index && tap_token_index
+
+  release_reader = prepare_steps.fetch(release_reader_index)
+  expected_release_reader = {
+    "client-id" => "${{ secrets.APP_RELEASE_SETTINGS_READER_CLIENT_ID }}",
+    "private-key" => "${{ secrets.APP_RELEASE_SETTINGS_READER_PRIVATE_KEY }}",
+    "owner" => "basetenlabs",
+    "repositories" => "baseten-switch",
+    "permission-administration" => "read"
+  }
+  abort "release-settings token has excess or missing scope" unless
+    release_reader.fetch("with") == expected_release_reader
+  abort "release-settings token is not immediately followed by its read" unless
+    prepare_steps.fetch(release_reader_index + 1).fetch("name") ==
+      "Require immutable releases before publication"
+
+  tap_prepare = homebrew_steps.fetch(tap_prepare_index)
+  abort "credentialless tap preparation has an unexpected environment" unless
+    tap_prepare.fetch("env") == { "RELEASE_TAG" => "${{ inputs.release_tag }}" }
+  tap_token = homebrew_steps.fetch(tap_token_index)
+  expected_tap_token = {
+    "client-id" => "${{ secrets.APP_HOMEBREW_UPDATER_CLIENT_ID }}",
+    "private-key" => "${{ secrets.APP_HOMEBREW_UPDATER_PRIVATE_KEY }}",
+    "owner" => "basetenlabs",
+    "repositories" => "homebrew-baseten",
+    "permission-contents" => "write",
+    "permission-pull-requests" => "write"
+  }
+  abort "tap token has excess or missing scope" unless tap_token.fetch("with") == expected_tap_token
+  abort "tap token is minted before credentialless preparation" unless tap_prepare_index < tap_token_index
+  abort "tap token is not immediately followed by publication" unless
+    homebrew_steps.fetch(tap_token_index + 1).fetch("name") ==
+      "Push the prepared commit and open or reuse its pull request"
+' "$WORKFLOW" || fail "GitHub App scope or sequencing contract failed"
 
 grep -Fq "git verify-tag \"\$RELEASE_TAG\"" "$WORKFLOW" \
     || fail "workflow does not verify the selected tag signature"
@@ -51,6 +98,16 @@ grep -Fq 'git config gpg.ssh.allowedSignersFile "$allowed_signers"' "$WORKFLOW" 
     || fail "workflow does not constrain SSH signatures to the approved principal"
 grep -Fq 'git describe --tags --exact-match HEAD' "$WORKFLOW" \
     || fail "workflow does not require an exact tag checkout"
+grep -Fq '+refs/heads/main:refs/remotes/origin/main' "$WORKFLOW" \
+    || fail "workflow does not fetch the current origin/main commit"
+grep -Fq 'release tag is not the current origin/main commit' "$WORKFLOW" \
+    || fail "workflow does not require the tag to equal origin/main"
+grep -Fq 'Require an unused version newer than every public release' "$WORKFLOW" \
+    || fail "workflow does not preflight the candidate version"
+grep -Fq 'release tag #{candidate_tag} is not newer than #{published_tag}' "$WORKFLOW" \
+    || fail "workflow does not compare the candidate with every published release"
+grep -Fq 'release tag #{candidate_tag} is not newer than tap main #{tap_tag}' "$WORKFLOW" \
+    || fail "workflow does not compare the candidate with the public tap before publication"
 grep -Fq 'scripts/release/build-artifacts.sh' "$WORKFLOW" \
     || fail "workflow does not invoke the strict artifact builder"
 grep -Fq 'BASETEN_SWITCH_RELEASE_SIGNING_MODE: adhoc' "$WORKFLOW" \
@@ -59,14 +116,23 @@ grep -Fq 'scripts/release/render-formula.sh' "$WORKFLOW" \
     || fail "workflow does not invoke the canonical formula renderer"
 grep -Fq 'scripts/security/run-gitleaks.sh dist' "$WORKFLOW" \
     || fail "workflow does not scan the release archive for secrets"
+for formula_preflight in \
+    'Validate the generated formula before publication' \
+    'ruby -c "$GENERATED_FORMULA"' \
+    'brew style "$GENERATED_FORMULA"'; do
+    grep -Fq "$formula_preflight" "$WORKFLOW" \
+        || fail "formula publication preflight is missing: $formula_preflight"
+done
 grep -Fq "subject-path: \${{ steps.formula.outputs.artifact }}" "$WORKFLOW" \
     || fail "workflow does not attest the final ZIP"
 grep -Fq "gh release create \"\$RELEASE_TAG\"" "$WORKFLOW" \
     || fail "workflow does not create a release from the selected tag"
 grep -Eq '^[[:space:]]+--prerelease[[:space:]]+\\$' "$WORKFLOW" \
     || fail "release creation is not marked as a prerelease"
-grep -Fq 'release already exists for %s; refusing to replace or add assets' "$WORKFLOW" \
-    || fail "workflow does not refuse existing releases"
+grep -Fq 'unpublished draft exists for #{tag}; inspect and remove only that draft before retrying' "$WORKFLOW" \
+    || fail "workflow does not identify a partial unpublished draft"
+grep -Fq 'published release already exists for #{tag}; refusing to replace or add assets' "$WORKFLOW" \
+    || fail "workflow does not refuse existing published releases"
 grep -Fq 'repos/basetenlabs/baseten-switch/immutable-releases' "$WORKFLOW" \
     || fail "release publication does not require the repository immutable-release setting"
 grep -Fq -- "--jq '.enabled == true'" "$WORKFLOW" \
@@ -83,9 +149,20 @@ for homebrew_permission in 'actions: read' 'attestations: read' 'contents: read'
 done
 grep -Fq 'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c' "$WORKFLOW" \
     || fail "Homebrew publication does not download the exact formula handoff"
-grep -Fq 'actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1' "$WORKFLOW" \
-    || fail "Homebrew publication does not use the pinned GitHub App token action"
+[[ "$(grep -Fc 'actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1' "$WORKFLOW")" == 2 ]] \
+    || fail "workflow does not use the pinned GitHub App token action exactly twice"
+for release_settings_token_value in \
+    'id: release-settings-token' \
+    'client-id: ${{ secrets.APP_RELEASE_SETTINGS_READER_CLIENT_ID }}' \
+    'private-key: ${{ secrets.APP_RELEASE_SETTINGS_READER_PRIVATE_KEY }}' \
+    'repositories: baseten-switch' \
+    'permission-administration: read' \
+    'GH_TOKEN: ${{ steps.release-settings-token.outputs.token }}'; do
+    grep -Fq "$release_settings_token_value" "$WORKFLOW" \
+        || fail "release-settings token is not minimally scoped: $release_settings_token_value"
+done
 for tap_token_value in \
+    'id: tap-token' \
     'client-id: ${{ secrets.APP_HOMEBREW_UPDATER_CLIENT_ID }}' \
     'private-key: ${{ secrets.APP_HOMEBREW_UPDATER_PRIVATE_KEY }}' \
     'owner: basetenlabs' \
@@ -118,10 +195,12 @@ for tap_contract in \
     'generated_formula="$handoff/homebrew-tap/$formula_path"' \
     'cmp -s "$generated_formula" "$formula_path"' \
     'brew style "$generated_formula"' \
-    'git push origin "HEAD:refs/heads/$tap_branch"' \
+    '[[ -z "${GH_TOKEN:-}" ]]' \
+    'git clone --branch main --single-branch' \
+    'git push origin "$EXPECTED_COMMIT:refs/heads/$TAP_BRANCH"' \
     'gh pr create' \
     '--base main' \
-    '--head "$tap_branch"'; do
+    '--head "$TAP_BRANCH"'; do
     grep -Fq -- "$tap_contract" "$WORKFLOW" \
         || fail "Homebrew pull request contract is missing: $tap_contract"
 done
@@ -141,15 +220,42 @@ fi
 
 immutable_setting_line="$(grep -nF 'repos/basetenlabs/baseten-switch/immutable-releases' "$WORKFLOW" | head -1 | cut -d: -f1)"
 release_create_line="$(grep -nF 'gh release create "$RELEASE_TAG"' "$WORKFLOW" | head -1 | cut -d: -f1)"
+release_version_line="$(grep -nF 'Require an unused version newer than every public release' "$WORKFLOW" | head -1 | cut -d: -f1)"
+formula_preflight_line="$(grep -nF 'Validate the generated formula before publication' "$WORKFLOW" | head -1 | cut -d: -f1)"
 release_verify_line="$(grep -nF 'release.fetch("immutable") == true' "$WORKFLOW" | head -1 | cut -d: -f1)"
-tap_token_line="$(grep -nF 'actions/create-github-app-token@' "$WORKFLOW" | head -1 | cut -d: -f1)"
+tap_clone_line="$(grep -nF 'git clone --branch main --single-branch' "$WORKFLOW" | head -1 | cut -d: -f1)"
+tap_token_line="$(grep -nF 'id: tap-token' "$WORKFLOW" | head -1 | cut -d: -f1)"
+tap_push_line="$(grep -nF 'git push origin "$EXPECTED_COMMIT:refs/heads/$TAP_BRANCH"' "$WORKFLOW" | head -1 | cut -d: -f1)"
 [[ "$immutable_setting_line" -lt "$release_create_line" ]] \
     || fail "immutable-release setting is checked after publication"
+[[ "$release_version_line" -lt "$release_create_line" ]] \
+    || fail "release version is checked after publication"
+[[ "$formula_preflight_line" -lt "$release_create_line" ]] \
+    || fail "generated formula is validated after publication"
 [[ "$release_verify_line" -lt "$tap_token_line" ]] \
     || fail "tap token is minted before the immutable release is verified"
+[[ "$tap_clone_line" -lt "$tap_token_line" && "$tap_token_line" -lt "$tap_push_line" ]] \
+    || fail "tap write token exists during clone or preparation"
+if tail -n "+$tap_token_line" "$WORKFLOW" | grep -Fq 'brew ruby'; then
+    fail "tap Ruby is evaluated after the write-scoped tap token is minted"
+fi
 
 if grep -Eiq -- 'APPLE_|NOTARY|NOTARIZ|SBOM|CYCLONEDX|RELEASE_TAG_SIGNING_PUBLIC_KEY_BASE64|gpg --batch|--draft|--clobber|gh release edit|gh release upload|gh release delete|gh pr merge' "$WORKFLOW"; then
     fail "workflow contains replacement, direct-main, auto-merge, or release mutation behavior"
+fi
+
+for release_doc_contract in \
+    'APP_RELEASE_SETTINGS_READER_CLIENT_ID' \
+    'APP_RELEASE_SETTINGS_READER_PRIVATE_KEY' \
+    'Administration permission set to' \
+    'previous_tag="$' \
+    'never-published draft' \
+    'gh api --method DELETE "$draft_url"'; do
+    grep -Fq "$release_doc_contract" "$RELEASING" \
+        || fail "release guide is missing contract: $release_doc_contract"
+done
+if grep -Fq 'rehearse the upgrade from `v0.1.0`' "$RELEASING"; then
+    fail "release guide hardcodes a stale previous release"
 fi
 
 printf 'PASS: pinned manual beta prerelease and protected tap PR workflow contract\n'

--- a/scripts/release/test-render-formula.sh
+++ b/scripts/release/test-render-formula.sh
@@ -12,27 +12,17 @@ fail() {
 }
 
 formula="$TMP_ROOT/Formula/baseten-switch.rb"
-patch="$TMP_ROOT/baseten-switch_1.2.3_homebrew.patch"
 checksum="0123456789abcdef0123456789abcdef0123456789abcdef0123456789ABCDEF"
 "$RENDERER" \
     --tag v1.2.3 \
     --sha256 "$checksum" \
     --approved-license-spdx MIT \
-    --output "$formula" \
-    --patch-output "$patch" >/dev/null
+    --output "$formula" >/dev/null
 
 [[ -f "$formula" ]] || fail "renderer did not create the formula"
-[[ -f "$patch" ]] || fail "renderer did not create the tap patch"
 [[ "$(stat -f '%Lp' "$formula" 2>/dev/null || stat -c '%a' "$formula")" == 644 ]] \
     || fail "formula mode is not 0644"
 ruby -c "$formula" >/dev/null || fail "formula is not valid Ruby syntax"
-tap_checkout="$TMP_ROOT/tap-checkout"
-mkdir -p "$tap_checkout"
-git -C "$tap_checkout" init -q
-git -C "$tap_checkout" apply "$patch" \
-    || fail "rendered tap patch does not apply to a clean checkout"
-cmp "$formula" "$tap_checkout/Formula/baseten-switch.rb" \
-    || fail "tap patch does not produce the rendered formula"
 
 grep -Fqx '# typed: strict' "$formula" \
     || fail "formula omitted the Homebrew Sorbet sigil"
@@ -90,8 +80,7 @@ failure_log="$TMP_ROOT/failure.log"
 if "$RENDERER" \
     --tag v1.2.3 \
     --sha256 "$checksum" \
-    --output "$TMP_ROOT/no-license.rb" \
-    --patch-output "$TMP_ROOT/no-license.patch" >"$failure_log" 2>&1; then
+    --output "$TMP_ROOT/no-license.rb" >"$failure_log" 2>&1; then
     fail "renderer accepted a missing approved SPDX license"
 fi
 grep -Fq -- '--approved-license-spdx' "$failure_log" \
@@ -101,8 +90,7 @@ if "$RENDERER" \
     --tag 1.2.3 \
     --sha256 "$checksum" \
     --approved-license-spdx MIT \
-    --output "$TMP_ROOT/bad-tag.rb" \
-    --patch-output "$TMP_ROOT/bad-tag.patch" >"$failure_log" 2>&1; then
+    --output "$TMP_ROOT/bad-tag.rb" >"$failure_log" 2>&1; then
     fail "renderer accepted a tag without the required v prefix"
 fi
 
@@ -110,8 +98,7 @@ if "$RENDERER" \
     --tag v1.2.3 \
     --sha256 not-a-checksum \
     --approved-license-spdx MIT \
-    --output "$TMP_ROOT/bad-checksum.rb" \
-    --patch-output "$TMP_ROOT/bad-checksum.patch" >"$failure_log" 2>&1; then
+    --output "$TMP_ROOT/bad-checksum.rb" >"$failure_log" 2>&1; then
     fail "renderer accepted an invalid checksum"
 fi
 
@@ -119,8 +106,7 @@ if "$RENDERER" \
     --tag v1.2.3 \
     --sha256 "$checksum" \
     --approved-license-spdx 'Apache-2.0"; system("id")' \
-    --output "$TMP_ROOT/injected.rb" \
-    --patch-output "$TMP_ROOT/injected.patch" >"$failure_log" 2>&1; then
+    --output "$TMP_ROOT/injected.rb" >"$failure_log" 2>&1; then
     fail "renderer accepted an unsafe license value"
 fi
 
@@ -128,8 +114,7 @@ if "$RENDERER" \
     --tag v1.2.3 \
     --sha256 "$checksum" \
     --approved-license-spdx MIT \
-    --output "$formula" \
-    --patch-output "$TMP_ROOT/overwrite.patch" >"$failure_log" 2>&1; then
+    --output "$formula" >"$failure_log" 2>&1; then
     fail "renderer replaced an existing formula"
 fi
 grep -Fq 'refusing to replace existing output' "$failure_log" \


### PR DESCRIPTION
## What

- Add `CHANGELOG.md` and a maintainer runbook in `RELEASING.md`.
- Require release tags to be signed, unused, newer than existing releases, and
  attached to the current `main` commit.
- Require immutable GitHub prereleases with checksum-pinned assets and artifact
  attestations.
- Generate the Homebrew formula and open a protected tap pull request for human
  review instead of updating the tap manually.
- Add release workflow and formula contract tests.

## Why

Make beta releases repeatable across the changelog, GitHub release, and public
Homebrew tap while preserving the tap's required review boundary.

## Testing

- `scripts/check.sh`
- `scripts/release/test-release-workflow.sh`
- `scripts/release/test-render-formula.sh`
- `scripts/release/test-release-contract.sh`
- `actionlint .github/workflows/release.yml`
- `shellcheck -e SC2016 scripts/release/render-formula.sh scripts/release/test-release-workflow.sh scripts/release/test-render-formula.sh`
- Independent security review of the final credential and publication
  boundaries

## Security and privacy

This changes release automation only. It does not change runtime credential,
prompt, routing, telemetry, or localhost API behavior, and it adds no runtime
dependencies.

The workflow uses two short-lived, repository-scoped GitHub App tokens. The
release-settings reader has Administration read access only to this repository.
The Homebrew updater has contents and pull-request write access only to the
public tap. Tap inspection and commit preparation occur without credentials,
and the workflow never pushes directly to tap `main` or merges its pull request.

Before the first release, maintainers must enable immutable releases and
configure the documented protected-environment variables and secrets.
