### PR TITLE
Support Baseten CLI API-key profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ user launch agents, starts the local gateway, installs Baseten Switch.app in
 sessions to the gateway. The final command checks the complete request path
 with a small live request.
 
+Baseten Switch uses the current
+[Baseten CLI profile](https://docs.baseten.co/reference/cli/baseten/auth) for
+authentication. Both browser OAuth and API-key profiles created by
+`baseten auth login` work with the gateway. Baseten controls each API key's
+permissions and resource access; Switch treats the key as an opaque
+credential.
+
 If macOS blocks the app's first launch, open **System Settings → Privacy &
 Security**, scroll to **Security**, and click **Open Anyway**. This control
 appears after a blocked launch attempt. A managed Mac may prohibit the
@@ -166,9 +173,16 @@ Baseten Switch stores configuration, local state, logs, and telemetry under
 ~/.config/baseten-switch/logs/door.log
 ```
 
-Run `baseten-switch auth login` if the Baseten credential expires. The command
-delegates authentication to the Baseten CLI, reloads the gateway, and prints
-the current identity.
+Run `baseten-switch auth login` if the Baseten credential expires, is rotated,
+or needs to change. The command delegates authentication to the Baseten CLI,
+reloads the gateway, and prints the current identity. `status` identifies the
+selected profile as OAuth or API key. The gateway also watches the selected
+CLI profile for login, logout, rotation, and profile changes.
+
+`BASETEN_API_KEY` is a separate environment fallback, not the selected CLI
+profile. Switch uses it only when `BASETEN_SWITCH_API_KEY_FALLBACK=1` and no
+selected profile credential is available. A selected OAuth or API-key profile
+always takes precedence.
 
 ## Upgrade
 
@@ -236,7 +250,9 @@ commands over direct edits; routing changes hot-reload without a restart.
 
 See [config/schema.md](config/schema.md) for every field and
 [config/gateway.example.yaml](config/gateway.example.yaml) for the generated
-shape. Store API-key overrides in
+shape. The Baseten CLI owns selected-profile credentials. If you explicitly
+enable the environment fallback, store `BASETEN_API_KEY` and
+`BASETEN_SWITCH_API_KEY_FALLBACK=1` in
 `~/.config/baseten-switch/env`, which must use mode `0600`, rather than in
 `gateway.yaml`.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -13,6 +13,9 @@ Testing runs in three layers, ordered from cheapest to most realistic:
    container exercises the source-build lifecycle and verifies the full
    install-to-first-request path.
 
+An additional opt-in live contract test validates API-key profile
+authentication against Baseten. The normal gate skips this networked lane.
+
 ## Layer 1: unit and integration tests
 
 ### Go
@@ -76,6 +79,9 @@ agents. Steps, in order:
 8. Smoke: `up`, `status`, idempotent `up`, `down`, `status` round trip on
    scratch ports with `BASETEN_SWITCH_LAUNCHD=off` and a fully sandboxed env. Never
    touches the live gateway.
+9. Validate the API-key profile live-test script in dry-run mode. The live
+   request runs only when explicitly enabled with a test key.
+
 All smoke steps isolate themselves with the env seams listed below; the gate
 never edits `~/.config/baseten-switch` or touches a running production gateway.
 
@@ -96,6 +102,45 @@ The API key enters only via `docker run -e`, never a image layer. Not
 simulated: macOS keychain OAuth, the menubar app, Gatekeeper/notarization,
 and real launchd installs.
 
+## Opt-in API-key profile contract
+
+This test creates a temporary Baseten CLI API-key profile, starts scratch
+router and door processes, and sends `GET /v1/models` plus one minimal Chat
+Completions request through the door. It verifies that admin status reports a
+healthy API-key profile, the environment fallback is disabled, and telemetry
+attributes inference to Baseten.
+
+Use an API key that may list models and invoke the selected model. The key is
+read only from the environment and is never printed. The model defaults to
+the public example model; override it when the key has access to a different
+model.
+
+```sh
+BASETEN_SWITCH_TEST_API_KEY='<test-key>' \
+BASETEN_SWITCH_TEST_MODEL='zai-org/GLM-5.2' \
+scripts/tests/test_api_key_profile_live.sh
+```
+
+To include the lane in the full gate:
+
+```sh
+BASETEN_SWITCH_RUN_API_KEY_PROFILE_LIVE=1 \
+BASETEN_SWITCH_TEST_API_KEY='<test-key>' \
+BASETEN_SWITCH_TEST_MODEL='zai-org/GLM-5.2' \
+scripts/check.sh
+```
+
+The script requires `baseten`, `curl`, `go`, and `lsof`. It uses a temporary
+`BASETEN_CONFIG_DIR`, insecure storage inside that temporary directory, an
+empty Switch environment file, scratch ports, and scratch pidfiles. It does
+not read the normal CLI profile store or operate on installed Switch
+processes. On exit it stops only the process IDs it started and removes only
+its validated temporary directory.
+
+Before cleanup, the script scans its output, logs, telemetry, and scratch
+state for the exact test key. It excludes the temporary CLI credential file,
+which intentionally contains the key.
+
 ## Writing tests: isolation seams
 
 Production code honors env overrides so tests and scratch instances never
@@ -111,6 +156,8 @@ touch real state. Any test that boots a component must set the relevant ones:
 | `BASETEN_SWITCH_GATEWAY_LOG`, `BASETEN_SWITCH_DOOR_LOG` | process log locations |
 | `BASETEN_SWITCH_TELEMETRY_DIR` | segmented telemetry store location |
 | `BASETEN_SWITCH_OAUTH_PROFILE` | named Baseten CLI profile; unset follows the CLI's current profile (point at a nonexistent name to run credential-less) |
+| `BASETEN_CONFIG_DIR` | Baseten CLI profile-store directory; live credential tests must use a scratch directory. |
+| `BASETEN_SWITCH_AUTH_NO_KEYRING=1` | prevent a scratch test from consulting the system keyring. |
 | `BASETEN_SWITCH_MENUBAR_APP` | menubar bundle path override |
 
 Hard rules for contributors and agents:

--- a/config/gateway.example.yaml
+++ b/config/gateway.example.yaml
@@ -7,7 +7,8 @@ global:
   # One global switch. Off is absolute native passthrough; On applies saved routing policy.
   routing_enabled: true
 
-  # Upstream auth; baseten is OPTIONAL with OAuth ('baseten auth login'), see schema.md for the API-key path.
+  # The selected Baseten CLI profile supplies OAuth or API-key auth automatically.
+  # baseten below is only the explicit environment fallback; see schema.md.
   auth:
     baseten:   ${BASETEN_API_KEY}
     anthropic: ${ANTHROPIC_API_KEY}

--- a/config/schema.md
+++ b/config/schema.md
@@ -20,7 +20,7 @@ SIGHUP. The native Mac app edits the same file through `baseten-switch`.
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `routing_enabled` | bool | `true` in new configs | The one global routing gate. It must be explicitly present. Off is absolute: native requests use the protocol-native provider, and aliases, raw Baseten slugs, Baseten model mappings, dedicated Baseten subagents, fallback, and Baseten credentials are not consulted by request resolution. Saved policy remains editable and becomes active again when On. |
-| `auth` | map[route] -> secret ref | (empty) | Backend credentials per upstream route. `${VAR}` resolves from env or `~/.config/baseten-switch/env`. |
+| `auth` | map[route] -> secret ref | (empty) | Environment fallback credentials per upstream route. The selected Baseten CLI profile supplies its OAuth or API-key credential automatically. `${VAR}` resolves from env or `~/.config/baseten-switch/env`. |
 | `telemetry_dir` | string | `~/.config/baseten-switch/telemetry` | Private directory containing versioned, monthly JSONL request segments. |
 | `telemetry_enabled` | bool | `true` | Toggle per-request telemetry collection. Disabling collection preserves existing history. |
 | `telemetry_retention_days` | int | `90` | Retention window for closed telemetry segments. The active segment is never deleted. |
@@ -148,6 +148,29 @@ substituted at gateway startup from:
 Resolved values are never written back to disk. The Tauri UI never
 displays resolved secrets; it shows the `${VAR_NAME}` placeholder
 verbatim and lets the user edit only the variable name.
+
+### Baseten authentication precedence
+
+Switch reads the selected profile created by `baseten auth login`. A selected
+OAuth profile or API-key profile takes precedence over `global.auth.baseten`.
+API keys remain opaque; Baseten enforces their permissions and resource
+access.
+
+`global.auth.baseten` expands to `BASETEN_API_KEY`, which is a separate
+environment fallback. Switch uses it only when
+`BASETEN_SWITCH_API_KEY_FALLBACK=1` and the selected CLI profile has no usable
+credential. Store both values in the mode-0600 Switch environment file when
+you need this fallback:
+
+```text
+BASETEN_SWITCH_API_KEY_FALLBACK=1
+BASETEN_API_KEY=...
+```
+
+`GET /v1/admin/auth/status` and the `auth` block in `GET /v1/admin/status`
+report `auth_type` as `oauth`, `api_key`, or `none`. An environment-only
+credential reports `auth_type: api_key` with `signed_in: false` and
+`fallback_in_use: true`; it does not become a selected CLI profile.
 
 ## Reload semantics
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -38,6 +38,11 @@ The generated configuration lives at
 `~/.config/baseten-switch/gateway.yaml`. Runtime state, logs, and telemetry
 use the same configuration directory.
 
+The gateway reads the current Baseten CLI profile. It supports both OAuth and
+API-key profiles and reports the active type through
+`GET /v1/admin/auth/status`. The separate `BASETEN_API_KEY` fallback requires
+`BASETEN_SWITCH_API_KEY_FALLBACK=1`; a selected profile takes precedence.
+
 ## Main commands
 
 ```text

--- a/gateway/cmd/baseten-switch/doctor.go
+++ b/gateway/cmd/baseten-switch/doctor.go
@@ -32,6 +32,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -185,8 +186,8 @@ func runDoctor(o doctorOpts) doctorReport {
 	routerState := probePort(adminAddr, routerHealthPath, routerHealthMarker)
 
 	// --- 3. auth ----------------------------------------------------------
-	doctorAuthCheck(add, f, unresolved, envFile, envFilePath)
-	doctorAuthHealthCheck(add, adminAddr, routerState == portOurs)
+	storeAuth := doctorAuthCheck(add, f, unresolved, envFile, envFilePath)
+	doctorAuthHealthCheck(add, adminAddr, routerState == portOurs, storeAuth)
 	doctorBasetenCLICheck(add)
 
 	// --- 4. router --------------------------------------------------------
@@ -409,21 +410,27 @@ func doctorConfigChecks(add addCheck, cfgPath string, cfgErr error, f *config.Fi
 // store (the same store the gateway reads). Not-signed-in is a FAIL
 // only when something actually depends on a Baseten credential: a
 // baseten-routed client, or an unresolved auth placeholder.
-func doctorAuthCheck(add addCheck, f *config.File, unresolved []string, envFile map[string]string, envFilePath string) {
+type doctorStoreAuth struct {
+	apiKeyProfile string
+	apiKeyReady   bool
+}
+
+func doctorAuthCheck(add addCheck, f *config.File, unresolved []string, envFile map[string]string, envFilePath string) doctorStoreAuth {
 	tok, _, err := auth.Load("")
 	var ak *auth.APIKeyProfileError
 	switch {
 	case err != nil && errors.As(err, &ak):
 		if ak.Key != "" {
 			add("auth", "signin", docOK, fmt.Sprintf("signed in with API key (profile %q)", ak.Profile), "")
+			return doctorStoreAuth{apiKeyProfile: ak.Profile, apiKeyReady: true}
 		} else {
 			add("auth", "signin", docWarn, fmt.Sprintf("profile %q uses API key auth but the key is not readable", ak.Profile),
 				"check the keyring or auth.json, or run 'baseten auth login'")
 		}
-		return
+		return doctorStoreAuth{apiKeyProfile: ak.Profile}
 	case err != nil:
 		add("auth", "signin", docWarn, fmt.Sprintf("credential store unreadable: %v", err), "baseten auth login")
-		return
+		return doctorStoreAuth{}
 	case tok != nil:
 		if !tok.Expiry.IsZero() && tok.Expiry.Before(time.Now()) {
 			add("auth", "signin", docWarn,
@@ -433,7 +440,7 @@ func doctorAuthCheck(add addCheck, f *config.File, unresolved []string, envFile 
 		} else {
 			add("auth", "signin", docOK, "signed in (OAuth)", "")
 		}
-		return
+		return doctorStoreAuth{}
 	}
 
 	// Not signed in. BASETEN_API_KEY (env or env file) still counts as
@@ -444,22 +451,23 @@ func doctorAuthCheck(add addCheck, f *config.File, unresolved []string, envFile 
 	}
 	if apiKey != "" {
 		add("auth", "signin", docOK, "no OAuth sign-in, but BASETEN_API_KEY is set (API key fallback)", "")
-		return
+		return doctorStoreAuth{}
 	}
 	bothFixes := fmt.Sprintf("baseten auth login   (or set the key in %s)", envFilePath)
 	if authVars := doctorAuthPlaceholders(f, unresolved); len(authVars) > 0 {
 		add("auth", "signin", docFail,
 			fmt.Sprintf("not signed in (no OAuth, no API key) and gateway.yaml references ${%s} which is unset; baseten-routed requests have no credential", strings.Join(authVars, "}, ${")),
 			fmt.Sprintf("baseten auth login   (or set %s=... in %s)", authVars[0], envFilePath))
-		return
+		return doctorStoreAuth{}
 	}
 	if names := doctorBasetenRouted(f); len(names) > 0 {
 		add("auth", "signin", docFail,
 			"not signed in (no OAuth, no API key); these clients route to baseten and their requests will fail: "+strings.Join(names, ", "),
 			bothFixes)
-		return
+		return doctorStoreAuth{}
 	}
 	add("auth", "signin", docWarn, "not signed in (no enabled client routes to baseten, so nothing breaks yet)", "baseten auth login")
+	return doctorStoreAuth{}
 }
 
 // doctorAuthHealthCheck reads the running router's credential health
@@ -467,7 +475,7 @@ func doctorAuthCheck(add addCheck, f *config.File, unresolved []string, envFile 
 // outcomes). The store-based signin check above cannot detect a dead
 // refresh token: the credential is present, but the token endpoint rejects
 // it. The current admin contract requires the health field.
-func doctorAuthHealthCheck(add addCheck, adminAddr string, routerUp bool) {
+func doctorAuthHealthCheck(add addCheck, adminAddr string, routerUp bool, store doctorStoreAuth) {
 	if !routerUp {
 		add("auth", "health", docSkip, "router not up; credential health is derived from the running router's refresh outcomes", "")
 		return
@@ -497,6 +505,13 @@ func doctorAuthHealthCheck(add addCheck, adminAddr string, routerUp bool) {
 	// the report, or flood the terminal.
 	lastErr := sanitizeAdminText(payload["last_refresh_error"], 200)
 	lastErrAt := sanitizeAdminText(payload["last_refresh_error_at"], 40)
+	routerSignedIn, _ := payload["signed_in"].(bool)
+	if store.apiKeyReady && (!routerSignedIn || health == "signed_out") {
+		add("auth", "health", docFail,
+			fmt.Sprintf("the credential store has readable API-key profile %q, but the running router reports signed out", store.apiKeyProfile),
+			"baseten-switch up   (adopt the current router binary and reload the selected profile)")
+		return
+	}
 	switch health {
 	case "refresh_failed":
 		detail := ""
@@ -1477,10 +1492,19 @@ func doctorE2EChecks(add addCheck, o doctorOpts, doorSpecs []door.Config, doorUp
 				fmt.Sprintf("1-token request through the door succeeded (status %d, %dms, model %s)", p.Status, p.LatencyMs, orDash(p.Model)), "")
 		} else {
 			add("e2e", "probe:"+port, docFail,
-				fmt.Sprintf("1-token request through the door failed (status %d): %s", p.Status, orDash(p.Error)),
+				fmt.Sprintf("1-token request through the door failed (status %d%s): %s", p.Status, doctorProbeViaSuffix(p.DoorVia), orDash(p.Error)),
 				"baseten-switch status   (then check the router and door logs)")
 		}
 		doctorProbeRouteCheck(add, port, p, probeStart, f, routerTargets[t.BindAddr], t.ProtocolShape, telPath)
+	}
+}
+
+func doctorProbeViaSuffix(via string) string {
+	switch via {
+	case "router", "fallback":
+		return ", served via " + via
+	default:
+		return ""
 	}
 }
 
@@ -1497,10 +1521,6 @@ func doctorE2EChecks(add addCheck, o doctorOpts, doorSpecs []door.Config, doorUp
 // X-Baseten-Switch-Door stamp so the probe can be attributed safely.
 func doctorProbeRouteCheck(add addCheck, port string, p *doctorProbeResult, probeStart time.Time, f *config.File, routerTarget, shape, telPath string) {
 	name := "route:" + port
-	if !doctorProbeOK(p) {
-		add("e2e", name, docSkip, "probe failed; no served route to compare", "")
-		return
-	}
 	cli, ok := doctorClientFor(f, routerTarget, shape)
 	if !ok {
 		add("e2e", name, docSkip, "cannot resolve the configured client for door target "+routerTarget+" (see config section)", "")
@@ -1514,12 +1534,20 @@ func doctorProbeRouteCheck(add addCheck, port string, p *doctorProbeResult, prob
 	probeModel := doctorProbeRequestModel(shape)
 	expected := gateway.ExpectedPrimaryRoute(cli, globalRoutingEnabled, probeModel)
 	if p.DoorVia == "fallback" {
+		outcome := "the probe passed"
+		if !doctorProbeOK(p) {
+			outcome = fmt.Sprintf("the probe failed with status %d", p.Status)
+		}
 		add("e2e", name, docFail,
-			fmt.Sprintf("the probe passed but the door's native failover served it (X-Baseten-Switch-Door: fallback), not the configured route %q; the %s path is broken behind a passing probe", configured, configured),
+			fmt.Sprintf("%s, and the door's native failover served it (X-Baseten-Switch-Door: fallback), not the configured route %q", outcome, configured),
 			"baseten-switch status   (the door tripped; check the router and the auth/health check)")
 		return
 	}
 	if p.DoorVia != "router" {
+		if !doctorProbeOK(p) && p.Status == 0 {
+			add("e2e", name, docSkip, "the failed probe returned no HTTP response; no served route can be attributed", "")
+			return
+		}
 		add("e2e", name, docFail,
 			"the door response omitted the required X-Baseten-Switch-Door routing stamp",
 			"baseten-switch up   (restart the door onto the current binary)")
@@ -1535,9 +1563,21 @@ func doctorProbeRouteCheck(add addCheck, port string, p *doctorProbeResult, prob
 		served = row.ConfiguredRoute
 	}
 	if served != expected {
+		trigger := doctorFallbackTrigger(row)
+		if !doctorProbeOK(p) {
+			add("e2e", name, docFail,
+				fmt.Sprintf("the failed probe reached route %q while the configured route is %q%s", served, expected, trigger),
+				"check the router log "+gatewayLogPath()+" and the auth/health check; the primary upstream is failing")
+			return
+		}
 		add("e2e", name, docFail,
-			fmt.Sprintf("the probe passed but route %q served it while the configured route is %q (the router's fallback_route kicked in); the %s path is broken behind a passing probe", served, expected, expected),
+			fmt.Sprintf("the probe passed but route %q served it while the configured route is %q%s; the %s path is broken behind a passing probe", served, expected, trigger, expected),
 			"check the router log "+gatewayLogPath()+" and the auth/health check; the primary upstream is failing")
+		return
+	}
+	if !doctorProbeOK(p) {
+		add("e2e", name, docOK,
+			fmt.Sprintf("the failed probe reached the configured route (%s), status %d%s", expected, p.Status, doctorFallbackTrigger(row)), "")
 		return
 	}
 	if expected != configured {
@@ -1546,6 +1586,17 @@ func doctorProbeRouteCheck(add addCheck, port string, p *doctorProbeResult, prob
 		return
 	}
 	add("e2e", name, docOK, fmt.Sprintf("served route matches the configured route (%s)", configured), "")
+}
+
+func doctorFallbackTrigger(row telemetry.EventV1) string {
+	if row.Fallback.Trigger == nil {
+		return ""
+	}
+	trigger := sanitizeAdminText(*row.Fallback.Trigger, 80)
+	if trigger == "" {
+		return ""
+	}
+	return " (fallback trigger " + strconv.Quote(trigger) + ")"
 }
 
 // doctorClientFor picks the enabled client the probe exercised: same

--- a/gateway/cmd/baseten-switch/doctor_test.go
+++ b/gateway/cmd/baseten-switch/doctor_test.go
@@ -66,6 +66,11 @@ type doctorFixtureCfg struct {
 	// authHealth sets the health field the fake admin serves at
 	// /v1/admin/auth/status ("-" omits the required field).
 	authHealth string
+	// apiKeyProfile makes the selected local profile a readable API-key
+	// profile. routerSignedOut independently models a stale router that has
+	// not loaded that credential.
+	apiKeyProfile   bool
+	routerSignedOut bool
 	// authLastError sets last_refresh_error alongside authHealth.
 	authLastError string
 	// basetenVersions writes one fake baseten CLI per entry (each in
@@ -85,8 +90,11 @@ type doctorFixtureCfg struct {
 	// client, requested model, and status), emulating the router's
 	// write. Empty probeTelRoute = no row (door-fallback case, or the
 	// no-row skip case).
-	probeTelRoute     string
-	probeTelEffective string
+	probeTelRoute        string
+	probeTelEffective    string
+	probeFallbackTrigger string
+	probeStatus          int
+	probeError           string
 	// probeConcurrentModel, when non-empty, makes the fake door append a
 	// second v1 event AFTER the probe's event: a concurrent harness
 	// request completing just behind the probe, the misattribution
@@ -228,7 +236,8 @@ func newDoctorFixture(t *testing.T, mut func(*doctorFixtureCfg)) *doctorFixture 
 				healthPart = fmt.Sprintf(`"health":%q,"last_refresh_error":%s,"last_refresh_error_at":"2026-07-13T09:55:00Z",`,
 					cfg.authHealth, errJSON)
 			}
-			fmt.Fprintf(w, `{"signed_in":true,%s"profile":"doc","fallback_enabled":false,"fallback_in_use":false,"email":"doc@example.com"}`, healthPart)
+			signedIn := !cfg.routerSignedOut
+			fmt.Fprintf(w, `{"signed_in":%t,%s"profile":"doc","fallback_enabled":false,"fallback_in_use":false,"email":"doc@example.com"}`, signedIn, healthPart)
 		})
 		srv := httptest.NewServer(mux)
 		t.Cleanup(srv.Close)
@@ -254,18 +263,27 @@ func newDoctorFixture(t *testing.T, mut func(*doctorFixtureCfg)) *doctorFixture 
 			if cfg.doorProbe != "" && r.Method == http.MethodPost && r.URL.Path == "/v1/messages" {
 				// Emulate the router's telemetry write for the probe,
 				// then answer with the door's serving marker header.
+				probeStatus := cfg.probeStatus
+				if probeStatus == 0 {
+					probeStatus = http.StatusOK
+				}
 				if cfg.probeTelRoute != "" {
 					completedAt := time.Now()
-					events := []telemetry.EventV1{doctorTestTelemetryEvent(
+					probeEvent := doctorTestTelemetryEvent(
 						completedAt,
 						1,
 						"claude-code",
 						cfg.probeTelRoute,
 						cfg.probeTelEffective,
 						doctorProbeRequestModel("anthropic"),
-						http.StatusOK,
+						probeStatus,
 						false,
-					)}
+					)
+					if cfg.probeFallbackTrigger != "" {
+						trigger := cfg.probeFallbackTrigger
+						probeEvent.Fallback = telemetry.FallbackV1{Attempted: true, Count: 1, Trigger: &trigger}
+					}
+					events := []telemetry.EventV1{probeEvent}
 					if cfg.probeConcurrentModel != "" {
 						events = append(events, doctorTestTelemetryEvent(
 							completedAt.Add(time.Nanosecond),
@@ -286,7 +304,12 @@ func newDoctorFixture(t *testing.T, mut func(*doctorFixtureCfg)) *doctorFixture 
 					w.Header().Set("X-Baseten-Switch-Door", cfg.doorProbe)
 				}
 				w.Header().Set("Content-Type", "application/json")
-				fmt.Fprint(w, `{"model":"probe-model"}`)
+				w.WriteHeader(probeStatus)
+				if probeStatus >= http.StatusBadRequest {
+					fmt.Fprint(w, cfg.probeError)
+				} else {
+					fmt.Fprint(w, `{"model":"probe-model"}`)
+				}
 				return
 			}
 			http.NotFound(w, r)
@@ -387,7 +410,19 @@ func newDoctorFixture(t *testing.T, mut func(*doctorFixtureCfg)) *doctorFixture 
 	}
 
 	// Auth store.
-	if cfg.signedIn {
+	if cfg.apiKeyProfile {
+		writeAuthJSON(t, `{
+  "version": 1,
+  "current": "example-profile",
+  "profiles": {
+    "example-profile": {
+      "remote_url": "https://api.example.com",
+      "auth_type": "api_key",
+      "api_key": "synthetic-doctor-key"
+    }
+  }
+}`)
+	} else if cfg.signedIn {
 		expiry := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
 		writeAuthJSON(t, fmt.Sprintf(`{
   "version": 1,
@@ -1319,6 +1354,25 @@ func TestDoctorUnresolvedAPIKeyNoOAuth(t *testing.T) {
 	}
 }
 
+func TestDoctorReadableAPIKeyProfileRouterSignedOutFails(t *testing.T) {
+	newDoctorFixture(t, func(c *doctorFixtureCfg) {
+		c.apiKeyProfile = true
+		c.routerSignedOut = true
+		c.authHealth = "signed_out"
+	})
+	rep := runDoctor(doctorOpts{})
+	if c := findCheck(t, rep, "auth", "signin"); c.Status != docOK || !strings.Contains(c.Finding, "API key") {
+		t.Fatalf("signin = %+v, want readable API-key profile", c)
+	}
+	c := findCheck(t, rep, "auth", "health")
+	if c.Status != docFail || !strings.Contains(c.Finding, "example-profile") || !strings.Contains(c.Finding, "router reports signed out") {
+		t.Fatalf("health = %+v, want profile/router inconsistency failure", c)
+	}
+	if rep.FirstFailure != "auth/health" {
+		t.Fatalf("first failure = %q, want auth/health", rep.FirstFailure)
+	}
+}
+
 func TestDoctorJSONShape(t *testing.T) {
 	newDoctorFixture(t, func(c *doctorFixtureCfg) {
 		c.settingsJSON = `{"permissions":{}}`
@@ -1984,6 +2038,62 @@ func TestDoctorProbeDoorFallbackFails(t *testing.T) {
 	}
 	if rep.ExitCode != 1 {
 		t.Errorf("exit = %d, want 1 (a fallback-served probe must fail the chain)", rep.ExitCode)
+	}
+}
+
+func TestDoctorFailedProbeNamesDoorFallback(t *testing.T) {
+	fx := newDoctorFixture(t, func(c *doctorFixtureCfg) {
+		c.doorProbe = "fallback"
+		c.probeStatus = http.StatusUnauthorized
+		c.probeError = `{"type":"error","error":{"message":"x-api-key header is required"}}`
+	})
+	rep := runDoctor(doctorOpts{probe: true, yes: true, timeoutSec: 5})
+	probe := findCheck(t, rep, "e2e", "probe:"+fx.doorPort)
+	if probe.Status != docFail || !strings.Contains(probe.Finding, "status 401, served via fallback") {
+		t.Fatalf("probe = %+v, want failed fallback attribution", probe)
+	}
+	routeCheck := findCheck(t, rep, "e2e", "route:"+fx.doorPort)
+	if routeCheck.Status != docFail || !strings.Contains(routeCheck.Finding, "native failover served it") || !strings.Contains(routeCheck.Finding, `"baseten"`) {
+		t.Fatalf("route = %+v, want configured-versus-fallback attribution", routeCheck)
+	}
+}
+
+func TestDoctorFailedProbeUsesRouterTelemetry(t *testing.T) {
+	fx := newDoctorFixture(t, func(c *doctorFixtureCfg) {
+		c.doorProbe = "router"
+		c.probeStatus = http.StatusServiceUnavailable
+		c.probeError = `{"error":"synthetic upstream failure"}`
+		c.probeTelRoute = "baseten"
+		c.probeTelEffective = "anthropic"
+		c.probeFallbackTrigger = "http_503\nunsafe-detail"
+	})
+	rep := runDoctor(doctorOpts{probe: true, yes: true, timeoutSec: 5})
+	probe := findCheck(t, rep, "e2e", "probe:"+fx.doorPort)
+	if probe.Status != docFail || !strings.Contains(probe.Finding, "status 503, served via router") {
+		t.Fatalf("probe = %+v, want failed router attribution", probe)
+	}
+	routeCheck := findCheck(t, rep, "e2e", "route:"+fx.doorPort)
+	for _, want := range []string{`route "anthropic"`, `configured route is "baseten"`, `fallback trigger "http_503 unsafe-detail"`} {
+		if routeCheck.Status != docFail || !strings.Contains(routeCheck.Finding, want) {
+			t.Fatalf("route = %+v, want safe telemetry detail %q", routeCheck, want)
+		}
+	}
+	if strings.Contains(routeCheck.Finding, "\n") {
+		t.Fatalf("route finding contains unsafe newline: %q", routeCheck.Finding)
+	}
+}
+
+func TestDoctorFailedProbeReachedConfiguredRoute(t *testing.T) {
+	fx := newDoctorFixture(t, func(c *doctorFixtureCfg) {
+		c.doorProbe = "router"
+		c.probeStatus = http.StatusUnauthorized
+		c.probeError = `{"error":"credential rejected"}`
+		c.probeTelRoute = "baseten"
+	})
+	rep := runDoctor(doctorOpts{probe: true, yes: true, timeoutSec: 5})
+	routeCheck := findCheck(t, rep, "e2e", "route:"+fx.doorPort)
+	if routeCheck.Status != docOK || !strings.Contains(routeCheck.Finding, "failed probe reached the configured route (baseten), status 401") {
+		t.Fatalf("route = %+v, want successful attribution of failed probe", routeCheck)
 	}
 }
 

--- a/gateway/cmd/baseten-switch/lifecycle.go
+++ b/gateway/cmd/baseten-switch/lifecycle.go
@@ -863,6 +863,8 @@ func authLine(adminAddr string, routerUp bool) string {
 	}
 	var a struct {
 		SignedIn       bool   `json:"signed_in"`
+		AuthType       string `json:"auth_type"`
+		Profile        string `json:"profile"`
 		Email          string `json:"email"`
 		FallbackInUse  bool   `json:"fallback_in_use"`
 		FallbackEnable bool   `json:"fallback_enabled"`
@@ -871,12 +873,19 @@ func authLine(adminAddr string, routerUp bool) string {
 		return fmt.Sprintf("unknown (auth status unavailable: %v)", err)
 	}
 	switch {
+	case a.SignedIn && a.AuthType == "api_key" && a.Profile != "":
+		return a.Profile + " API key"
+	case a.SignedIn && a.AuthType == "api_key":
+		return "API key"
+	case a.SignedIn && a.Profile != "":
+		return a.Profile + " OAuth"
 	case a.SignedIn && a.Email != "":
-		return fmt.Sprintf("signed in (OAuth, %s)", a.Email)
+		return a.Email + " OAuth"
 	case a.SignedIn:
-		return "signed in (OAuth)"
+		// Routers predating auth_type only supported OAuth profiles.
+		return "OAuth"
 	case a.FallbackInUse:
-		return "API key fallback in use (no OAuth sign-in)"
+		return "API-key fallback in use"
 	default:
 		return "not signed in (run 'baseten auth login')"
 	}

--- a/gateway/cmd/baseten-switch/lifecycle_test.go
+++ b/gateway/cmd/baseten-switch/lifecycle_test.go
@@ -245,7 +245,7 @@ func TestPrintStatusExitCodes(t *testing.T) {
 			0,
 			[]string{"Router:  up", "claude-code", "switch ON", "codex", "switch OFF",
 				"Door:    up", "not tripped", "3 fallback rules",
-				"Auth:    signed in (OAuth, user@example.com)"},
+				"Auth:    user@example.com OAuth"},
 		},
 		{
 			"router down",
@@ -292,6 +292,32 @@ func TestPrintStatusExitCodes(t *testing.T) {
 			}
 			if strings.Contains(buf.String(), "parked") {
 				t.Fatalf("disabled client rendered:\n%s", buf.String())
+			}
+		})
+	}
+}
+
+func TestAuthLineCredentialLabels(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		want    string
+	}{
+		{"oauth profile", `{"signed_in":true,"auth_type":"oauth","profile":"example-profile"}`, "example-profile OAuth"},
+		{"api key profile", `{"signed_in":true,"auth_type":"api_key","profile":"example-profile"}`, "example-profile API key"},
+		{"environment fallback", `{"signed_in":false,"auth_type":"api_key","fallback_in_use":true}`, "API-key fallback in use"},
+		{"signed out", `{"signed_in":false,"auth_type":"none"}`, "not signed in"},
+		{"older router defaults to oauth", `{"signed_in":true,"profile":"example-profile"}`, "example-profile OAuth"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, tc.payload)
+			}))
+			defer srv.Close()
+			got := authLine(hostPort(t, srv.URL), true)
+			if !strings.Contains(got, tc.want) {
+				t.Fatalf("authLine() = %q, want it to contain %q", got, tc.want)
 			}
 		})
 	}

--- a/gateway/cmd/gateway/admin.go
+++ b/gateway/cmd/gateway/admin.go
@@ -551,7 +551,7 @@ func (g *Gateway) adminStatus(w http.ResponseWriter, r *http.Request) {
 			globalEnabled = *state.file.Global.RoutingEnabled
 		}
 	}
-	signedIn, fallbackInUse := g.authState()
+	signedIn, authType, fallbackInUse := g.authState()
 	ah := g.authHealth()
 	writeJSON(w, 200, map[string]any{
 		"router_pid":          os.Getpid(),
@@ -579,6 +579,7 @@ func (g *Gateway) adminStatus(w http.ResponseWriter, r *http.Request) {
 		"model_catalog": g.modelCatalogHealthJSON(),
 		"auth": map[string]any{
 			"signed_in":             signedIn,
+			"auth_type":             authType,
 			"health":                ah.Health,
 			"last_refresh_error":    ah.LastError,
 			"last_refresh_error_at": rfc3339OrEmpty(ah.LastErrorAt),

--- a/gateway/cmd/gateway/admin_model_catalog.go
+++ b/gateway/cmd/gateway/admin_model_catalog.go
@@ -25,10 +25,12 @@ const (
 	modelCatalogMaxBody                       = 8 << 20
 	modelCatalogSignedOutReasonNotSignedIn    = "not_signed_in"
 	modelCatalogSignedOutReasonSessionExpired = "session_expired"
+	modelCatalogSignedOutReasonRejected       = "credential_rejected"
 	basetenModelAPIsAvailabilitySource        = "baseten_model_apis"
 )
 
 var errModelCatalogUnauthorized = errors.New("model catalog authorization rejected")
+var errModelCatalogForbidden = errors.New("model catalog access denied")
 var modelCatalogNow = time.Now
 
 type modelCatalogResponse struct {
@@ -61,12 +63,10 @@ func (g *Gateway) adminModelCatalog(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// The live catalog belongs to the signed-in OAuth session. Do not use
-	// basetenAuthClient here because it can silently fall back to an API key.
-	g.authMu.Lock()
-	client := g.oauthClient
-	g.authMu.Unlock()
-	if client == nil {
+	// The live catalog belongs to the selected Baseten CLI profile. The
+	// environment fallback is intentionally excluded from this account view.
+	selected, ok := g.basetenProfileAuth()
+	if !ok {
 		writeModelCatalogJSON(w, r.Method, modelCatalogResponse{
 			State:           "signed_out",
 			SignedOutReason: modelCatalogSignedOutReasonNotSignedIn,
@@ -77,13 +77,25 @@ func (g *Gateway) adminModelCatalog(w http.ResponseWriter, r *http.Request) {
 
 	ctx, cancel := context.WithTimeout(r.Context(), modelCatalogTimeout)
 	defer cancel()
-	models, err := g.fetchModelCatalog(ctx, client)
+	models, err := g.fetchModelCatalog(ctx, selected.client, selected.authorization())
 	if err != nil {
 		if errors.Is(err, errModelCatalogUnauthorized) {
+			reason := modelCatalogSignedOutReasonSessionExpired
+			if selected.source == basetenAuthProfileAPIKey {
+				reason = modelCatalogSignedOutReasonRejected
+			}
 			writeModelCatalogJSON(w, r.Method, modelCatalogResponse{
 				State:           "signed_out",
-				SignedOutReason: modelCatalogSignedOutReasonSessionExpired,
+				SignedOutReason: reason,
 				Models:          []modelCatalogModel{},
+			})
+			return
+		}
+		if errors.Is(err, errModelCatalogForbidden) {
+			writeModelCatalogJSON(w, r.Method, modelCatalogResponse{
+				State:  "error",
+				Models: []modelCatalogModel{},
+				Error:  "The selected Baseten credential does not have access to the model catalog",
 			})
 			return
 		}
@@ -232,7 +244,7 @@ func writeModelCatalogJSON(w http.ResponseWriter, method string, response modelC
 	}
 }
 
-func (g *Gateway) fetchModelCatalog(ctx context.Context, client *http.Client) ([]modelCatalogModel, error) {
+func (g *Gateway) fetchModelCatalog(ctx context.Context, client *http.Client, authorization string) ([]modelCatalogModel, error) {
 	endpoint, err := modelCatalogEndpoint(g.runtimeConfig().OAuthHost)
 	if err != nil {
 		return nil, err
@@ -252,6 +264,9 @@ func (g *Gateway) fetchModelCatalog(ctx context.Context, client *http.Client) ([
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, pageURL.String(), nil)
 		if err != nil {
 			return nil, fmt.Errorf("build model catalog request: %w", err)
+		}
+		if authorization != "" {
+			req.Header.Set("Authorization", authorization)
 		}
 		resp, err := client.Do(req)
 		if err != nil {
@@ -314,6 +329,9 @@ func readModelCatalogBody(resp *http.Response) ([]byte, error) {
 	}
 	if resp.StatusCode == http.StatusUnauthorized {
 		return nil, errModelCatalogUnauthorized
+	}
+	if resp.StatusCode == http.StatusForbidden {
+		return nil, errModelCatalogForbidden
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return nil, fmt.Errorf("model catalog upstream returned a non-success status")

--- a/gateway/cmd/gateway/admin_model_catalog_test.go
+++ b/gateway/cmd/gateway/admin_model_catalog_test.go
@@ -469,6 +469,71 @@ func TestAdminModelCatalogSignedOutDoesNotUseAPIKeyFallback(t *testing.T) {
 	}
 }
 
+func TestAdminModelCatalogUsesSelectedAPIKeyProfile(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Api-Key selected-profile-key" {
+			t.Fatalf("Authorization = %q, want selected API-key profile", got)
+		}
+		_, _ = io.WriteString(w, `{"items":[{"name":"example/model","display_name":"Example"}],"pagination":{"has_more":false,"cursor":null}}`)
+	}))
+	defer upstream.Close()
+
+	g := &Gateway{
+		cfg: Config{
+			OAuthHost:      upstream.URL,
+			BasetenKey:     "environment-fallback-must-not-win",
+			APIKeyFallback: true,
+		},
+		client:           upstream.Client(),
+		pricing:          pricing.New(),
+		cliProfileAPIKey: "selected-profile-key",
+	}
+	mux := http.NewServeMux()
+	g.registerAdmin(mux)
+	g.adminServer = &http.Server{Handler: mux}
+
+	recorder, response := modelCatalogRequest(t, g, http.MethodGet, nil)
+	if recorder.Code != http.StatusOK || response.State != "ready" || len(response.Models) != 1 {
+		t.Fatalf("status = %d response = %+v, want ready catalog", recorder.Code, response)
+	}
+}
+
+func TestAdminModelCatalogAPIKeyAuthorizationOutcomes(t *testing.T) {
+	for _, test := range []struct {
+		status int
+		state  string
+		reason string
+		error  string
+	}{
+		{http.StatusUnauthorized, "signed_out", modelCatalogSignedOutReasonRejected, ""},
+		{http.StatusForbidden, "error", "", "The selected Baseten credential does not have access to the model catalog"},
+	} {
+		t.Run(http.StatusText(test.status), func(t *testing.T) {
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "synthetic upstream secret", test.status)
+			}))
+			defer upstream.Close()
+			g := &Gateway{
+				cfg:              Config{OAuthHost: upstream.URL},
+				client:           upstream.Client(),
+				pricing:          pricing.New(),
+				cliProfileAPIKey: "selected-profile-key",
+			}
+			mux := http.NewServeMux()
+			g.registerAdmin(mux)
+			g.adminServer = &http.Server{Handler: mux}
+
+			recorder, response := modelCatalogRequest(t, g, http.MethodGet, nil)
+			if response.State != test.state || response.SignedOutReason != test.reason || response.Error != test.error {
+				t.Fatalf("response = %+v", response)
+			}
+			if strings.Contains(recorder.Body.String(), "synthetic upstream secret") || strings.Contains(recorder.Body.String(), "selected-profile-key") {
+				t.Fatal("catalog response leaked credential or upstream body")
+			}
+		})
+	}
+}
+
 func TestAdminModelCatalogUnauthorizedMeansExpiredSession(t *testing.T) {
 	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "token=upstream-secret", http.StatusUnauthorized)
@@ -645,7 +710,13 @@ func TestAdminModelCatalogSanitizesUpstreamFailures(t *testing.T) {
 			if response.State != "error" {
 				t.Fatalf("response = %+v, want error", response)
 			}
-			assertEmptyModelCatalogError(t, response)
+			if tt.name == "non-success response" {
+				if response.Error != "The selected Baseten credential does not have access to the model catalog" {
+					t.Fatalf("error = %q, want stable access-denied guidance", response.Error)
+				}
+			} else {
+				assertEmptyModelCatalogError(t, response)
+			}
 			if containsAny(recorder.Body.String(), "upstream-secret", "token=", "401") {
 				t.Fatalf("response leaked upstream details: %s", recorder.Body.String())
 			}

--- a/gateway/cmd/gateway/auth_admin.go
+++ b/gateway/cmd/gateway/auth_admin.go
@@ -17,12 +17,13 @@ func (g *Gateway) handleAuthStatus(w http.ResponseWriter, r *http.Request) {
 		g.reject(w, 405, "method not allowed")
 		return
 	}
-	signedIn, fallbackInUse := g.authState()
+	signedIn, authType, fallbackInUse := g.authState()
 	email, expiresAt := g.authEmailAndExpiry()
 	ah := g.authHealth()
 	cfg := g.runtimeConfig()
 	writeJSON(w, 200, map[string]any{
 		"signed_in":             signedIn,
+		"auth_type":             authType,
 		"health":                ah.Health,
 		"last_refresh_error":    ah.LastError,
 		"last_refresh_error_at": rfc3339OrEmpty(ah.LastErrorAt),

--- a/gateway/cmd/gateway/auth_health_test.go
+++ b/gateway/cmd/gateway/auth_health_test.go
@@ -87,6 +87,28 @@ func writeOAuthProfileExpiry(t *testing.T, remoteURL, refreshToken string, expir
 	}
 }
 
+func writeAPIKeyProfile(t *testing.T, apiKey string) {
+	t.Helper()
+	path := os.Getenv("BASETEN_SWITCH_AUTH_FILE")
+	if path == "" {
+		t.Fatal("BASETEN_SWITCH_AUTH_FILE not set (call testConfig first)")
+	}
+	blob := fmt.Sprintf(`{
+  "version": 1,
+  "current": "p",
+  "profiles": {
+    "p": {
+      "remote_url": "https://app.baseten.co",
+      "auth_type": "api_key",
+      "api_key": %q
+    }
+  }
+}`, apiKey)
+	if err := os.WriteFile(path, []byte(blob), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func adminAuthBlock(t *testing.T, g *Gateway) map[string]any {
 	t.Helper()
 	resp, err := http.Get(adminURL(g, "/v1/admin/status"))

--- a/gateway/cmd/gateway/auth_tick_test.go
+++ b/gateway/cmd/gateway/auth_tick_test.go
@@ -12,11 +12,13 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
 
 	"github.com/basetenlabs/baseten-switch/gateway/internal/auth"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/proxy"
 
 	"golang.org/x/oauth2"
 	"time"
@@ -426,4 +428,66 @@ func TestAuthTickSignedOutWatchesForFirstLogin(t *testing.T) {
 	if auth := adminAuthBlock(t, g); auth["signed_in"] != true {
 		t.Fatalf("signed_in = %v after first login, want true", auth["signed_in"])
 	}
+}
+
+func TestAuthTickAPIKeyCredentialTransitions(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer upstream.Close()
+	tokenSrv := newDeadTokenServer(t)
+	tokenSrv.dead.Store(false)
+
+	cfg := testConfig(t, upstream.URL, upstream.URL)
+	cfg.BasetenKey = ""
+	cfg.APIKeyFallback = false
+	cfg.OAuthProfile = "p"
+
+	assertSelection := func(t *testing.T, g *Gateway, wantMode proxy.UpstreamAuthMode, wantKey string, wantOK bool) {
+		t.Helper()
+		mode, key, _, ok := g.buildUpstreamClient("baseten")
+		if ok != wantOK || (ok && (mode != wantMode || key != wantKey)) {
+			t.Fatalf("auth selection = (%v, %q, %t), want (%v, %q, %t)", mode, key, ok, wantMode, wantKey, wantOK)
+		}
+	}
+
+	t.Run("first login unreadable recovery rotation and logout", func(t *testing.T) {
+		g, adminL, _ := newGateway(t, cfg, resolvedAnthropicBaseten(t))
+		defer adminL.Close()
+		assertSelection(t, g, 0, "", false)
+
+		writeAPIKeyProfile(t, "")
+		g.authTickOnce()
+		assertSelection(t, g, 0, "", false)
+
+		writeAPIKeyProfile(t, "api-key-one")
+		g.authTickOnce()
+		assertSelection(t, g, proxy.UpstreamModeAPIKey, "api-key-one", true)
+
+		writeAPIKeyProfile(t, "api-key-two")
+		g.authTickOnce()
+		assertSelection(t, g, proxy.UpstreamModeAPIKey, "api-key-two", true)
+
+		if err := os.Remove(os.Getenv("BASETEN_SWITCH_AUTH_FILE")); err != nil {
+			t.Fatal(err)
+		}
+		g.authTickOnce()
+		assertSelection(t, g, 0, "", false)
+		if signedIn, authType, _ := g.authState(); signedIn || authType != "none" {
+			t.Fatalf("auth after logout = signed_in %t auth_type %q", signedIn, authType)
+		}
+	})
+
+	t.Run("OAuth to API key and back", func(t *testing.T) {
+		writeOAuthProfileExpiry(t, tokenSrv.srv.URL, "oauth-one", time.Now().Add(time.Hour))
+		g, adminL, _ := newGateway(t, cfg, resolvedAnthropicBaseten(t))
+		defer adminL.Close()
+		assertSelection(t, g, proxy.UpstreamModeOAuth, "", true)
+
+		writeAPIKeyProfile(t, "api-key-replacement")
+		g.authTickOnce()
+		assertSelection(t, g, proxy.UpstreamModeAPIKey, "api-key-replacement", true)
+
+		writeOAuthProfileExpiry(t, tokenSrv.srv.URL, "oauth-two", time.Now().Add(time.Hour))
+		g.authTickOnce()
+		assertSelection(t, g, proxy.UpstreamModeOAuth, "", true)
+	})
 }

--- a/gateway/cmd/gateway/gateway.go
+++ b/gateway/cmd/gateway/gateway.go
@@ -513,6 +513,10 @@ type Gateway struct {
 	// Shared auth state across all baseten-routed listeners.
 	oauthClient     *http.Client
 	oauthProfileErr error
+	// cliProfileAPIKey is the key from the selected Baseten CLI api_key
+	// profile. It is profile auth, not the separately enabled environment
+	// fallback. Guarded by authMu.
+	cliProfileAPIKey string
 	// Credential-health state (all guarded by authMu). signed_in has
 	// always meant "a credential exists in the store"; these fields
 	// track whether that credential actually WORKS, fed by
@@ -534,6 +538,10 @@ type Gateway struct {
 	// later death must be recorded against the token that actually died.
 	authCredFP string
 	authDeadFP string // authCredFP at the moment the credential went dead
+	// authStoreFP fingerprints the selected CLI credential and its auth type.
+	// It is compared in memory to detect profile switches, key rotation, login,
+	// logout, and OAuth/API-key transitions without retaining another secret.
+	authStoreFP string
 	// authGen counts client builds. Refresh outcomes carry the
 	// generation they were built under; a refresh in flight across a
 	// refreshAuth swap must not mark the new credential dead (or heal
@@ -809,22 +817,36 @@ func (g *Gateway) refreshAuth() {
 	gen := g.authGen
 	notify := func(fp string, err error) { g.noteAuthRefresh(gen, fp, err) }
 	client, tick, credFP, err := auth.HTTPClientWithNotify(context.Background(), cfg.OAuthProfile, cfg.OAuthHost, notify)
+	g.cliProfileAPIKey = ""
+	g.authStoreFP = ""
 	switch {
 	case err == nil:
 		g.oauthClient = client
 		g.authTick = tick
 		g.oauthProfileErr = nil
+		g.authStoreFP = oauthStoreFingerprint(credFP)
 	case errors.Is(err, auth.ErrNotSignedIn):
 		g.oauthClient = nil
 		g.authTick = nil
 		g.oauthProfileErr = err
 	case errors.Is(err, auth.ErrAPIKeyProfile):
-		// The baseten CLI profile authenticates with an API key, not
-		// OAuth: a valid state, served via the API-key fallback path
-		// when configured, so no failure log.
+		// The selected Baseten CLI profile authenticates with an API key.
+		// This is first-class profile auth, independent of BASETEN_API_KEY.
 		g.oauthClient = nil
 		g.authTick = nil
 		g.oauthProfileErr = err
+		var apiKeyProfile *auth.APIKeyProfileError
+		if errors.As(err, &apiKeyProfile) {
+			g.cliProfileAPIKey = strings.TrimSpace(apiKeyProfile.Key)
+			g.authStoreFP = apiKeyStoreFingerprint(apiKeyProfile.Profile, g.cliProfileAPIKey)
+		}
+		// API-key profiles have no OAuth refresh lineage. Do not carry
+		// OAuth-only health state across a profile transition.
+		g.authDead = false
+		g.authDeadFP = ""
+		g.authLastErr = ""
+		g.authLastErrAt = time.Time{}
+		g.authLastOKAt = time.Time{}
 	default:
 		g.oauthClient = nil
 		g.authTick = nil
@@ -849,7 +871,7 @@ func (g *Gateway) refreshAuth() {
 		g.authLastErrAt = time.Time{}
 	}
 	fmt.Fprintf(os.Stderr, "[gateway] auth: profile=%s signed_in=%t health=%s fallback=%t\n",
-		cfg.OAuthProfile, g.oauthClient != nil, g.authHealthLocked(), cfg.APIKeyFallback)
+		cfg.OAuthProfile, g.oauthClient != nil || g.cliProfileAPIKey != "", g.authHealthLocked(), cfg.APIKeyFallback)
 	g.kickCatalogRefresh()
 }
 
@@ -910,13 +932,11 @@ func (g *Gateway) noteAuthRefresh(gen int, fp string, err error) {
 }
 
 // Background auth-tick cadences. Package vars so tests can shrink them.
-// The normal tick rides oauth2.ReuseTokenSource, so real refresh traffic
-// stays at roughly one token-endpoint round trip per access-token lifetime
-// (~1h) regardless of the tick rate. The dead cadence only re-reads the
-// local credential store (no network), so it can run much tighter to pick
-// up a re-login quickly.
+// Every tick first reads the local CLI store so direct profile changes
+// converge within 30 seconds. Healthy OAuth then rides oauth2.ReuseTokenSource,
+// so real refresh traffic remains bounded by the access-token lifetime.
 var (
-	authTickInterval     = 5 * time.Minute
+	authTickInterval     = 30 * time.Second
 	authTickDeadInterval = 30 * time.Second
 )
 
@@ -950,14 +970,14 @@ func (g *Gateway) runAuthTick(ctx context.Context) {
 	}
 }
 
-// authTickPeriod picks the wait before the next tick: tight while the
-// credential is dead or absent (the tick is then a local store read and
-// recovery latency is what the user feels after a login), relaxed
-// otherwise.
+// authTickPeriod remains split for tests and future tuning. Both production
+// values currently honor the same 30-second CLI-store convergence promise.
 func (g *Gateway) authTickPeriod() time.Duration {
 	g.authMu.Lock()
 	defer g.authMu.Unlock()
-	if g.authDead || errors.Is(g.oauthProfileErr, auth.ErrNotSignedIn) {
+	profileUnavailable := errors.Is(g.oauthProfileErr, auth.ErrNotSignedIn) ||
+		(errors.Is(g.oauthProfileErr, auth.ErrAPIKeyProfile) && g.cliProfileAPIKey == "")
+	if g.authDead || profileUnavailable {
 		return authTickDeadInterval
 	}
 	return authTickInterval
@@ -971,39 +991,20 @@ func (g *Gateway) authTickOnce() {
 	cfg := g.runtimeConfig()
 	g.authMu.Lock()
 	dead := g.authDead
-	deadFP := g.authDeadFP
 	tick := g.authTick
 	profile := cfg.OAuthProfile
-	signedOut := errors.Is(g.oauthProfileErr, auth.ErrNotSignedIn)
+	storeFP := g.authStoreFP
 	g.authMu.Unlock()
-	if dead {
-		// A dead credential never comes back on its own; replaying the
-		// refresh would only burn token-endpoint calls. Watch the store
-		// (local read, no network) for a refresh token that differs from
-		// the one that died: that is a re-login, so rebuild the client
-		// through the same path SIGHUP uses.
-		tok, _, err := auth.Load(profile)
-		if err != nil || tok == nil {
-			return
-		}
-		if auth.CredFingerprint(tok.RefreshToken) == deadFP {
-			return
-		}
-		fmt.Fprintf(os.Stderr, "[gateway] auth: stored credential changed after refresh failure; reloading credential (re-login detected, no SIGHUP needed)\n")
+
+	observedFP := selectedCredentialStoreFingerprint(profile)
+	if observedFP != storeFP {
+		fmt.Fprintf(os.Stderr, "[gateway] auth: selected CLI credential changed; reloading credential (no SIGHUP needed)\n")
 		g.refreshAuth()
 		return
 	}
-	if signedOut {
-		// A FIRST login is otherwise invisible: with no credential at
-		// boot there is no client and no tick to notice one appearing,
-		// and auth login's SIGHUP fallback promises the router picks it
-		// up on its own. Local store read, no network.
-		tok, _, err := auth.Load(profile)
-		if err != nil || tok == nil {
-			return
-		}
-		fmt.Fprintf(os.Stderr, "[gateway] auth: credential appeared in the store; loading it (login detected, no SIGHUP needed)\n")
-		g.refreshAuth()
+	if dead {
+		// A dead OAuth credential never recovers without a store change. Do
+		// not replay a rejected refresh grant on the store-watch cadence.
 		return
 	}
 	if tick == nil {
@@ -1015,6 +1016,35 @@ func (g *Gateway) authTickOnce() {
 	_ = tick()
 }
 
+func oauthStoreFingerprint(refreshTokenFingerprint string) string {
+	if refreshTokenFingerprint == "" {
+		return ""
+	}
+	return "oauth:" + refreshTokenFingerprint
+}
+
+func apiKeyStoreFingerprint(profile, apiKey string) string {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return ""
+	}
+	return "api_key:" + auth.CredFingerprint(profile+"\x00"+apiKey)
+}
+
+// selectedCredentialStoreFingerprint reads only the local CLI credential
+// store. Its output is compared in memory and is never logged or persisted.
+func selectedCredentialStoreFingerprint(profile string) string {
+	tok, _, err := auth.Load(profile)
+	if err == nil && tok != nil {
+		return oauthStoreFingerprint(auth.CredFingerprint(tok.RefreshToken))
+	}
+	var apiKeyProfile *auth.APIKeyProfileError
+	if errors.As(err, &apiKeyProfile) {
+		return apiKeyStoreFingerprint(apiKeyProfile.Profile, apiKeyProfile.Key)
+	}
+	return ""
+}
+
 // authHealthLocked derives the health enum. Caller holds authMu.
 //   - signed_out:     no OAuth credential in the store
 //   - refresh_failed: credential present but the token endpoint rejected
@@ -1023,7 +1053,7 @@ func (g *Gateway) authTickOnce() {
 //   - ok:             credential present, no known problem
 func (g *Gateway) authHealthLocked() string {
 	switch {
-	case g.oauthClient == nil:
+	case g.oauthClient == nil && g.cliProfileAPIKey == "":
 		return "signed_out"
 	case g.authDead:
 		return "refresh_failed"
@@ -1061,28 +1091,86 @@ func rfc3339OrEmpty(t time.Time) string {
 	return t.UTC().Format(time.RFC3339)
 }
 
-func (g *Gateway) authState() (signedIn bool, fallbackInUse bool) {
+func (g *Gateway) authState() (signedIn bool, authType string, fallbackInUse bool) {
 	cfg := g.runtimeConfig()
 	g.authMu.Lock()
 	defer g.authMu.Unlock()
-	signedIn = g.oauthClient != nil
+	signedIn = g.oauthClient != nil || g.cliProfileAPIKey != ""
+	switch {
+	case g.oauthClient != nil:
+		authType = "oauth"
+	case g.cliProfileAPIKey != "":
+		authType = "api_key"
+	default:
+		authType = "none"
+	}
 	if !signedIn && cfg.APIKeyFallback && cfg.BasetenKey != "" {
+		authType = "api_key"
 		fallbackInUse = true
 	}
 	return
 }
 
-func (g *Gateway) basetenAuthClient() (useOAuth bool, client *http.Client, fallback bool) {
-	cfg := g.runtimeConfig()
+type basetenAuthSource string
+
+const (
+	basetenAuthProfileOAuth  basetenAuthSource = "profile_oauth"
+	basetenAuthProfileAPIKey basetenAuthSource = "profile_api_key"
+	basetenAuthEnvFallback   basetenAuthSource = "environment_fallback"
+)
+
+type basetenAuthSelection struct {
+	mode   proxy.UpstreamAuthMode
+	apiKey string
+	client *http.Client
+	source basetenAuthSource
+}
+
+func (s basetenAuthSelection) authorization() string {
+	if s.mode == proxy.UpstreamModeAPIKey {
+		return "Api-Key " + s.apiKey
+	}
+	return ""
+}
+
+// basetenProfileAuth returns only the selected CLI profile. Account-scoped
+// surfaces use it so an environment fallback cannot silently change identity.
+func (g *Gateway) basetenProfileAuth() (basetenAuthSelection, bool) {
 	g.authMu.Lock()
 	defer g.authMu.Unlock()
 	if g.oauthClient != nil {
-		return true, g.oauthClient, false
+		return basetenAuthSelection{
+			mode:   proxy.UpstreamModeOAuth,
+			client: g.oauthClient,
+			source: basetenAuthProfileOAuth,
+		}, true
 	}
+	if g.cliProfileAPIKey != "" {
+		return basetenAuthSelection{
+			mode:   proxy.UpstreamModeAPIKey,
+			apiKey: g.cliProfileAPIKey,
+			client: g.client,
+			source: basetenAuthProfileAPIKey,
+		}, true
+	}
+	return basetenAuthSelection{}, false
+}
+
+// basetenAuth applies the complete credential precedence rule.
+func (g *Gateway) basetenAuth() (basetenAuthSelection, bool) {
+	if selected, ok := g.basetenProfileAuth(); ok {
+		return selected, true
+	}
+	cfg := g.runtimeConfig()
 	if cfg.APIKeyFallback && cfg.BasetenKey != "" {
-		return false, g.client, true
+		return basetenAuthSelection{
+			mode:   proxy.UpstreamModeAPIKey,
+			apiKey: cfg.BasetenKey,
+			client: g.client,
+			source: basetenAuthEnvFallback,
+		}, true
 	}
-	return false, nil, false
+	return basetenAuthSelection{}, false
 }
 
 func defaultTransport() *http.Transport {
@@ -1339,7 +1427,7 @@ func (g *Gateway) countTokens(cl *clientListener, w http.ResponseWriter, r *http
 func (g *Gateway) healthzClient(cl *clientListener, w http.ResponseWriter, r *http.Request) {
 	rt := cl.cfg.Route
 	upstreamModel := g.upstreamModelFor(cl.cfg)
-	signedIn, _ := g.authState()
+	signedIn, _, _ := g.authState()
 	body, _ := json.Marshal(map[string]any{
 		"status":          "ok",
 		"client":          cl.cfg.Name,
@@ -1398,15 +1486,14 @@ func (g *Gateway) forwardModelsGet(cl *clientListener, w http.ResponseWriter, r 
 	req.Header.Set("Accept", "application/json")
 	var upClient *http.Client
 	if rt == "baseten" {
-		useOAuth, c, fallback := g.basetenAuthClient()
-		if useOAuth {
-			upClient = c
-		} else if fallback {
-			upClient = c
-			req.Header.Set("Authorization", "Api-Key "+cfg.BasetenKey)
-		} else {
+		selected, ok := g.basetenAuth()
+		if !ok {
 			g.rejectNeedsLogin(w)
 			return
+		}
+		upClient = selected.client
+		if authorization := selected.authorization(); authorization != "" {
+			req.Header.Set("Authorization", authorization)
 		}
 	} else {
 		upClient = g.client
@@ -1708,12 +1795,9 @@ func upstreamResponsesEndpoint(baseURL string) string {
 // to use for forwarding to the given route.
 func (g *Gateway) buildUpstreamClient(rt string) (mode proxy.UpstreamAuthMode, basetenKey string, upClient *http.Client, ok bool) {
 	if rt == "baseten" {
-		useOAuth, c, fallback := g.basetenAuthClient()
-		if useOAuth {
-			return proxy.UpstreamModeOAuth, "", c, true
-		}
-		if fallback {
-			return proxy.UpstreamModeAPIKey, g.runtimeConfig().BasetenKey, c, true
+		selected, found := g.basetenAuth()
+		if found {
+			return selected.mode, selected.apiKey, selected.client, true
 		}
 		return 0, "", nil, false
 	}

--- a/gateway/cmd/gateway/gateway_test.go
+++ b/gateway/cmd/gateway/gateway_test.go
@@ -762,6 +762,146 @@ func TestBasetenRouteAPIKeyFallbackForwardsAPIKeyHeader(t *testing.T) {
 	}
 }
 
+func TestBasetenCLIAPIKeyProfileAuthenticatesGatewaySurfaces(t *testing.T) {
+	var mu sync.Mutex
+	seen := map[string]int{}
+	profileKey := "synthetic-profile-key"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Api-Key "+profileKey {
+			t.Errorf("%s Authorization = %q, want selected profile API key", r.URL.Path, got)
+		}
+		if got := r.Header.Get("X-Api-Key"); got != "" {
+			t.Errorf("%s forwarded inbound X-Api-Key = %q", r.URL.Path, got)
+		}
+		mu.Lock()
+		seen[r.URL.Path]++
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/messages":
+			_, _ = io.WriteString(w, `{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"example/model","usage":{"input_tokens":1,"output_tokens":1}}`)
+		case "/v1/responses":
+			_, _ = io.WriteString(w, `{"id":"resp_1","object":"response","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`)
+		case "/v1/models":
+			_, _ = io.WriteString(w, `{"data":[]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := testConfig(t, server.URL, server.URL)
+	cfg.BasetenKey = "environment-key-must-not-win"
+	cfg.APIKeyFallback = true
+	cfg.OAuthProfile = "p"
+	writeAPIKeyProfile(t, profileKey)
+	claude := resolvedAnthropicBaseten(t)
+	codex := resolvedOpenAIBaseten(t, "codex", "baseten")
+	g, adminL, _ := newGateway(t, cfg, claude, codex)
+	defer adminL.Close()
+	stop := start(t, g)
+	defer stop()
+
+	requests := []struct {
+		method string
+		url    string
+		body   string
+	}{
+		{http.MethodPost, clientURL(g, claude.Name, "/v1/messages"), `{"model":"alias","messages":[{"role":"user","content":"ping"}]}`},
+		{http.MethodPost, clientURL(g, codex.Name, "/v1/responses"), `{"model":"alias","input":"ping"}`},
+		{http.MethodGet, clientURL(g, codex.Name, "/v1/models"), ""},
+	}
+	for _, test := range requests {
+		req, err := http.NewRequest(test.method, test.url, strings.NewReader(test.body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer harness-secret")
+		req.Header.Set("X-Api-Key", "harness-api-secret")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("%s %s status = %d", test.method, test.url, resp.StatusCode)
+		}
+	}
+
+	resp, err := http.Get(adminURL(g, "/v1/admin/auth/status"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var status map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if status["signed_in"] != true || status["auth_type"] != "api_key" || status["fallback_in_use"] != false {
+		t.Fatalf("auth status = %+v", status)
+	}
+	encoded, _ := json.Marshal(status)
+	if bytes.Contains(encoded, []byte(profileKey)) {
+		t.Fatal("admin auth status leaked selected API key")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, path := range []string{"/v1/messages", "/v1/responses", "/v1/models"} {
+		if seen[path] == 0 {
+			t.Errorf("upstream did not receive %s", path)
+		}
+	}
+}
+
+func TestBasetenAuthorizationFailuresDoNotPromoteNativeFallback(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			var nativeHits atomic.Int32
+			baseten := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(status)
+				_, _ = io.WriteString(w, `{"error":"authorization failed"}`)
+			}))
+			defer baseten.Close()
+			native := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nativeHits.Add(1)
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer native.Close()
+
+			cfg := testConfig(t, baseten.URL, native.URL)
+			cfg.BasetenKey = ""
+			cfg.APIKeyFallback = false
+			cfg.OAuthProfile = "p"
+			writeAPIKeyProfile(t, "synthetic-restricted-key")
+			rc := resolvedAnthropicBaseten(t)
+			rc.FallbackRoute = "anthropic"
+			g, adminL, _ := newGateway(t, cfg, rc)
+			defer adminL.Close()
+			stop := start(t, g)
+			defer stop()
+
+			req, _ := http.NewRequest(http.MethodPost, clientURL(g, rc.Name, "/v1/messages"), strings.NewReader(`{"model":"alias","messages":[]}`))
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+			if resp.StatusCode != status {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, status)
+			}
+			if nativeHits.Load() != 0 {
+				t.Fatalf("native fallback received %d requests", nativeHits.Load())
+			}
+		})
+	}
+}
+
 func TestAdminAuthStatusReportsNotSignedIn(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	defer srv.Close()

--- a/gateway/cmd/gateway/pricing_refresh.go
+++ b/gateway/cmd/gateway/pricing_refresh.go
@@ -196,7 +196,7 @@ func (g *Gateway) stopCatalogRefresh() {
 // holding configuration, auth, routing, or pricing publication locks.
 func (g *Gateway) refreshCatalogOnce(parent context.Context) {
 	cfg := g.runtimeConfig()
-	client, authorization, ok := g.catalogRequestClient(cfg)
+	client, authorization, ok := g.catalogRequestClient()
 	if !ok {
 		return
 	}
@@ -243,15 +243,9 @@ func (g *Gateway) refreshCatalogOnce(parent context.Context) {
 		metadata.ModelCount, metadata.PricedModelCount, metadata.Revision)
 }
 
-func (g *Gateway) catalogRequestClient(cfg Config) (*http.Client, string, bool) {
-	g.authMu.Lock()
-	oauthClient := g.oauthClient
-	g.authMu.Unlock()
-	if oauthClient != nil {
-		return oauthClient, "", true
-	}
-	if cfg.APIKeyFallback && cfg.BasetenKey != "" {
-		return g.client, "Bearer " + cfg.BasetenKey, true
+func (g *Gateway) catalogRequestClient() (*http.Client, string, bool) {
+	if selected, ok := g.basetenAuth(); ok {
+		return selected.client, selected.authorization(), true
 	}
 	return nil, "", false
 }

--- a/gateway/cmd/gateway/pricing_refresh_test.go
+++ b/gateway/cmd/gateway/pricing_refresh_test.go
@@ -38,13 +38,13 @@ func catalogTestGateway(server *httptest.Server) *Gateway {
 	}
 }
 
-func TestCatalogRefreshPublishesLiveSnapshotWithBearer(t *testing.T) {
+func TestCatalogRefreshPublishesLiveSnapshotWithAPIKey(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || r.URL.Path != "/v1/models" {
 			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
 		}
-		if got := r.Header.Get("Authorization"); got != "Bearer catalog-key" {
-			t.Fatalf("Authorization = %q, want Bearer catalog-key", got)
+		if got := r.Header.Get("Authorization"); got != "Api-Key catalog-key" {
+			t.Fatalf("Authorization = %q, want Api-Key catalog-key", got)
 		}
 		if got := r.Header.Get("Accept"); got != "application/json" {
 			t.Fatalf("Accept = %q", got)
@@ -108,6 +108,25 @@ func TestCatalogRefreshPublishesLiveSnapshotWithBearer(t *testing.T) {
 			"cache-restored catalog health = %+v",
 			restoredHealth,
 		)
+	}
+}
+
+func TestCatalogRefreshSelectedProfilePrecedesEnvironmentFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Api-Key selected-profile-key" {
+			t.Fatalf("Authorization = %q, want selected profile API key", got)
+		}
+		_, _ = w.Write([]byte(liveCatalogFixture))
+	}))
+	defer server.Close()
+
+	g := catalogTestGateway(server)
+	g.cfg.BasetenKey = "environment-fallback-must-not-win"
+	g.cliProfileAPIKey = "selected-profile-key"
+	g.refreshCatalogOnce(context.Background())
+
+	if metadata := g.pricing.Capture().BasetenMetadata(); metadata.Source != "baseten_v1_models" || metadata.ModelCount != 1 {
+		t.Fatalf("metadata = %+v", metadata)
 	}
 }
 

--- a/gateway/internal/config/gateway.example.yaml
+++ b/gateway/internal/config/gateway.example.yaml
@@ -7,7 +7,8 @@ global:
   # One global switch. Off is absolute native passthrough; On applies saved routing policy.
   routing_enabled: true
 
-  # Upstream auth; baseten is OPTIONAL with OAuth ('baseten auth login'), see schema.md for the API-key path.
+  # The selected Baseten CLI profile supplies OAuth or API-key auth automatically.
+  # baseten below is only the explicit environment fallback; see schema.md.
   auth:
     baseten:   ${BASETEN_API_KEY}
     anthropic: ${ANTHROPIC_API_KEY}

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/Display.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/Display.swift
@@ -89,6 +89,8 @@ func liveModelCatalogSignedOutMessage(
         return "Sign in to Baseten to load Model APIs."
     case .sessionExpired:
         return "Your Baseten session expired. Sign in again to load Model APIs."
+    case .credentialRejected:
+        return "Your Baseten API key was rejected. Update it and try again."
     }
 }
 

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/GatewayClient.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/GatewayClient.swift
@@ -243,6 +243,7 @@ enum LiveModelCatalogResponseState: String, Equatable, Sendable {
 enum LiveModelCatalogSignedOutReason: String, Equatable, Sendable {
     case notSignedIn = "not_signed_in"
     case sessionExpired = "session_expired"
+    case credentialRejected = "credential_rejected"
 }
 
 enum ReasoningOptionType: String, Equatable, Sendable {
@@ -590,6 +591,7 @@ struct HealthSnapshot: Equatable, Sendable {
 
 struct AuthStatus: Equatable, Sendable {
     var signedIn: Bool
+    var authType: String
     var profile: String
     var fallbackEnabled: Bool
     var fallbackInUse: Bool
@@ -598,6 +600,7 @@ struct AuthStatus: Equatable, Sendable {
 
     init(dict: [String: Any]) {
         signedIn = dict["signed_in"] as? Bool ?? false
+        authType = dict["auth_type"] as? String ?? ""
         profile = dict["profile"] as? String ?? ""
         fallbackEnabled = dict["fallback_enabled"] as? Bool ?? false
         fallbackInUse = dict["fallback_in_use"] as? Bool ?? false

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/PopupDisplay.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/PopupDisplay.swift
@@ -48,7 +48,7 @@ func versionSkewNote(routerVersion: String, cliVersion: String) -> String? {
 }
 
 /// Auth line from the admin status auth block. Signed in shows the
-/// OAuth profile; fallback-in-use is appended (or shown alone when not
+/// selected profile and credential type; fallback-in-use is appended (or shown alone when not
 /// signed in) so degraded auth is visible where the controls are.
 /// Health overlays (oauth-expiry spike): "refresh_failed" means the
 /// token endpoint rejected the stored credential, so every
@@ -63,10 +63,13 @@ func authLineLabel(auth: AuthStatus?) -> String {
         return "Auth: reauthentication required"
     }
     // signed_in is store presence; health "signed_out" is the gateway
-    // holding no OAuth client. Either signal renders the
+    // holding no usable selected-profile credential. Either signal renders the
     // not-signed-in presentation.
     if auth.signedIn && auth.health != "signed_out" {
-        let who = auth.profile.isEmpty ? "OAuth" : "\(auth.profile) OAuth"
+        // Routers predating auth_type only supported OAuth profiles, so an
+        // omitted or unknown value retains the mixed-version OAuth label.
+        let kind = auth.authType == "api_key" ? "API key" : "OAuth"
+        let who = auth.profile.isEmpty ? kind : "\(auth.profile) \(kind)"
         if auth.fallbackInUse {
             return "Auth: \(who), API-key fallback in use"
         }

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/ModelCatalogTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/ModelCatalogTests.swift
@@ -356,6 +356,7 @@ final class ModelCatalogTests: XCTestCase {
             .loading,
             .signedOut(.notSignedIn),
             .signedOut(.sessionExpired),
+            .signedOut(.credentialRejected),
             .error("unavailable"),
         ] {
             let projection = projectModelCatalog(
@@ -430,6 +431,9 @@ final class ModelCatalogTests: XCTestCase {
         XCTAssertEqual(
             liveModelCatalogSignedOutMessage(.sessionExpired),
             "Your Baseten session expired. Sign in again to load Model APIs.")
+        XCTAssertEqual(
+            liveModelCatalogSignedOutMessage(.credentialRejected),
+            "Your Baseten API key was rejected. Update it and try again.")
 
         let backendErrorState = makeState(modelCatalogReader:
             FixedModelCatalogReader(.success(catalogSnapshot(

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/PopupDisplayTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/PopupDisplayTests.swift
@@ -47,12 +47,15 @@ final class PopupDisplayTests: XCTestCase {
 
     private func auth(signedIn: Bool, profile: String,
                       fallbackInUse: Bool, health: String = "",
-                      lastError: String = "") -> AuthStatus {
-        AuthStatus(dict: ["signed_in": signedIn, "profile": profile,
-                          "fallback_enabled": true,
-                          "fallback_in_use": fallbackInUse,
-                          "health": health,
-                          "last_refresh_error": lastError])
+                      lastError: String = "",
+                      authType: String? = nil) -> AuthStatus {
+        var dict: [String: Any] = ["signed_in": signedIn, "profile": profile,
+                                   "fallback_enabled": true,
+                                   "fallback_in_use": fallbackInUse,
+                                   "health": health,
+                                   "last_refresh_error": lastError]
+        if let authType { dict["auth_type"] = authType }
+        return AuthStatus(dict: dict)
     }
 
     func testAuthLineLabel() {
@@ -77,6 +80,16 @@ final class PopupDisplayTests: XCTestCase {
             authLineLabel(auth: auth(signedIn: false, profile: "",
                                      fallbackInUse: false)),
             "Auth: not signed in")
+        XCTAssertEqual(
+            authLineLabel(auth: auth(signedIn: true, profile: "example-profile",
+                                     fallbackInUse: false,
+                                     authType: "api_key")),
+            "Auth: example-profile API key")
+        // An omitted auth_type is the mixed-version OAuth default.
+        XCTAssertEqual(
+            authLineLabel(auth: auth(signedIn: true, profile: "example-profile",
+                                     fallbackInUse: false)),
+            "Auth: example-profile OAuth")
     }
 
     // Health-driven auth line states (oauth-expiry spike).

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/StatsTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/StatsTests.swift
@@ -113,7 +113,7 @@ final class StatsTests: XCTestCase {
           "uptime_seconds": 12, "version": "v0.2.1",
           "config_path": "/tmp/live/gateway.yaml",
           "global_routing_enabled": true,
-          "auth": {"signed_in": true, "profile": "user@example",
+          "auth": {"signed_in": true, "auth_type": "api_key", "profile": "example-profile",
                    "fallback_enabled": true, "fallback_in_use": false,
                    "health": "ok", "last_refresh_error": "",
                    "last_refresh_error_at": "", "last_refresh_ok_at": ""},
@@ -124,7 +124,8 @@ final class StatsTests: XCTestCase {
         XCTAssertEqual(snap.configPath, "/tmp/live/gateway.yaml")
         XCTAssertTrue(snap.globalRoutingEnabled)
         XCTAssertEqual(snap.auth?.signedIn, true)
-        XCTAssertEqual(snap.auth?.profile, "user@example")
+        XCTAssertEqual(snap.auth?.authType, "api_key")
+        XCTAssertEqual(snap.auth?.profile, "example-profile")
         XCTAssertEqual(snap.auth?.fallbackEnabled, true)
         XCTAssertEqual(snap.auth?.fallbackInUse, false)
         XCTAssertEqual(snap.auth?.health, "ok")
@@ -252,6 +253,7 @@ final class StatsTests: XCTestCase {
 
         // Absent fields decode to empty strings, not nil.
         let old = AdminStatusSnapshot(dict: decode(#"{"auth": {"signed_in": true}}"#))
+        XCTAssertEqual(old.auth?.authType, "")
         XCTAssertEqual(old.auth?.health, "")
         XCTAssertEqual(old.auth?.lastRefreshError, "")
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -361,4 +361,24 @@ grep -q 'Router:  DOWN' "$UP_DIR/status-down.out" \
     || { cat "$UP_DIR/status-down.out"; fail "status missing 'Router:  DOWN' after down"; }
 echo "ok (up -> status 0 -> idempotent up -> down -> status nonzero)"
 
+# -------------------------------- opt-in: API-key profile live contract
+# The script always runs in dry-run mode so its public entrypoint is covered.
+# The networked contract requires both an explicit opt-in and a caller-supplied
+# test key. It creates a separate CLI store and starts only scratch processes.
+step "API-key profile live contract"
+"$REPO_DIR/scripts/tests/test_api_key_profile_live.sh" --dry-run \
+    > "$TMPDIR_CHECK/api-key-profile-live-dry-run.out" \
+    || fail "API-key profile live contract dry run"
+if [[ "$OFFLINE" == 1 ]]; then
+    echo "skipped (--offline; dry run passed)"
+elif [[ "${BASETEN_SWITCH_RUN_API_KEY_PROFILE_LIVE:-}" == "1" ]]; then
+    [[ -n "${BASETEN_SWITCH_TEST_API_KEY:-}" ]] \
+        || fail "BASETEN_SWITCH_TEST_API_KEY is required for the opted-in live contract"
+    env BASETEN_SWITCH_TEST_BINARY="$GW_DIR/bin/baseten-switch" \
+        "$REPO_DIR/scripts/tests/test_api_key_profile_live.sh" \
+        || fail "API-key profile live contract"
+else
+    echo "skipped (set BASETEN_SWITCH_RUN_API_KEY_PROFILE_LIVE=1 and BASETEN_SWITCH_TEST_API_KEY to opt in; dry run passed)"
+fi
+
 printf '\nALL CHECKS PASSED\n'

--- a/scripts/tests/test_api_key_profile_live.sh
+++ b/scripts/tests/test_api_key_profile_live.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# Opt-in live contract for a Baseten CLI API-key profile.
+#
+# This script creates all credentials and runtime state under one temporary
+# directory. It never starts, stops, or reconfigures an installed Switch.
+
+set -euo pipefail
+
+# Never allow inherited shell tracing to expose the test key.
+set +x
+
+if [[ "${1:-}" == "--dry-run" ]]; then
+    printf '%s\n' \
+        "api-key profile live contract: dry run" \
+        "would create an isolated Baseten CLI profile and Switch runtime" \
+        "would test /v1/models and one minimal inference through a scratch door" \
+        "would scan scratch output for credential disclosure before cleanup"
+    exit 0
+fi
+if [[ "$#" -ne 0 ]]; then
+    printf 'usage: %s [--dry-run]\n' "$0" >&2
+    exit 2
+fi
+
+fail() {
+    printf 'api-key profile live contract: %s\n' "$*" >&2
+    exit 1
+}
+
+for command_name in baseten curl go lsof; do
+    command -v "$command_name" >/dev/null 2>&1 \
+        || fail "required command is unavailable: $command_name"
+done
+
+api_key="${BASETEN_SWITCH_TEST_API_KEY:-}"
+unset BASETEN_SWITCH_TEST_API_KEY
+[[ -n "$api_key" ]] \
+    || fail "BASETEN_SWITCH_TEST_API_KEY must contain an inference-capable test key"
+
+model="${BASETEN_SWITCH_TEST_MODEL:-zai-org/GLM-5.2}"
+if [[ "$model" != */* || ! "$model" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+    fail "BASETEN_SWITCH_TEST_MODEL must be a Baseten model slug"
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_dir="$(cd "$script_dir/../.." && pwd -P)"
+scratch_parent="${TMPDIR:-/tmp}"
+scratch_parent="${scratch_parent%/}"
+scratch_dir="$(mktemp -d "$scratch_parent/baseten-switch-api-key-live.XXXXXX")"
+chmod 700 "$scratch_dir"
+
+profile="switch-api-key-test"
+baseten_config_dir="$scratch_dir/baseten"
+auth_file="$baseten_config_dir/auth.json"
+switch_dir="$scratch_dir/switch"
+output_dir="$scratch_dir/output"
+telemetry_dir="$switch_dir/telemetry"
+router_log="$switch_dir/router.log"
+door_log="$switch_dir/door.log"
+router_pidfile="$switch_dir/router.pid"
+door_pidfile="$switch_dir/door.pid"
+config_path="$switch_dir/gateway.yaml"
+env_file="$switch_dir/env"
+binary="${BASETEN_SWITCH_TEST_BINARY:-$scratch_dir/bin/baseten-switch}"
+
+mkdir -p "$baseten_config_dir" "$switch_dir" "$output_dir" \
+    "$telemetry_dir" "$scratch_dir/home" "$scratch_dir/bin"
+chmod 700 "$baseten_config_dir" "$switch_dir" "$output_dir" "$telemetry_dir"
+: > "$env_file"
+chmod 600 "$env_file"
+
+pids=()
+scan_for_key() {
+    local found=""
+    [[ -d "$scratch_dir" && -n "$api_key" ]] || return 0
+    found="$({
+        find "$scratch_dir" -type f \
+            ! -path "$auth_file" \
+            ! -path "$binary" \
+            -exec grep -Fl -- "$api_key" {} + 2>/dev/null || true
+    } | head -1)"
+    [[ -z "$found" ]]
+}
+
+cleanup() {
+    local status=$?
+    local pid
+    trap - EXIT INT TERM
+    set +e
+    for pid in "${pids[@]:-}"; do
+        if [[ -n "$pid" ]]; then
+            kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+        fi
+    done
+    if ! scan_for_key; then
+        printf '%s\n' \
+            "api-key profile live contract: test key appeared outside the temporary credential file" >&2
+        status=1
+    fi
+    case "$scratch_dir" in
+        "$scratch_parent"/baseten-switch-api-key-live.*)
+            [[ -d "$scratch_dir" ]] && rm -rf -- "$scratch_dir"
+            ;;
+        *)
+            printf '%s\n' \
+                "api-key profile live contract: refused to remove an unexpected scratch path" >&2
+            status=1
+            ;;
+    esac
+    exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+valid_port() {
+    local port="$1"
+    case "$port" in
+        ''|*[!0-9]*) return 1 ;;
+    esac
+    (( port >= 1024 && port <= 65535 ))
+}
+
+port_is_free() {
+    ! lsof -nP -iTCP:"$1" -sTCP:LISTEN >/dev/null 2>&1
+}
+
+choose_port() {
+    local requested="$1"
+    local offset="$2"
+    local port
+    if [[ -n "$requested" ]]; then
+        valid_port "$requested" || fail "scratch port override is invalid"
+        port_is_free "$requested" || fail "scratch port override is already in use"
+        printf '%s\n' "$requested"
+        return
+    fi
+    port=$((30000 + (($$ + offset) % 30000)))
+    while (( port <= 65535 )); do
+        if port_is_free "$port"; then
+            printf '%s\n' "$port"
+            return
+        fi
+        port=$((port + 1))
+    done
+    fail "could not find a free scratch port"
+}
+
+admin_port="$(choose_port "${BASETEN_SWITCH_TEST_ADMIN_PORT:-}" 101)"
+router_port="$(choose_port "${BASETEN_SWITCH_TEST_ROUTER_PORT:-}" 211)"
+door_port="$(choose_port "${BASETEN_SWITCH_TEST_DOOR_PORT:-}" 307)"
+[[ "$admin_port" != "$router_port" && "$admin_port" != "$door_port" && \
+    "$router_port" != "$door_port" ]] || fail "scratch ports must be distinct"
+
+if [[ -z "${BASETEN_SWITCH_TEST_BINARY:-}" ]]; then
+    (
+        cd "$repo_dir/gateway"
+        go build -o "$binary" ./cmd/baseten-switch
+    ) > "$output_dir/build.out" 2>&1 \
+        || fail "could not build the test binary"
+fi
+[[ -x "$binary" ]] || fail "test binary is not executable"
+
+# The API key travels over stdin. The CLI stores it only in the isolated,
+# insecure-storage auth.json that cleanup removes.
+printf '%s\n' "$api_key" |
+    env HOME="$scratch_dir/home" \
+        BASETEN_CONFIG_DIR="$baseten_config_dir" \
+        BASETEN_REMOTE_URL="https://api.baseten.co" \
+        baseten auth login \
+            --with-api-key \
+            --profile "$profile" \
+            --insecure-storage \
+            --output none \
+            > "$output_dir/login.out" 2>&1 \
+    || fail "Baseten CLI API-key login failed"
+
+[[ -f "$auth_file" ]] || fail "Baseten CLI did not create the isolated credential file"
+
+cat > "$config_path" <<EOF
+global:
+  routing_enabled: true
+  telemetry_dir: \${BASETEN_SWITCH_TELEMETRY_DIR}
+  telemetry_enabled: true
+clients:
+  - name: api-key-profile-live
+    enabled: true
+    bind_addr: 127.0.0.1:$router_port
+    protocol_shape: openai
+    default_model: $model
+door:
+  cooldown: 2s
+  probe_interval: 1s
+  ports:
+    - bind_addr: 127.0.0.1:$door_port
+      router_addr: 127.0.0.1:$router_port
+EOF
+chmod 600 "$config_path"
+
+switch_env=(
+    "HOME=$scratch_dir/home"
+    "BASETEN_CONFIG_DIR=$baseten_config_dir"
+    "BASETEN_REMOTE_URL=https://api.baseten.co"
+    "BASETEN_BASE_URL=https://inference.baseten.co"
+    "BASETEN_SWITCH_AUTH_FILE="
+    "BASETEN_SWITCH_AUTH_NO_KEYRING=1"
+    "BASETEN_SWITCH_OAUTH_PROFILE=$profile"
+    "BASETEN_SWITCH_CONFIG_PATH=$config_path"
+    "BASETEN_SWITCH_ENV_FILE=$env_file"
+    "BASETEN_SWITCH_ADMIN_ADDR=127.0.0.1:$admin_port"
+    "BASETEN_SWITCH_GATEWAY_PIDFILE=$router_pidfile"
+    "BASETEN_SWITCH_DOOR_PIDFILE=$door_pidfile"
+    "BASETEN_SWITCH_GATEWAY_LOG=$router_log"
+    "BASETEN_SWITCH_DOOR_LOG=$door_log"
+    "BASETEN_SWITCH_TELEMETRY_DIR=$telemetry_dir"
+    "BASETEN_SWITCH_API_KEY_FALLBACK=0"
+    "BASETEN_SWITCH_PRIVATE_RUNTIME=0"
+    "BASETEN_SWITCH_LAUNCHD=off"
+    "BASETEN_SWITCH_MENUBAR=off"
+    "BASETEN_API_KEY="
+    "ANTHROPIC_API_KEY="
+    "OPENAI_API_KEY="
+)
+
+unset BASETEN_API_KEY ANTHROPIC_API_KEY OPENAI_API_KEY
+
+env "${switch_env[@]}" \
+    "$binary" gateway start --foreground --port "$admin_port" \
+    > "$router_log" 2>&1 &
+router_pid=$!
+pids+=("$router_pid")
+
+wait_for_url() {
+    local url="$1"
+    local pid="$2"
+    for _ in $(seq 1 50); do
+        curl -fsS -m 1 "$url" >/dev/null 2>&1 && return 0
+        kill -0 "$pid" 2>/dev/null || return 1
+        sleep 0.2
+    done
+    return 1
+}
+
+wait_for_url "http://127.0.0.1:$admin_port/healthz" "$router_pid" \
+    || fail "scratch router did not become healthy"
+
+env "${switch_env[@]}" \
+    "$binary" door --config "$config_path" \
+    > "$door_log" 2>&1 &
+door_pid=$!
+pids+=("$door_pid")
+
+wait_for_url "http://127.0.0.1:$door_port/doorz" "$door_pid" \
+    || fail "scratch door did not become healthy"
+
+curl -fsS -m 15 \
+    "http://127.0.0.1:$admin_port/v1/admin/auth/status" \
+    > "$output_dir/auth-status.json" \
+    || fail "admin auth status request failed"
+
+grep -Eq '"signed_in"[[:space:]]*:[[:space:]]*true' \
+    "$output_dir/auth-status.json" \
+    || fail "admin auth status did not report a selected profile"
+grep -Eq '"auth_type"[[:space:]]*:[[:space:]]*"api_key"' \
+    "$output_dir/auth-status.json" \
+    || fail "admin auth status did not report API-key authentication"
+grep -Eq '"profile"[[:space:]]*:[[:space:]]*"switch-api-key-test"' \
+    "$output_dir/auth-status.json" \
+    || fail "admin auth status did not report the isolated profile"
+grep -Eq '"health"[[:space:]]*:[[:space:]]*"ok"' \
+    "$output_dir/auth-status.json" \
+    || fail "admin auth status did not report healthy authentication"
+grep -Eq '"fallback_enabled"[[:space:]]*:[[:space:]]*false' \
+    "$output_dir/auth-status.json" \
+    || fail "environment API-key fallback was not disabled"
+grep -Eq '"fallback_in_use"[[:space:]]*:[[:space:]]*false' \
+    "$output_dir/auth-status.json" \
+    || fail "admin auth status reported fallback use"
+
+models_status="$(curl -sS -m 60 \
+    -o "$output_dir/models.json" \
+    -w '%{http_code}' \
+    "http://127.0.0.1:$door_port/v1/models")" \
+    || fail "model discovery request failed"
+[[ "$models_status" == "200" ]] \
+    || fail "model discovery did not return HTTP 200"
+
+cat > "$output_dir/inference-request.json" <<EOF
+{"model":"$model","messages":[{"role":"user","content":"Reply with OK."}],"max_tokens":1,"stream":false}
+EOF
+inference_status="$(curl -sS -m 180 \
+    -H 'Content-Type: application/json' \
+    -o "$output_dir/inference-response.json" \
+    -w '%{http_code}' \
+    --data-binary "@$output_dir/inference-request.json" \
+    "http://127.0.0.1:$door_port/v1/chat/completions")" \
+    || fail "minimal inference request failed"
+[[ "$inference_status" == "200" ]] \
+    || fail "minimal inference did not return HTTP 200"
+
+telemetry_ok=0
+for _ in $(seq 1 25); do
+    if grep -R -Eq '"client":"api-key-profile-live".*"effective_provider":"baseten"' \
+        "$telemetry_dir" 2>/dev/null; then
+        telemetry_ok=1
+        break
+    fi
+    sleep 0.2
+done
+[[ "$telemetry_ok" == 1 ]] \
+    || fail "telemetry did not attribute inference to Baseten"
+
+scan_for_key \
+    || fail "test key appeared outside the temporary credential file"
+
+printf '%s\n' "api-key profile live contract: ok"

--- a/scripts/tests/test_api_key_profile_live.sh
+++ b/scripts/tests/test_api_key_profile_live.sh
@@ -166,7 +166,7 @@ fi
 printf '%s\n' "$api_key" |
     env HOME="$scratch_dir/home" \
         BASETEN_CONFIG_DIR="$baseten_config_dir" \
-        BASETEN_REMOTE_URL="https://api.baseten.co" \
+        BASETEN_REMOTE_URL="https://app.baseten.co" \
         baseten auth login \
             --with-api-key \
             --profile "$profile" \


### PR DESCRIPTION
## Summary

- authenticate Baseten requests with API-key profiles selected through the Baseten CLI, while preserving OAuth and the opt-in environment fallback
- reload profile login, logout, switching, and key rotation without restarting the gateway
- report the active authentication type in CLI and macOS status, and improve failed doctor-probe route attribution
- add an isolated opt-in live contract test for model discovery and inference

## Testing

- `scripts/check.sh`
- opt-in live API-key profile contract using a local build and isolated CLI profile, including `/v1/models`, inference, telemetry attribution, and credential leak checks