### PR TITLE
Fix legacy Claude backup migration for linked settings

### DIFF
--- a/gateway/cmd/baseten-switch/claude_adapter.go
+++ b/gateway/cmd/baseten-switch/claude_adapter.go
@@ -36,6 +36,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -152,6 +153,10 @@ type claudeAdapter struct {
 // claudeBeforeSettingsMutation is a test seam for changes after the adapter
 // has staged recovery state but before safefile revalidates the preimage.
 var claudeBeforeSettingsMutation func()
+
+// claudeBeforeMigratedBackupReplace is a test seam for a change after one
+// migrated-backup generation has been captured but before the next atomic CAS.
+var claudeBeforeMigratedBackupReplace func(action string)
 
 func (a *claudeAdapter) acquireSettingsMutationLock() (*configMutationLock, error) {
 	if err := os.MkdirAll(filepath.Dir(a.backupPath), 0o700); err != nil {
@@ -540,15 +545,40 @@ func loadClaudeBackup(path string) (*claudeBackup, error) {
 	return &bak, nil
 }
 
+// loadClaudeBackupSnapshot parses a backup from the same safe-file snapshot
+// that a legacy migration later replaces. The snapshot prevents a concurrent
+// backup writer from being overwritten between load and migration.
+func loadClaudeBackupSnapshot(path string) (*claudeBackup, *safefile.Snapshot, error) {
+	snap, err := safefile.Read(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read backup %s: %w", path, err)
+	}
+	if !snap.Exists {
+		return nil, snap, nil
+	}
+	var bak claudeBackup
+	if err := json.Unmarshal(snap.Data, &bak); err != nil {
+		return nil, nil, fmt.Errorf("parse backup %s: %w", path, err)
+	}
+	return &bak, snap, nil
+}
+
+func marshalClaudeBackup(bak *claudeBackup) ([]byte, error) {
+	b, err := json.MarshalIndent(bak, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(b, '\n'), nil
+}
+
 // saveClaudeBackup writes dir 0700 / file 0600: snapshots can embed
 // other providers' base URLs and sit next to future codex snapshots
 // that embed credentials.
 func saveClaudeBackup(path string, bak *claudeBackup) error {
-	b, err := json.MarshalIndent(bak, "", "  ")
+	b, err := marshalClaudeBackup(bak)
 	if err != nil {
 		return err
 	}
-	b = append(b, '\n')
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
@@ -632,6 +662,94 @@ func recordClaudeBackupFile(bak *claudeBackup, snap *safefile.Snapshot) {
 	}
 }
 
+func replaceClaudeBackupSnapshot(snap *safefile.Snapshot, bak *claudeBackup) (*safefile.Snapshot, error) {
+	if snap == nil {
+		return nil, fmt.Errorf("missing backup snapshot")
+	}
+	b, err := marshalClaudeBackup(bak)
+	if err != nil {
+		return nil, err
+	}
+	return snap.Replace(b, 0o600)
+}
+
+func replaceMigratedClaudeBackup(snap *safefile.Snapshot, bak *claudeBackup, action string) (*safefile.Snapshot, error) {
+	if claudeBeforeMigratedBackupReplace != nil {
+		claudeBeforeMigratedBackupReplace(action)
+	}
+	committed, err := replaceClaudeBackupSnapshot(snap, bak)
+	if err == nil {
+		return committed, nil
+	}
+	if safefile.CommitApplied(err) {
+		if errors.Is(err, safefile.ErrConflict) {
+			return committed, fmt.Errorf("%s was applied, but post-commit verification found that the migrated backup changed concurrently; the concurrent backup was not overwritten: %w", action, err)
+		}
+		return committed, fmt.Errorf("%s was applied, but its durability or post-commit verification failed: %w", action, err)
+	}
+	if errors.Is(err, safefile.ErrConflict) {
+		return nil, fmt.Errorf("%s refused because the migrated backup changed concurrently and was not overwritten: %w", action, err)
+	}
+	return nil, fmt.Errorf("%s failed before backup replacement, so the replacement was not applied: %w", action, err)
+}
+
+// migrateLegacyLinkedBackupSnapshot upgrades a pre-link-aware backup only when
+// its recorded file hash proves that the current linked target is the exact file
+// generation the backup describes. The settings snapshot supplies the bytes,
+// resolved path, identity, and pre-save verification. The backup snapshot binds
+// the parsed backup preimage to its atomic replacement. Migration changes only
+// target provenance and persists it before the caller may mutate settings.
+func (a *claudeAdapter) migrateLegacyLinkedBackupSnapshot(bak *claudeBackup, backupSnap, settingsSnap *safefile.Snapshot) (*claudeBackup, bool, *safefile.Snapshot, error) {
+	if bak == nil {
+		return nil, false, backupSnap, nil
+	}
+	if bak.ConfigPath != a.settingsPath {
+		return bak, false, backupSnap, fmt.Errorf("refusing to modify %s because backup %s is for %s, not %s; settings and backup left intact", a.settingsPath, a.backupPath, bak.ConfigPath, a.settingsPath)
+	}
+
+	resolvedRecorded := bak.ResolvedPath != ""
+	identityRecorded := bak.WrittenIdentity != nil
+	if resolvedRecorded != identityRecorded {
+		return bak, false, backupSnap, fmt.Errorf("refusing to modify %s because the backup has incomplete linked-target metadata; link and backup left intact", a.settingsPath)
+	}
+	if resolvedRecorded || !settingsSnap.Linked {
+		return bak, false, backupSnap, nil
+	}
+	if backupSnap == nil || !backupSnap.Exists {
+		return bak, false, backupSnap, fmt.Errorf("refusing to migrate the legacy backup for %s because its snapshotted backup file is missing; settings left intact", a.settingsPath)
+	}
+	if !settingsSnap.Exists || bak.WrittenHash == "" || sha256Hex(settingsSnap.Data) != bak.WrittenHash {
+		return bak, false, backupSnap, fmt.Errorf("refusing to modify %s because its legacy backup predates linked-settings support and the current linked target does not exactly match its recorded file generation; link and backup left intact; restore the link to the file managed by the earlier 'claude on' and retry, or restore the backed-up values manually; do not delete the backup", a.settingsPath)
+	}
+
+	migrated := cloneClaudeBackup(bak)
+	recordClaudeBackupFile(migrated, settingsSnap)
+	if err := settingsSnap.Verify(); err != nil {
+		return bak, false, backupSnap, fmt.Errorf("verify linked target before migrating legacy backup: %w; link and backup left intact", err)
+	}
+	committedBackup, err := replaceClaudeBackupSnapshot(backupSnap, migrated)
+	if err != nil {
+		if safefile.CommitApplied(err) {
+			if errors.Is(err, safefile.ErrConflict) {
+				return migrated, true, committedBackup, fmt.Errorf("legacy backup migration was applied, but post-commit verification found that the backup changed concurrently; the concurrent backup was not overwritten: %w; settings untouched; inspect %s before retrying", err, a.backupPath)
+			}
+			return migrated, true, committedBackup, fmt.Errorf("legacy backup migration was applied, but its durability or post-commit verification failed: %w; settings untouched; inspect %s before retrying", err, a.backupPath)
+		}
+		if errors.Is(err, safefile.ErrConflict) {
+			return bak, false, backupSnap, fmt.Errorf("legacy backup changed concurrently and was not overwritten: %w; settings untouched", err)
+		}
+		return bak, false, backupSnap, fmt.Errorf("atomically migrate legacy backup: %w; settings untouched and backup replacement was not applied", err)
+	}
+	return migrated, true, committedBackup, nil
+}
+
+// migrateLegacyLinkedBackup keeps the focused migration contract used by
+// tests and callers that do not perform later backup writes.
+func (a *claudeAdapter) migrateLegacyLinkedBackup(bak *claudeBackup, backupSnap, settingsSnap *safefile.Snapshot) (*claudeBackup, bool, error) {
+	migrated, changed, _, err := a.migrateLegacyLinkedBackupSnapshot(bak, backupSnap, settingsSnap)
+	return migrated, changed, err
+}
+
 // claudeBackupMatchesFile binds a link-aware backup to the file committed by
 // `on`. Legacy backups remain valid for direct regular paths. A legacy backup
 // is not allowed to clean-restore through a link because it does not identify
@@ -680,12 +798,29 @@ func (a *claudeAdapter) on() int {
 	envExistedPre := env != nil
 	baseManaged, _ := a.claudeOnState(env)
 
-	bak, err := loadClaudeBackup(a.backupPath)
+	bak, backupSnap, err := loadClaudeBackupSnapshot(a.backupPath)
 	if err != nil {
 		fmt.Fprintf(a.out, "claude on: %v\n", err)
 		return 1
 	}
+	bak, migratedBackup, backupSnap, err := a.migrateLegacyLinkedBackupSnapshot(bak, backupSnap, snap)
+	if err != nil {
+		fmt.Fprintf(a.out, "claude on: %v\n", err)
+		return 1
+	}
+	// Adoption is independently durable. Roll back later additive snapshots to
+	// this provenance-bearing baseline, never to the ambiguous legacy backup.
 	originalBackup := cloneClaudeBackup(bak)
+	saveExistingBackup := func(next *claudeBackup, action string) error {
+		if !migratedBackup {
+			return saveClaudeBackup(a.backupPath, next)
+		}
+		committedBackup, replaceErr := replaceMigratedClaudeBackup(backupSnap, next, action)
+		if committedBackup != nil {
+			backupSnap = committedBackup
+		}
+		return replaceErr
+	}
 	if bak != nil && !claudeBackupTargetSafe(bak, snap) {
 		fmt.Fprintf(a.out, "claude on: refusing to modify %s because it no longer resolves to the target recorded by the backup; link and backup left intact\n",
 			a.settingsPath)
@@ -713,7 +848,7 @@ func (a *claudeAdapter) on() int {
 	// but the fixed-value keys are backed up even in a base-only legacy
 	// state so custom or manually-added values restore exactly.
 	var nb *claudeBackup
-	backupChanged := false
+	backupChanged := migratedBackup
 	if bak == nil && changed {
 		nb = &claudeBackup{
 			ConfigPath:  a.settingsPath,
@@ -752,7 +887,7 @@ func (a *claudeAdapter) on() int {
 		if backupChanged {
 			bak.WrittenHash = sha256Hex(raw)
 			recordClaudeBackupFile(bak, snap)
-			if err := saveClaudeBackup(a.backupPath, bak); err != nil {
+			if err := saveExistingBackup(bak, "migrated backup additive update"); err != nil {
 				fmt.Fprintf(a.out, "claude on: write backup: %v (settings untouched)\n", err)
 				return 1
 			}
@@ -780,8 +915,8 @@ func (a *claudeAdapter) on() int {
 					// Nothing was modified; drop the staged backup.
 					_ = os.Remove(a.backupPath)
 				case backupChanged && originalBackup != nil:
-					if restoreErr := saveClaudeBackup(a.backupPath, originalBackup); restoreErr != nil {
-						fmt.Fprintf(a.out, "claude on: warning: settings were untouched, but the prior backup could not be restored: %v\n", restoreErr)
+					if restoreErr := saveExistingBackup(originalBackup, "migrated backup rollback"); restoreErr != nil {
+						fmt.Fprintf(a.out, "claude on: warning: settings were untouched, but backup rollback did not complete cleanly: %v\n", restoreErr)
 					}
 				}
 			}
@@ -799,8 +934,14 @@ func (a *claudeAdapter) on() int {
 				if hashTarget != nil && committed != nil {
 					hashTarget.WrittenHash = sha256Hex(newRaw)
 					recordClaudeBackupFile(hashTarget, committed)
-					if saveErr := saveClaudeBackup(a.backupPath, hashTarget); saveErr != nil {
-						fmt.Fprintf(a.out, "claude on: warning: could not bind the retained backup to the committed file: %v\n", saveErr)
+					var saveErr error
+					if nb != nil {
+						saveErr = saveClaudeBackup(a.backupPath, hashTarget)
+					} else {
+						saveErr = saveExistingBackup(hashTarget, "migrated backup commit binding")
+					}
+					if saveErr != nil {
+						fmt.Fprintf(a.out, "claude on: warning: backup binding after the settings commit did not complete cleanly: %v\n", saveErr)
 					}
 				}
 				fmt.Fprintln(a.out, "claude on: settings changed, but post-commit verification failed; original backup retained")
@@ -816,8 +957,8 @@ func (a *claudeAdapter) on() int {
 		}
 		if err := snap.Verify(); err != nil {
 			if originalBackup != nil {
-				if restoreErr := saveClaudeBackup(a.backupPath, originalBackup); restoreErr != nil {
-					fmt.Fprintf(a.out, "claude on: warning: settings changed concurrently and the prior backup could not be restored: %v\n", restoreErr)
+				if restoreErr := saveExistingBackup(originalBackup, "migrated backup rollback"); restoreErr != nil {
+					fmt.Fprintf(a.out, "claude on: warning: settings changed concurrently and backup rollback did not complete cleanly: %v\n", restoreErr)
 				}
 			}
 			fmt.Fprintf(a.out, "claude on: %v\n", err)
@@ -835,8 +976,14 @@ func (a *claudeAdapter) on() int {
 		}
 		hashTarget.WrittenHash = sha256Hex(newRaw)
 		recordClaudeBackupFile(hashTarget, committed)
-		if err := saveClaudeBackup(a.backupPath, hashTarget); err != nil {
-			fmt.Fprintf(a.out, "claude on: warning: could not refresh the backup drift hash: %v\n", err)
+		var refreshErr error
+		if nb != nil {
+			refreshErr = saveClaudeBackup(a.backupPath, hashTarget)
+		} else {
+			refreshErr = saveExistingBackup(hashTarget, "migrated backup drift-hash refresh")
+		}
+		if refreshErr != nil {
+			fmt.Fprintf(a.out, "claude on: warning: backup drift-hash refresh did not complete cleanly: %v\n", refreshErr)
 		}
 	}
 
@@ -871,7 +1018,7 @@ func (a *claudeAdapter) off() int {
 	}
 	raw := snap.Data
 	existed := snap.Exists
-	bak, err := loadClaudeBackup(a.backupPath)
+	bak, backupSnap, err := loadClaudeBackupSnapshot(a.backupPath)
 	if err != nil {
 		fmt.Fprintf(a.out, "claude off: %v\n", err)
 		return 1
@@ -879,8 +1026,9 @@ func (a *claudeAdapter) off() int {
 	if bak != nil && bak.ConfigPath != a.settingsPath {
 		// Should be unreachable given the hash-keyed filename; refuse
 		// to restore a snapshot of a different file.
-		fmt.Fprintf(a.out, "warning: backup %s is for %s, not %s; ignoring it\n", a.backupPath, bak.ConfigPath, a.settingsPath)
-		bak = nil
+		fmt.Fprintf(a.out, "claude off: refusing to modify %s because backup %s is for %s; settings and backup left intact\n",
+			a.settingsPath, a.backupPath, bak.ConfigPath)
+		return 1
 	}
 	if bak != nil && a.poisonedBackup(bak) {
 		fmt.Fprintf(a.out, "warning: backup %s itself points at a gateway port; discarding it instead of restoring (poisoned-backup guard)\n", a.backupPath)
@@ -893,6 +1041,11 @@ func (a *claudeAdapter) off() int {
 
 	if bak == nil {
 		return a.offStripOnly(root, snap, nil)
+	}
+	bak, _, err = a.migrateLegacyLinkedBackup(bak, backupSnap, snap)
+	if err != nil {
+		fmt.Fprintf(a.out, "claude off: %v\n", err)
+		return 1
 	}
 
 	if !claudeBackupTargetSafe(bak, snap) {

--- a/gateway/cmd/baseten-switch/claude_adapter_link_test.go
+++ b/gateway/cmd/baseten-switch/claude_adapter_link_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -481,18 +482,19 @@ func TestClaudeOnOffCreatesAndRemovesThroughSymlinkedParent(t *testing.T) {
 	}
 }
 
-func TestClaudeLegacyBackupDoesNotRestoreThroughFinalLink(t *testing.T) {
+func TestClaudeLegacyLinkedBackupOnOffMigration(t *testing.T) {
 	requireSymlinks(t)
 	a, out := testAdapter(t)
 	if err := os.MkdirAll(filepath.Dir(a.settingsPath), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	target := filepath.Join(filepath.Dir(a.settingsPath), "cloud-settings.json")
-	managed := []byte(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081","CLAUDE_CODE_ATTRIBUTION_HEADER":"0","ENABLE_TOOL_SEARCH":"true","OTHER":"keep"}}`)
+	managed := []byte(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081","OTHER":"keep"},"theme":"dark"}`)
 	if err := os.WriteFile(target, managed, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Symlink(target, a.settingsPath); err != nil {
+	linkText := filepath.Base(target)
+	if err := os.Symlink(linkText, a.settingsPath); err != nil {
 		t.Fatal(err)
 	}
 	legacy := &claudeBackup{
@@ -506,41 +508,80 @@ func TestClaudeLegacyBackupDoesNotRestoreThroughFinalLink(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if code := a.off(); code != 1 {
-		t.Fatalf("off = %d, want legacy linked-target refusal (%s)", code, out.String())
+	if code := a.on(); code != 0 {
+		t.Fatalf("on = %d (%s)", code, out.String())
 	}
-	if got := fileBytes(t, target); !bytes.Equal(got, managed) {
-		t.Fatalf("legacy refusal changed linked target: %s", got)
+	if got, err := os.Readlink(a.settingsPath); err != nil || got != linkText {
+		t.Fatalf("on changed settings link: text=%q err=%v, want %q", got, err, linkText)
 	}
-	if _, err := os.Readlink(a.settingsPath); err != nil {
-		t.Fatalf("off replaced settings link: %v", err)
+	assertClaudeOnValues(t, a)
+	if got, ok := envValue(t, target, "OTHER"); !ok || got != "keep" {
+		t.Fatalf("unrelated env after on = %q, ok=%v", got, ok)
 	}
-	if _, err := os.Stat(a.backupPath); err != nil {
-		t.Fatalf("legacy refusal cleared backup: %v", err)
+	if got := readTree(t, target)["theme"]; got != "dark" {
+		t.Fatalf("unrelated setting after on = %v", got)
+	}
+	upgraded, err := loadClaudeBackup(a.backupPath)
+	if err != nil || upgraded == nil {
+		t.Fatalf("load upgraded backup: bak=%v err=%v", upgraded, err)
+	}
+	_, snap, err := readClaudeSettings(a.settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if upgraded.ResolvedPath != snap.ResolvedPath || upgraded.WrittenIdentity == nil || *upgraded.WrittenIdentity != snap.Identity {
+		t.Fatalf("upgraded provenance = resolved %q identity %v, want %q %+v", upgraded.ResolvedPath, upgraded.WrittenIdentity, snap.ResolvedPath, snap.Identity)
+	}
+	if upgraded.WrittenHash != sha256Hex(snap.Data) {
+		t.Fatalf("upgraded written hash = %q, want current target hash", upgraded.WrittenHash)
+	}
+	if upgraded.ConfigPath != legacy.ConfigPath || upgraded.Values[claudeManagedEnvKey] != legacy.Values[claudeManagedEnvKey] || upgraded.Existed != legacy.Existed {
+		t.Fatalf("migration changed legacy recovery state: got %+v want %+v", upgraded, legacy)
+	}
+
+	out.Reset()
+	if code := a.off(); code != 0 {
+		t.Fatalf("off = %d (%s)", code, out.String())
+	}
+	if got, err := os.Readlink(a.settingsPath); err != nil || got != linkText {
+		t.Fatalf("off changed settings link: text=%q err=%v, want %q", got, err, linkText)
+	}
+	if got, ok := envValue(t, target, claudeManagedEnvKey); !ok || got != "https://legacy.example.com" {
+		t.Fatalf("legacy base URL after off = %q, ok=%v", got, ok)
+	}
+	for _, key := range []string{claudeAttributionEnvKey, claudeToolSearchEnvKey} {
+		if _, ok := envValue(t, target, key); ok {
+			t.Errorf("legacy-uncovered %s survived off", key)
+		}
+	}
+	if got, ok := envValue(t, target, "OTHER"); !ok || got != "keep" {
+		t.Fatalf("unrelated env after off = %q, ok=%v", got, ok)
+	}
+	if got := readTree(t, target)["theme"]; got != "dark" {
+		t.Fatalf("unrelated setting after off = %v", got)
+	}
+	if _, err := os.Stat(a.backupPath); !os.IsNotExist(err) {
+		t.Fatalf("backup after off: %v", err)
 	}
 }
 
-func TestClaudeLegacyBackupDoesNotRestoreThroughSymlinkedParent(t *testing.T) {
+func TestClaudeLegacyBackupMigratesThroughSymlinkedParent(t *testing.T) {
 	requireSymlinks(t)
 	a, out := testAdapter(t)
 	configuredDir := filepath.Dir(a.settingsPath)
-	firstDir := configuredDir + ".first"
-	secondDir := configuredDir + ".second"
-	for _, dir := range []string{firstDir, secondDir} {
-		if err := os.MkdirAll(dir, 0o700); err != nil {
-			t.Fatal(err)
-		}
-	}
-	firstRaw := []byte(`{"env":{"ANTHROPIC_BASE_URL":"https://first.example.com"}}`)
-	secondRaw := []byte(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081","CLAUDE_CODE_ATTRIBUTION_HEADER":"0","ENABLE_TOOL_SEARCH":"true"},"owner":"second"}`)
-	if err := os.WriteFile(filepath.Join(firstDir, filepath.Base(a.settingsPath)), firstRaw, 0o600); err != nil {
+	realDir := configuredDir + ".real"
+	if err := os.MkdirAll(realDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	secondTarget := filepath.Join(secondDir, filepath.Base(a.settingsPath))
-	if err := os.WriteFile(secondTarget, secondRaw, 0o600); err != nil {
+	if err := os.MkdirAll(filepath.Dir(configuredDir), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Symlink(secondDir, configuredDir); err != nil {
+	managed := []byte(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081","OTHER":"keep"},"theme":"dark"}`)
+	target := filepath.Join(realDir, filepath.Base(a.settingsPath))
+	if err := os.WriteFile(target, managed, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realDir, configuredDir); err != nil {
 		t.Fatal(err)
 	}
 	legacy := &claudeBackup{
@@ -548,21 +589,682 @@ func TestClaudeLegacyBackupDoesNotRestoreThroughSymlinkedParent(t *testing.T) {
 		Values:      map[string]string{claudeManagedEnvKey: "https://legacy.example.com"},
 		EnvExisted:  true,
 		Existed:     true,
-		WrittenHash: sha256Hex(secondRaw),
+		WrittenHash: sha256Hex(managed),
 	}
 	if err := saveClaudeBackup(a.backupPath, legacy); err != nil {
 		t.Fatal(err)
 	}
 
-	if code := a.off(); code != 1 {
-		t.Fatalf("off = %d, want legacy parent-link refusal (%s)", code, out.String())
+	if code := a.on(); code != 0 {
+		t.Fatalf("on = %d (%s)", code, out.String())
 	}
-	if got := fileBytes(t, secondTarget); !bytes.Equal(got, secondRaw) {
-		t.Fatalf("legacy refusal changed retargeted parent file: %s", got)
+	upgraded, err := loadClaudeBackup(a.backupPath)
+	if err != nil || upgraded == nil {
+		t.Fatalf("load upgraded backup: bak=%v err=%v", upgraded, err)
 	}
-	if _, err := os.Stat(a.backupPath); err != nil {
-		t.Fatalf("legacy refusal cleared backup: %v", err)
+	_, snap, err := readClaudeSettings(a.settingsPath)
+	if err != nil {
+		t.Fatal(err)
 	}
+	if upgraded.ResolvedPath != target || upgraded.ResolvedPath != snap.ResolvedPath || upgraded.WrittenIdentity == nil || *upgraded.WrittenIdentity != snap.Identity {
+		t.Fatalf("upgraded provenance = resolved %q identity %v, want %q %+v", upgraded.ResolvedPath, upgraded.WrittenIdentity, target, snap.Identity)
+	}
+	if info, err := os.Lstat(configuredDir); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("on changed configured parent symlink: info=%v err=%v", info, err)
+	}
+
+	out.Reset()
+	if code := a.off(); code != 0 {
+		t.Fatalf("off = %d (%s)", code, out.String())
+	}
+	if got, ok := envValue(t, target, claudeManagedEnvKey); !ok || got != "https://legacy.example.com" {
+		t.Fatalf("legacy base URL after off = %q, ok=%v", got, ok)
+	}
+	for _, key := range []string{claudeAttributionEnvKey, claudeToolSearchEnvKey} {
+		if _, ok := envValue(t, target, key); ok {
+			t.Errorf("legacy-uncovered %s survived off", key)
+		}
+	}
+	if got, ok := envValue(t, target, "OTHER"); !ok || got != "keep" {
+		t.Fatalf("unrelated env after off = %q, ok=%v", got, ok)
+	}
+	if info, err := os.Lstat(configuredDir); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("off changed configured parent symlink: info=%v err=%v", info, err)
+	}
+	if st, err := os.Stat(target); err != nil || st.Mode().Perm() != 0o640 {
+		t.Fatalf("target mode after off = %v, err=%v", st.Mode().Perm(), err)
+	}
+	if _, err := os.Stat(a.backupPath); !os.IsNotExist(err) {
+		t.Fatalf("backup after off: %v", err)
+	}
+}
+
+func TestClaudeLegacyLinkedBackupDirectOffMigration(t *testing.T) {
+	requireSymlinks(t)
+	a, out := testAdapter(t)
+	if err := os.MkdirAll(filepath.Dir(a.settingsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(filepath.Dir(a.settingsPath), "cloud-settings.json")
+	managed := []byte(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081","OTHER":"keep"},"theme":"dark"}`)
+	if err := os.WriteFile(target, managed, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	linkText := filepath.Base(target)
+	if err := os.Symlink(linkText, a.settingsPath); err != nil {
+		t.Fatal(err)
+	}
+	legacy := &claudeBackup{
+		ConfigPath:  a.settingsPath,
+		Values:      map[string]string{claudeManagedEnvKey: "https://legacy.example.com"},
+		EnvExisted:  true,
+		Existed:     true,
+		WrittenHash: sha256Hex(managed),
+	}
+	if err := saveClaudeBackup(a.backupPath, legacy); err != nil {
+		t.Fatal(err)
+	}
+
+	if code := a.off(); code != 0 {
+		t.Fatalf("off = %d (%s)", code, out.String())
+	}
+	if got, err := os.Readlink(a.settingsPath); err != nil || got != linkText {
+		t.Fatalf("off changed settings link: text=%q err=%v, want %q", got, err, linkText)
+	}
+	if got, ok := envValue(t, target, claudeManagedEnvKey); !ok || got != "https://legacy.example.com" {
+		t.Fatalf("legacy base URL after off = %q, ok=%v", got, ok)
+	}
+	if got, ok := envValue(t, target, "OTHER"); !ok || got != "keep" {
+		t.Fatalf("unrelated env after off = %q, ok=%v", got, ok)
+	}
+	if got := readTree(t, target)["theme"]; got != "dark" {
+		t.Fatalf("unrelated setting after off = %v", got)
+	}
+	if _, err := os.Stat(a.backupPath); !os.IsNotExist(err) {
+		t.Fatalf("backup after off: %v", err)
+	}
+}
+
+func TestClaudeLegacyLinkedBackupHashMismatchRefuses(t *testing.T) {
+	requireSymlinks(t)
+	for _, command := range []string{"on", "off"} {
+		t.Run(command, func(t *testing.T) {
+			a, out := testAdapter(t)
+			if err := os.MkdirAll(filepath.Dir(a.settingsPath), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			target := filepath.Join(filepath.Dir(a.settingsPath), "cloud-settings.json")
+			recorded := []byte(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081","OTHER":"before"}}`)
+			drifted := []byte(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081","OTHER":"after"},"theme":"dark"}`)
+			if err := os.WriteFile(target, drifted, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			linkText := filepath.Base(target)
+			if err := os.Symlink(linkText, a.settingsPath); err != nil {
+				t.Fatal(err)
+			}
+			legacy := &claudeBackup{
+				ConfigPath:  a.settingsPath,
+				Values:      map[string]string{claudeManagedEnvKey: "https://legacy.example.com"},
+				EnvExisted:  true,
+				Existed:     true,
+				WrittenHash: sha256Hex(recorded),
+			}
+			if err := saveClaudeBackup(a.backupPath, legacy); err != nil {
+				t.Fatal(err)
+			}
+			backupBefore := fileBytes(t, a.backupPath)
+
+			var code int
+			if command == "on" {
+				code = a.on()
+			} else {
+				code = a.off()
+			}
+			if code != 1 {
+				t.Fatalf("%s = %d, want refusal (%s)", command, code, out.String())
+			}
+			for _, want := range []string{"legacy backup", "predates linked-settings support", "does not exactly match", "backup left intact", "restore the link", "do not delete the backup"} {
+				if !strings.Contains(out.String(), want) {
+					t.Errorf("%s diagnostic missing %q: %q", command, want, out.String())
+				}
+			}
+			if got := fileBytes(t, target); !bytes.Equal(got, drifted) {
+				t.Fatalf("%s changed drifted target: %s", command, got)
+			}
+			if got, err := os.Readlink(a.settingsPath); err != nil || got != linkText {
+				t.Fatalf("%s changed settings link: text=%q err=%v, want %q", command, got, err, linkText)
+			}
+			if got := fileBytes(t, a.backupPath); !bytes.Equal(got, backupBefore) {
+				t.Fatalf("%s changed non-adoptable legacy backup", command)
+			}
+		})
+	}
+}
+
+func TestClaudeLinkedBackupPartialMetadataRefuses(t *testing.T) {
+	requireSymlinks(t)
+	for _, metadata := range []string{"resolved path only", "identity only"} {
+		for _, command := range []string{"on", "off"} {
+			t.Run(metadata+"/"+command, func(t *testing.T) {
+				a, out := testAdapter(t)
+				if err := os.MkdirAll(filepath.Dir(a.settingsPath), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				target := filepath.Join(filepath.Dir(a.settingsPath), "cloud-settings.json")
+				managed := []byte(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081","OTHER":"keep"}}`)
+				if err := os.WriteFile(target, managed, 0o600); err != nil {
+					t.Fatal(err)
+				}
+				linkText := filepath.Base(target)
+				if err := os.Symlink(linkText, a.settingsPath); err != nil {
+					t.Fatal(err)
+				}
+				_, snap, err := readClaudeSettings(a.settingsPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				bak := &claudeBackup{
+					ConfigPath:  a.settingsPath,
+					Values:      map[string]string{claudeManagedEnvKey: "https://legacy.example.com"},
+					EnvExisted:  true,
+					Existed:     true,
+					WrittenHash: sha256Hex(managed),
+				}
+				if metadata == "resolved path only" {
+					bak.ResolvedPath = snap.ResolvedPath
+				} else {
+					identity := snap.Identity
+					bak.WrittenIdentity = &identity
+				}
+				if err := saveClaudeBackup(a.backupPath, bak); err != nil {
+					t.Fatal(err)
+				}
+				backupBefore := fileBytes(t, a.backupPath)
+
+				var code int
+				if command == "on" {
+					code = a.on()
+				} else {
+					code = a.off()
+				}
+				if code != 1 {
+					t.Fatalf("%s = %d, want refusal (%s)", command, code, out.String())
+				}
+				if !strings.Contains(out.String(), "incomplete") || !strings.Contains(out.String(), "metadata") {
+					t.Errorf("%s diagnostic does not identify incomplete metadata: %q", command, out.String())
+				}
+				if got := fileBytes(t, target); !bytes.Equal(got, managed) {
+					t.Fatalf("%s changed target: %s", command, got)
+				}
+				if got, err := os.Readlink(a.settingsPath); err != nil || got != linkText {
+					t.Fatalf("%s changed settings link: text=%q err=%v, want %q", command, got, err, linkText)
+				}
+				if got := fileBytes(t, a.backupPath); !bytes.Equal(got, backupBefore) {
+					t.Fatalf("%s changed partial-metadata backup", command)
+				}
+			})
+		}
+	}
+}
+
+func TestClaudeLegacyLinkedBackupRetargetAfterMigrationKeepsProvenance(t *testing.T) {
+	requireSymlinks(t)
+	a, out := testAdapter(t)
+	if err := os.MkdirAll(filepath.Dir(a.settingsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	first := filepath.Join(filepath.Dir(a.settingsPath), "first.json")
+	second := filepath.Join(filepath.Dir(a.settingsPath), "second.json")
+	firstRaw := []byte(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081","OTHER":"keep"}}`)
+	secondRaw := []byte(`{"env":{"ANTHROPIC_BASE_URL":"https://second.example.com","OTHER":"second"}}`)
+	if err := os.WriteFile(first, firstRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(second, secondRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Base(first), a.settingsPath); err != nil {
+		t.Fatal(err)
+	}
+	_, firstSnap, err := readClaudeSettings(a.settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := &claudeBackup{
+		ConfigPath:  a.settingsPath,
+		Values:      map[string]string{claudeManagedEnvKey: "https://legacy.example.com"},
+		EnvExisted:  true,
+		Existed:     true,
+		WrittenHash: sha256Hex(firstRaw),
+	}
+	if err := saveClaudeBackup(a.backupPath, legacy); err != nil {
+		t.Fatal(err)
+	}
+
+	var staged *claudeBackup
+	var stagedErr error
+	oldHook := claudeBeforeSettingsMutation
+	claudeBeforeSettingsMutation = func() {
+		staged, stagedErr = loadClaudeBackup(a.backupPath)
+		if err := os.Remove(a.settingsPath); err != nil {
+			panic(err)
+		}
+		if err := os.Symlink(filepath.Base(second), a.settingsPath); err != nil {
+			panic(err)
+		}
+	}
+	t.Cleanup(func() { claudeBeforeSettingsMutation = oldHook })
+
+	if code := a.on(); code != 1 {
+		t.Fatalf("on = %d, want retarget conflict (%s)", code, out.String())
+	}
+	if stagedErr != nil || staged == nil {
+		t.Fatalf("load staged backup: bak=%v err=%v", staged, stagedErr)
+	}
+	if staged.ResolvedPath != firstSnap.ResolvedPath || staged.WrittenIdentity == nil || *staged.WrittenIdentity != firstSnap.Identity {
+		t.Fatalf("staged provenance = resolved %q identity %v, want %q %+v", staged.ResolvedPath, staged.WrittenIdentity, firstSnap.ResolvedPath, firstSnap.Identity)
+	}
+	if !backupCovers(staged, claudeAttributionEnvKey) || !backupCovers(staged, claudeToolSearchEnvKey) {
+		t.Fatalf("staged backup does not cover additive keys: %+v", staged)
+	}
+	if got := fileBytes(t, first); !bytes.Equal(got, firstRaw) {
+		t.Fatalf("original target changed: %s", got)
+	}
+	if got := fileBytes(t, second); !bytes.Equal(got, secondRaw) {
+		t.Fatalf("retargeted target changed: %s", got)
+	}
+	if got, err := os.Readlink(a.settingsPath); err != nil || got != filepath.Base(second) {
+		t.Fatalf("retargeted link changed: text=%q err=%v", got, err)
+	}
+	retained, err := loadClaudeBackup(a.backupPath)
+	if err != nil || retained == nil {
+		t.Fatalf("load retained backup: bak=%v err=%v", retained, err)
+	}
+	if retained.ResolvedPath != firstSnap.ResolvedPath || retained.WrittenIdentity == nil || *retained.WrittenIdentity != firstSnap.Identity {
+		t.Fatalf("retained provenance = resolved %q identity %v, want %q %+v", retained.ResolvedPath, retained.WrittenIdentity, firstSnap.ResolvedPath, firstSnap.Identity)
+	}
+	if retained.WrittenHash != legacy.WrittenHash || retained.Values[claudeManagedEnvKey] != legacy.Values[claudeManagedEnvKey] {
+		t.Fatalf("retained backup changed legacy recovery state: got %+v want %+v", retained, legacy)
+	}
+	if backupCovers(retained, claudeAttributionEnvKey) || backupCovers(retained, claudeToolSearchEnvKey) {
+		t.Fatalf("failed mutation retained stale additive backup entries: %+v", retained)
+	}
+}
+
+func TestClaudeLegacyLinkedBackupMigrationWriteFailurePreservesOriginal(t *testing.T) {
+	requireSymlinks(t)
+	a, out := testAdapter(t)
+	if err := os.MkdirAll(filepath.Dir(a.settingsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(filepath.Dir(a.settingsPath), "cloud-settings.json")
+	managed := []byte(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081","OTHER":"keep"}}`)
+	if err := os.WriteFile(target, managed, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	linkText := filepath.Base(target)
+	if err := os.Symlink(linkText, a.settingsPath); err != nil {
+		t.Fatal(err)
+	}
+	legacy := &claudeBackup{
+		ConfigPath:  a.settingsPath,
+		Values:      map[string]string{claudeManagedEnvKey: "https://legacy.example.com"},
+		EnvExisted:  true,
+		Existed:     true,
+		WrittenHash: sha256Hex(managed),
+	}
+	if err := saveClaudeBackup(a.backupPath, legacy); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-create the lock so making the backup directory read-only blocks only
+	// the migration's atomic replacement, not mutation-lock acquisition.
+	if err := os.WriteFile(a.backupPath+".mutation.lock", nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	backupBefore := fileBytes(t, a.backupPath)
+	backupDir := filepath.Dir(a.backupPath)
+	if err := os.Chmod(backupDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(backupDir, 0o700) })
+
+	if code := a.on(); code != 1 {
+		t.Fatalf("on = %d, want migrated-backup replacement failure (%s)", code, out.String())
+	}
+	for _, want := range []string{"backup", "settings untouched", "not applied"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("on diagnostic missing %q for migrated-backup write failure: %q", want, out.String())
+		}
+	}
+	if got := fileBytes(t, target); !bytes.Equal(got, managed) {
+		t.Fatalf("failed migration changed settings target: %s", got)
+	}
+	if got, err := os.Readlink(a.settingsPath); err != nil || got != linkText {
+		t.Fatalf("failed migration changed settings link: text=%q err=%v, want %q", got, err, linkText)
+	}
+	if got := fileBytes(t, a.backupPath); !bytes.Equal(got, backupBefore) {
+		t.Fatalf("failed migration changed original legacy backup bytes")
+	}
+}
+
+func TestClaudeLegacyLinkedBackupMigrationRejectsConcurrentBackupChange(t *testing.T) {
+	requireSymlinks(t)
+	a, _ := testAdapter(t)
+	if err := os.MkdirAll(filepath.Dir(a.settingsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(filepath.Dir(a.settingsPath), "cloud-settings.json")
+	managed := []byte(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081","OTHER":"keep"}}`)
+	if err := os.WriteFile(target, managed, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	linkText := filepath.Base(target)
+	if err := os.Symlink(linkText, a.settingsPath); err != nil {
+		t.Fatal(err)
+	}
+	legacy := &claudeBackup{
+		ConfigPath:  a.settingsPath,
+		Values:      map[string]string{claudeManagedEnvKey: "https://legacy.example.com"},
+		EnvExisted:  true,
+		Existed:     true,
+		WrittenHash: sha256Hex(managed),
+	}
+	if err := saveClaudeBackup(a.backupPath, legacy); err != nil {
+		t.Fatal(err)
+	}
+	bak, backupSnap, err := loadClaudeBackupSnapshot(a.backupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, settingsSnap, err := readClaudeSettings(a.settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	concurrent := cloneClaudeBackup(legacy)
+	concurrent.Values[claudeManagedEnvKey] = "https://concurrent.example.com"
+	if err := saveClaudeBackup(a.backupPath, concurrent); err != nil {
+		t.Fatal(err)
+	}
+	concurrentBytes := fileBytes(t, a.backupPath)
+
+	got, migrated, err := a.migrateLegacyLinkedBackup(bak, backupSnap, settingsSnap)
+	if err == nil || migrated {
+		t.Fatalf("migration = bak=%+v migrated=%v err=%v, want concurrent-backup refusal", got, migrated, err)
+	}
+	if !strings.Contains(err.Error(), "changed concurrently") || !strings.Contains(err.Error(), "not overwritten") {
+		t.Fatalf("concurrent-backup diagnostic = %q", err)
+	}
+	if got == nil || got.ResolvedPath != "" || got.WrittenIdentity != nil || got.Values[claudeManagedEnvKey] != legacy.Values[claudeManagedEnvKey] {
+		t.Fatalf("failed migration returned changed legacy state: %+v", got)
+	}
+	if actual := fileBytes(t, a.backupPath); !bytes.Equal(actual, concurrentBytes) {
+		t.Fatalf("migration overwrote concurrent backup")
+	}
+	if actual := fileBytes(t, target); !bytes.Equal(actual, managed) {
+		t.Fatalf("concurrent-backup refusal changed settings target: %s", actual)
+	}
+	if actual, err := os.Readlink(a.settingsPath); err != nil || actual != linkText {
+		t.Fatalf("concurrent-backup refusal changed settings link: text=%q err=%v, want %q", actual, err, linkText)
+	}
+}
+
+func TestClaudeLegacyLinkedBackupAdditiveSaveFailureKeepsAdoptedProvenance(t *testing.T) {
+	requireSymlinks(t)
+	a, out := testAdapter(t)
+	if err := os.MkdirAll(filepath.Dir(a.settingsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(filepath.Dir(a.settingsPath), "cloud-settings.json")
+	managed := []byte(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081","OTHER":"keep"}}`)
+	if err := os.WriteFile(target, managed, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	linkText := filepath.Base(target)
+	if err := os.Symlink(linkText, a.settingsPath); err != nil {
+		t.Fatal(err)
+	}
+	_, settingsSnap, err := readClaudeSettings(a.settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := &claudeBackup{
+		ConfigPath:  a.settingsPath,
+		Values:      map[string]string{claudeManagedEnvKey: "https://legacy.example.com"},
+		EnvExisted:  true,
+		Existed:     true,
+		WrittenHash: sha256Hex(managed),
+	}
+	if err := saveClaudeBackup(a.backupPath, legacy); err != nil {
+		t.Fatal(err)
+	}
+	expected := cloneClaudeBackup(legacy)
+	recordClaudeBackupFile(expected, settingsSnap)
+	expectedBytes, err := marshalClaudeBackup(expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backupDir := filepath.Dir(a.backupPath)
+	hookCalled := false
+	oldHook := claudeBeforeMigratedBackupReplace
+	claudeBeforeMigratedBackupReplace = func(action string) {
+		if action != "migrated backup additive update" {
+			return
+		}
+		hookCalled = true
+		if err := os.Chmod(backupDir, 0o500); err != nil {
+			panic(err)
+		}
+	}
+	t.Cleanup(func() {
+		claudeBeforeMigratedBackupReplace = oldHook
+		_ = os.Chmod(backupDir, 0o700)
+	})
+
+	if code := a.on(); code != 1 {
+		t.Fatalf("on = %d, want additive-backup replacement failure (%s)", code, out.String())
+	}
+	if !hookCalled {
+		t.Fatal("on did not route the additive update through the migrated-backup CAS seam")
+	}
+	for _, want := range []string{"write backup", "failed before backup replacement", "not applied", "settings untouched"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("additive-backup failure diagnostic missing %q: %q", want, out.String())
+		}
+	}
+	if got := fileBytes(t, target); !bytes.Equal(got, managed) {
+		t.Fatalf("additive-backup failure changed settings target: %s", got)
+	}
+	if got, err := os.Readlink(a.settingsPath); err != nil || got != linkText {
+		t.Fatalf("additive-backup failure changed settings link: text=%q err=%v, want %q", got, err, linkText)
+	}
+	retainedBytes := fileBytes(t, a.backupPath)
+	if len(retainedBytes) == 0 {
+		t.Fatal("additive-backup failure truncated the sole recovery backup")
+	}
+	if !bytes.Equal(retainedBytes, expectedBytes) {
+		t.Fatal("additive-backup failure changed the adopted recovery backup")
+	}
+	retained, err := loadClaudeBackup(a.backupPath)
+	if err != nil || retained == nil {
+		t.Fatalf("retained backup is not valid JSON recovery state: bak=%v err=%v bytes=%q", retained, err, retainedBytes)
+	}
+	if retained.ResolvedPath != settingsSnap.ResolvedPath || retained.WrittenIdentity == nil || *retained.WrittenIdentity != settingsSnap.Identity {
+		t.Fatalf("retained provenance = resolved %q identity %v, want %q %+v", retained.ResolvedPath, retained.WrittenIdentity, settingsSnap.ResolvedPath, settingsSnap.Identity)
+	}
+	if retained.WrittenHash != legacy.WrittenHash || retained.Values[claudeManagedEnvKey] != legacy.Values[claudeManagedEnvKey] {
+		t.Fatalf("retained backup changed legacy recovery state: got %+v want %+v", retained, legacy)
+	}
+	if backupCovers(retained, claudeAttributionEnvKey) || backupCovers(retained, claudeToolSearchEnvKey) {
+		t.Fatalf("failed additive save falsely committed managed-key snapshots: %+v", retained)
+	}
+	backups, err := filepath.Glob(filepath.Join(filepath.Dir(a.backupPath), "config-backup.*.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(backups) != 1 || backups[0] != a.backupPath {
+		t.Fatalf("recovery backup files = %v, want only %s", backups, a.backupPath)
+	}
+}
+
+func TestClaudeLegacyLinkedBackupAdditiveSaveRejectsConcurrentBackupChange(t *testing.T) {
+	requireSymlinks(t)
+	a, out := testAdapter(t)
+	if err := os.MkdirAll(filepath.Dir(a.settingsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(filepath.Dir(a.settingsPath), "cloud-settings.json")
+	managed := []byte(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081","OTHER":"keep"}}`)
+	if err := os.WriteFile(target, managed, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	linkText := filepath.Base(target)
+	if err := os.Symlink(linkText, a.settingsPath); err != nil {
+		t.Fatal(err)
+	}
+	_, settingsSnap, err := readClaudeSettings(a.settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := &claudeBackup{
+		ConfigPath:  a.settingsPath,
+		Values:      map[string]string{claudeManagedEnvKey: "https://legacy.example.com"},
+		EnvExisted:  true,
+		Existed:     true,
+		WrittenHash: sha256Hex(managed),
+	}
+	if err := saveClaudeBackup(a.backupPath, legacy); err != nil {
+		t.Fatal(err)
+	}
+	concurrent := cloneClaudeBackup(legacy)
+	recordClaudeBackupFile(concurrent, settingsSnap)
+	concurrent.Model = "concurrent-model"
+	concurrentBytes, err := marshalClaudeBackup(concurrent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	concurrentTemp := a.backupPath + ".concurrent"
+	if err := os.WriteFile(concurrentTemp, concurrentBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Remove(concurrentTemp) })
+
+	hookCalled := false
+	oldHook := claudeBeforeMigratedBackupReplace
+	claudeBeforeMigratedBackupReplace = func(action string) {
+		if action != "migrated backup additive update" {
+			return
+		}
+		hookCalled = true
+		if err := os.Rename(concurrentTemp, a.backupPath); err != nil {
+			panic(err)
+		}
+	}
+	t.Cleanup(func() { claudeBeforeMigratedBackupReplace = oldHook })
+
+	if code := a.on(); code != 1 {
+		t.Fatalf("on = %d, want concurrent additive-backup refusal (%s)", code, out.String())
+	}
+	if !hookCalled {
+		t.Fatal("on did not route the additive update through the migrated-backup CAS seam")
+	}
+	if !strings.Contains(out.String(), "changed concurrently") || !strings.Contains(out.String(), "not overwritten") {
+		t.Fatalf("concurrent additive-backup diagnostic = %q", out.String())
+	}
+	if got := fileBytes(t, a.backupPath); !bytes.Equal(got, concurrentBytes) {
+		t.Fatalf("additive save overwrote concurrent backup")
+	}
+	if got := fileBytes(t, target); !bytes.Equal(got, managed) {
+		t.Fatalf("concurrent additive-backup refusal changed settings target: %s", got)
+	}
+	if got, err := os.Readlink(a.settingsPath); err != nil || got != linkText {
+		t.Fatalf("concurrent additive-backup refusal changed settings link: text=%q err=%v, want %q", got, err, linkText)
+	}
+}
+
+func TestClaudeOnConfigPathMismatchRefusesBeforeMutation(t *testing.T) {
+	t.Run("direct legacy backup", func(t *testing.T) {
+		a, out := testAdapter(t)
+		managed := []byte(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081","OTHER":"keep"}}`)
+		writeSettingsFile(t, a, string(managed))
+		bak := &claudeBackup{
+			ConfigPath:  a.settingsPath + ".other",
+			Values:      map[string]string{claudeManagedEnvKey: "https://legacy.example.com"},
+			EnvExisted:  true,
+			Existed:     true,
+			WrittenHash: sha256Hex(managed),
+		}
+		if err := saveClaudeBackup(a.backupPath, bak); err != nil {
+			t.Fatal(err)
+		}
+		backupBefore := fileBytes(t, a.backupPath)
+
+		if code := a.on(); code != 1 {
+			t.Fatalf("on = %d, want config-path refusal (%s)", code, out.String())
+		}
+		for _, want := range []string{"backup", "is for", "left intact"} {
+			if !strings.Contains(out.String(), want) {
+				t.Errorf("config-path diagnostic missing %q: %q", want, out.String())
+			}
+		}
+		if got := fileBytes(t, a.settingsPath); !bytes.Equal(got, managed) {
+			t.Fatalf("config-path refusal changed direct settings: %s", got)
+		}
+		if got := fileBytes(t, a.backupPath); !bytes.Equal(got, backupBefore) {
+			t.Fatalf("config-path refusal changed direct legacy backup")
+		}
+	})
+
+	t.Run("linked current backup", func(t *testing.T) {
+		requireSymlinks(t)
+		a, out := testAdapter(t)
+		if err := os.MkdirAll(filepath.Dir(a.settingsPath), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		target := filepath.Join(filepath.Dir(a.settingsPath), "cloud-settings.json")
+		managed := []byte(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081","OTHER":"keep"}}`)
+		if err := os.WriteFile(target, managed, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		linkText := filepath.Base(target)
+		if err := os.Symlink(linkText, a.settingsPath); err != nil {
+			t.Fatal(err)
+		}
+		_, snap, err := readClaudeSettings(a.settingsPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		bak := &claudeBackup{
+			ConfigPath:  a.settingsPath + ".other",
+			Values:      map[string]string{claudeManagedEnvKey: "https://legacy.example.com"},
+			EnvExisted:  true,
+			Existed:     true,
+			WrittenHash: sha256Hex(managed),
+		}
+		recordClaudeBackupFile(bak, snap)
+		if err := saveClaudeBackup(a.backupPath, bak); err != nil {
+			t.Fatal(err)
+		}
+		backupBefore := fileBytes(t, a.backupPath)
+
+		if code := a.on(); code != 1 {
+			t.Fatalf("on = %d, want config-path refusal (%s)", code, out.String())
+		}
+		for _, want := range []string{"backup", "is for", "left intact"} {
+			if !strings.Contains(out.String(), want) {
+				t.Errorf("config-path diagnostic missing %q: %q", want, out.String())
+			}
+		}
+		if got := fileBytes(t, target); !bytes.Equal(got, managed) {
+			t.Fatalf("config-path refusal changed linked settings: %s", got)
+		}
+		if got, err := os.Readlink(a.settingsPath); err != nil || got != linkText {
+			t.Fatalf("config-path refusal changed settings link: text=%q err=%v, want %q", got, err, linkText)
+		}
+		if got := fileBytes(t, a.backupPath); !bytes.Equal(got, backupBefore) {
+			t.Fatalf("config-path refusal changed current backup")
+		}
+	})
 }
 
 func TestClaudeOffNeverRemovesFinalSymlinkTarget(t *testing.T) {


### PR DESCRIPTION
## Summary

- migrate older Claude backups when the current linked target exactly matches the recorded file hash
- keep migration-related backup updates atomic and protected by preimage checks
- fail closed for drift, malformed metadata, config-path mismatches, retargets, and concurrent backup changes

## Testing

- go test -count=1 -race ./cmd/baseten-switch
- go test -count=1 ./internal/safefile
- scripts/check.sh