### PR TITLE
Add crash-safe recovery for routing mutations

### DIFF
--- a/gateway/cmd/baseten-switch/claude_adapter.go
+++ b/gateway/cmd/baseten-switch/claude_adapter.go
@@ -93,6 +93,9 @@ func cmdClaude(args []string) int {
 		fmt.Fprintln(os.Stderr, "usage: baseten-switch claude on|off|status|subagents [<model>|on|inherit]|route [<family> <target|default>]|reasoning baseten <model> off|follow-harness|effort <value>|default  (start/stop are aliases for on/off)")
 		return 2
 	}
+	if replayed, rc := preflightClaudeTerminalReplay(args); replayed {
+		return rc
+	}
 	a, err := newClaudeAdapterFromEnv()
 	if err != nil {
 		if args[0] == "route" ||
@@ -128,11 +131,47 @@ func cmdClaude(args []string) int {
 	case "route":
 		return a.route(args[1:], os.Stdout)
 	case "reasoning":
-		return runClientReasoning(a.clientName, args[1:], os.Stdout)
+		return runClientReasoning(mutationSurfaceClaude, a.clientName, args[1:], os.Stdout)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown claude subcommand: %s (use on|off|status|subagents|route|reasoning)\n", args[0])
 		return 2
 	}
+}
+
+func preflightClaudeTerminalReplay(args []string) (bool, int) {
+	path, _ := resolveConfigPath()
+	var opts mutationOptions
+	var spec journaledMutationSpec
+	var err error
+	switch args[0] {
+	case "route":
+		var positional []string
+		opts, positional, err = parseMutationOptions(args[1:])
+		if err != nil || len(positional) != 2 {
+			return false, 0
+		}
+		spec = journaledMutationSpec{Operation: "set_claude_route", Surface: mutationSurfaceClaude, Key: positional[0], RequestedTarget: positional[1]}
+	case "subagents":
+		var positional []string
+		opts, positional, err = parseMutationOptions(args[1:])
+		if err != nil || len(positional) != 1 {
+			return false, 0
+		}
+		target := positional[0]
+		if target == "off" {
+			target = "inherit"
+		}
+		spec = journaledMutationSpec{Operation: "set_claude_subagents", Surface: mutationSurfaceClaude, Key: "subagents", RequestedTarget: target}
+	case "reasoning":
+		opts, spec, err = reasoningTerminalReplayRequest("", args[1:])
+		if err != nil {
+			return false, 0
+		}
+		spec.Surface = mutationSurfaceClaude
+	default:
+		return false, 0
+	}
+	return preflightTerminalReplay(path, opts, spec, os.Stdout)
 }
 
 // claudeAdapter carries the resolved paths and gateway topology for
@@ -166,6 +205,7 @@ func (a *claudeAdapter) requiresJournaledMutation(_ mutationOptions) (bool, erro
 }
 
 func (a *claudeAdapter) runClaudeJournaledMutationLocked(opts mutationOptions, stdout io.Writer, spec journaledMutationSpec) int {
+	spec.Surface = mutationSurfaceClaude
 	out := stdout
 	if !opts.JSON {
 		out = a.out
@@ -1235,8 +1275,9 @@ func (a *claudeAdapter) subagentsSetModel(model string, opts mutationOptions, st
 		})
 	}
 	if err := config.SetClientScalars(a.configPath, a.clientName, set); err != nil {
-		fmt.Fprintf(a.out, "claude subagents: %v\n", err)
-		return 1
+		return failMutation(opts, stdout, mutationResult{
+			Operation: "set_claude_subagents", Client: a.clientName, Key: "subagents", RequestedTarget: model, ConfigPath: a.configPath,
+		}, "config_edit_failed", err.Error(), false, 1)
 	}
 
 	switch class {
@@ -1259,8 +1300,9 @@ func (a *claudeAdapter) subagentsSetModel(model string, opts mutationOptions, st
 func (a *claudeAdapter) subagentsRouting(want, requestedTarget string, opts mutationOptions, stdout io.Writer, journaled bool) int {
 	f, err := config.Load(a.configPath)
 	if err != nil {
-		fmt.Fprintf(a.out, "claude subagents: %v\n", err)
-		return 1
+		return failMutation(opts, stdout, mutationResult{
+			Operation: "set_claude_subagents", Client: a.clientName, Key: "subagents", RequestedTarget: requestedTarget, ConfigPath: a.configPath,
+		}, "config_load_failed", err.Error(), false, 1)
 	}
 	var cur *config.Client
 	for i := range f.Clients {
@@ -1270,8 +1312,9 @@ func (a *claudeAdapter) subagentsRouting(want, requestedTarget string, opts muta
 		}
 	}
 	if cur == nil {
-		fmt.Fprintf(a.out, "claude subagents: no client named %q in %s\n", a.clientName, a.configPath)
-		return 1
+		return failMutation(opts, stdout, mutationResult{
+			Operation: "set_claude_subagents", Client: a.clientName, Key: "subagents", RequestedTarget: requestedTarget, ConfigPath: a.configPath,
+		}, "invalid_routing_policy", "selected client is absent from the routing config", false, 1)
 	}
 	if want == "on" && cur.SubagentModel == "" {
 		return failMutation(opts, stdout, mutationResult{
@@ -1337,8 +1380,9 @@ func (a *claudeAdapter) subagentsRouting(want, requestedTarget string, opts muta
 	}
 
 	if err := config.SetClientScalars(a.configPath, a.clientName, set); err != nil {
-		fmt.Fprintf(a.out, "claude subagents: %v\n", err)
-		return 1
+		return failMutation(opts, stdout, mutationResult{
+			Operation: "set_claude_subagents", Client: a.clientName, Key: "subagents", RequestedTarget: requestedTarget, ConfigPath: a.configPath,
+		}, "config_edit_failed", err.Error(), false, 1)
 	}
 	a.subagentsReloadAndVerify(cur.SubagentModel, want)
 	if want == "off" {
@@ -1716,8 +1760,9 @@ func (a *claudeAdapter) routeSet(key, target string, stdout io.Writer, opts muta
 		})
 	}
 	if err := config.SetClientMapEntries(a.configPath, a.clientName, "model_routes", map[string]string{key: target}); err != nil {
-		fmt.Fprintf(a.out, "claude route: %v\n", err)
-		return 1
+		return failMutation(opts, stdout, mutationResult{
+			Operation: "set_claude_route", Client: a.clientName, Key: key, RequestedTarget: target, ConfigPath: a.configPath,
+		}, "config_edit_failed", err.Error(), false, 1)
 	}
 	switch class {
 	case subagentClassSlug:
@@ -1733,8 +1778,9 @@ func (a *claudeAdapter) routeSet(key, target string, stdout io.Writer, opts muta
 func (a *claudeAdapter) routeRemove(key string, stdout io.Writer, opts mutationOptions, journaled bool) int {
 	f, err := config.Load(a.configPath)
 	if err != nil {
-		fmt.Fprintf(a.out, "claude route: %v\n", err)
-		return 1
+		return failMutation(opts, stdout, mutationResult{
+			Operation: "set_claude_route", Client: a.clientName, Key: key, RequestedTarget: "default", ConfigPath: a.configPath,
+		}, "config_load_failed", err.Error(), false, 1)
 	}
 	var cur *config.Client
 	for i := range f.Clients {
@@ -1744,10 +1790,21 @@ func (a *claudeAdapter) routeRemove(key string, stdout io.Writer, opts mutationO
 		}
 	}
 	if cur == nil {
-		fmt.Fprintf(a.out, "claude route: no client named %q in %s\n", a.clientName, a.configPath)
-		return 1
+		return failMutation(opts, stdout, mutationResult{
+			Operation: "set_claude_route", Client: a.clientName, Key: key, RequestedTarget: "default", ConfigPath: a.configPath,
+		}, "invalid_routing_policy", "selected client is absent from the routing config", false, 1)
 	}
 	if _, pinned := cur.ModelRoutes[key]; !pinned {
+		if journaled {
+			return a.runClaudeJournaledMutationLocked(opts, stdout, journaledMutationSpec{
+				Operation:       "set_claude_route",
+				RequestedTarget: "default",
+				Client:          a.clientName,
+				Key:             key,
+				Apply:           func(string) error { return nil },
+				HumanSuccess:    fmt.Sprintf("claude route: %s already default (no pin in gateway.yaml)", key),
+			})
+		}
 		fmt.Fprintf(a.out, "claude route: %s already default (no pin in gateway.yaml)\n", key)
 		return 0
 	}
@@ -1772,8 +1829,9 @@ func (a *claudeAdapter) routeRemove(key string, stdout io.Writer, opts mutationO
 		return 0
 	}
 	if err := config.RemoveClientMapEntries(a.configPath, a.clientName, "model_routes", []string{key}); err != nil {
-		fmt.Fprintf(a.out, "claude route: %v\n", err)
-		return 1
+		return failMutation(opts, stdout, mutationResult{
+			Operation: "set_claude_route", Client: a.clientName, Key: key, RequestedTarget: "default", ConfigPath: a.configPath,
+		}, "config_edit_failed", err.Error(), false, 1)
 	}
 	a.routeReloadAndVerify(key, "")
 	fmt.Fprintf(a.out, "claude route: %s -> default (pin removed from %s)\n", key, a.configPath)

--- a/gateway/cmd/baseten-switch/claude_route_test.go
+++ b/gateway/cmd/baseten-switch/claude_route_test.go
@@ -629,7 +629,7 @@ door:
 		if strings.Contains(stderr, "verified live") {
 			t.Errorf("stale admin must not verify: %q", stderr)
 		}
-		if !strings.Contains(stderr, "restored and reactivated the prior exact config") {
+		if !strings.Contains(stderr, "prior routing state was restored") {
 			t.Errorf("rollback confirmation missing: %q", stderr)
 		}
 		if strings.Contains(stderr, "warning: SIGHUP sent") {

--- a/gateway/cmd/baseten-switch/claude_subagents_test.go
+++ b/gateway/cmd/baseten-switch/claude_subagents_test.go
@@ -377,7 +377,7 @@ func TestSubagentsOnWithoutModelExits1(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("on without model = %d, want 1 (%s)", code, stderr)
 	}
-	if !strings.Contains(stderr, "no subagent_model configured") {
+	if !strings.Contains(stderr, "set a subagent model") {
 		t.Errorf("error must name the fix: %q", stderr)
 	}
 }
@@ -585,7 +585,7 @@ door:
 	if strings.Contains(stderr, "verified live") {
 		t.Errorf("stale admin must not verify: %q", stderr)
 	}
-	if !strings.Contains(stderr, "restored and reactivated the prior exact config") {
+	if !strings.Contains(stderr, "prior routing state was restored") {
 		t.Errorf("rollback confirmation missing: %q", stderr)
 	}
 	// The notice must be calm, not scary: no "warning" prefix.

--- a/gateway/cmd/baseten-switch/codex_adapter.go
+++ b/gateway/cmd/baseten-switch/codex_adapter.go
@@ -78,6 +78,9 @@ func cmdCodex(args []string) int {
 		fmt.Fprintln(os.Stderr, "usage: baseten-switch codex on|off|status|route <baseten-slug>|reasoning baseten <model> off|follow-harness|effort <value>|default  (start/stop are aliases for on/off)")
 		return 2
 	}
+	if replayed, rc := preflightCodexTerminalReplay(args); replayed {
+		return rc
+	}
 	a, err := newCodexAdapterFromEnv()
 	if err != nil {
 		if args[0] == "reasoning" || args[0] == "route" {
@@ -114,11 +117,56 @@ func cmdCodex(args []string) int {
 	case "route":
 		return a.route(args[1:], os.Stdout)
 	case "reasoning":
-		return runClientReasoning(a.clientName, args[1:], os.Stdout)
+		return runClientReasoning(mutationSurfaceCodex, a.clientName, args[1:], os.Stdout)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown codex subcommand: %s (use on|off|status|route|reasoning)\n", args[0])
 		return 2
 	}
+}
+
+func preflightCodexTerminalReplay(args []string) (bool, int) {
+	path, _ := resolveConfigPath()
+	var opts mutationOptions
+	var spec journaledMutationSpec
+	var err error
+	switch args[0] {
+	case "route":
+		var positional []string
+		opts, positional, err = parseMutationOptions(args[1:])
+		if err != nil || len(positional) != 1 {
+			return false, 0
+		}
+		spec = journaledMutationSpec{Operation: "set_codex_route", Surface: mutationSurfaceCodex, Key: "default_model", RequestedTarget: positional[0]}
+	case "reasoning":
+		opts, spec, err = reasoningTerminalReplayRequest("", args[1:])
+		if err != nil {
+			return false, 0
+		}
+		spec.Surface = mutationSurfaceCodex
+	default:
+		return false, 0
+	}
+	return preflightTerminalReplay(path, opts, spec, os.Stdout)
+}
+
+func codexTargetClientName(file *config.File) (string, error) {
+	var selected string
+	for i := range file.Clients {
+		client := &file.Clients[i]
+		if client.ProtocolShape != "openai" {
+			continue
+		}
+		if client.Name == "codex" {
+			return client.Name, nil
+		}
+		if selected == "" {
+			selected = client.Name
+		}
+	}
+	if selected == "" {
+		return "", fmt.Errorf("no openai-shape client")
+	}
+	return selected, nil
 }
 
 // codexAdapter carries the resolved paths and gateway topology for one
@@ -963,6 +1011,7 @@ func (a *codexAdapter) route(args []string, stdout io.Writer) int {
 		out,
 		journaledMutationSpec{
 			Operation:       "set_codex_route",
+			Surface:         mutationSurfaceCodex,
 			RequestedTarget: target,
 			Client:          a.clientName,
 			Key:             "default_model",

--- a/gateway/cmd/baseten-switch/doctor.go
+++ b/gateway/cmd/baseten-switch/doctor.go
@@ -5,13 +5,13 @@
 // and names the FIRST failed link with a concrete fix, so a broken
 // setup never needs a manual link-by-link back-and-forth.
 //
-// doctor NEVER mutates anything: no starts, no config writes, no
-// settings writes. The only side effect is terminal output. Exit
-// codes: 0 = no check failed (warns allowed), 1 = at least one FAIL,
-// 2 = usage error. The one exception is the opt-in `--fix` repair
-// loop (doctor_fix.go), which mutates only by running existing
-// baseten-switch verbs as confirmed child processes; runDoctor itself
-// stays read-only in both modes.
+// doctor NEVER mutates config, journal/terminal recovery state, router state,
+// or installed settings. It may create or secure coordination metadata while
+// acquiring the mutation status lock. Exit codes: 0 = no check failed (warns
+// allowed), 1 = at least one FAIL, 2 = usage error. The one exception is the
+// opt-in `--fix` repair loop (doctor_fix.go), which mutates only by running
+// existing baseten-switch verbs as confirmed child processes; runDoctor
+// itself stays read-only with respect to managed state in both modes.
 //
 // Test override points (the same seams the rest of the CLI uses):
 // BASETEN_SWITCH_CONFIG_PATH, BASETEN_SWITCH_ADMIN_ADDR, BASETEN_SWITCH_GATEWAY_PIDFILE,
@@ -53,6 +53,10 @@ const (
 	docFail = "fail"
 	docSkip = "skip"
 )
+
+// doctorInspectRoutingMutationStatus is a seam for exercising the doctor's
+// rendering and repair policy independently from journal and router I/O.
+var doctorInspectRoutingMutationStatus = inspectRoutingMutationStatus
 
 type doctorCheck struct {
 	Section string `json:"section"`
@@ -132,8 +136,9 @@ func cmdDoctor(args []string) int {
 	return rep.ExitCode
 }
 
-// runDoctor executes every check in request-path order and returns the
-// full report. All state gathering is read-only.
+// runDoctor executes every check in request-path order and returns the full
+// report. State gathering does not mutate managed state; mutation status may
+// acquire its coordination lock.
 func runDoctor(o doctorOpts) doctorReport {
 	rep := doctorReport{}
 	var add addCheck = func(section, name, status, finding, fix string, fixArgv ...string) {
@@ -191,7 +196,15 @@ func runDoctor(o doctorOpts) doctorReport {
 	doctorBasetenCLICheck(add)
 
 	// --- 4. router --------------------------------------------------------
-	st := doctorRouterChecks(add, adminAddr, routerState)
+	// Inspect mutation recovery before attaching any automatic lifecycle
+	// repair. Starting the router can make the config currently on disk
+	// authoritative, so an unfinished or unreadable mutation must suppress
+	// every `up` fix until recovery has been handled explicitly.
+	mutationStatus, mutationStatusErr := doctorInspectRoutingMutationStatus(cfgPath)
+	allowStartupFix := mutationStatusErr == nil && mutationStatus.Classification == mutationStatusNone
+	st := doctorRouterChecks(add, adminAddr, routerState, allowStartupFix)
+	doctorMutationRecoveryCheckForStatus(add, mutationStatus, mutationStatusErr)
+	doctorRouterClientChecks(add, st)
 	boundAddrs := map[string]bool{}
 	if st != nil {
 		for _, c := range st.Clients {
@@ -202,7 +215,7 @@ func runDoctor(o doctorOpts) doctorReport {
 	}
 
 	// --- 5. door ----------------------------------------------------------
-	doorUp := doctorDoorChecks(add, doorSpecs, st != nil, boundAddrs)
+	doorUp := doctorDoorChecks(add, doorSpecs, st != nil, boundAddrs, allowStartupFix)
 
 	// Resolve the telemetry store path once: the claude subagents traffic
 	// check (section 6) and the telemetry section (9) both use it.
@@ -218,7 +231,7 @@ func runDoctor(o doctorOpts) doctorReport {
 	doctorCodexChecks(add, f, envFile, envFilePath)
 
 	// --- 7. supervision ---------------------------------------------------
-	doctorSupervisionChecks(add, routerState, doorSpecs, doorUp)
+	doctorSupervisionChecks(add, routerState, doorSpecs, doorUp, allowStartupFix)
 
 	// --- 8. e2e -----------------------------------------------------------
 	doctorE2EChecks(add, o, doorSpecs, doorUp, f, telPath)
@@ -638,19 +651,23 @@ func doctorBasetenRouted(f *config.File) []string {
 }
 
 // doctorRouterChecks probes the admin listener (ours/foreign/down, the
-// probePort semantics `up` uses), parses the admin status, and checks
-// every enabled client: bound, valid route, sane fallback_route, and a
-// listener that actually accepts TCP. Returns the parsed status (nil
-// when unavailable) for the door wiring check.
-func doctorRouterChecks(add addCheck, adminAddr string, state portState) *doctorAdminStatus {
+// probePort semantics `up` uses) and parses the admin status. Returns the
+// parsed status (nil when unavailable) for the mutation, client, and door
+// wiring checks.
+func doctorRouterChecks(add addCheck, adminAddr string, state portState, allowStartupFix bool) *doctorAdminStatus {
 	switch state {
 	case portForeign:
 		add("router", "reachable", docFail,
 			fmt.Sprintf("a foreign process (%s) owns %s (answers, but not our router)", portOwner(adminAddr), adminAddr),
 			"free the port or change BASETEN_SWITCH_ADMIN_ADDR")
 	case portDown:
-		add("router", "reachable", docFail, fmt.Sprintf("router not running (nothing listens on %s)", adminAddr),
-			"baseten-switch up", "up")
+		if allowStartupFix {
+			add("router", "reachable", docFail, fmt.Sprintf("router not running (nothing listens on %s)", adminAddr),
+				"baseten-switch up", "up")
+		} else {
+			add("router", "reachable", docFail, fmt.Sprintf("router not running (nothing listens on %s)", adminAddr),
+				"resolve the routing mutation recovery state before running 'baseten-switch up'")
+		}
 	default:
 		var h struct {
 			UptimeSeconds int64 `json:"uptime_seconds"`
@@ -667,7 +684,6 @@ func doctorRouterChecks(add addCheck, adminAddr string, state portState) *doctor
 	}
 	if state != portOurs {
 		add("router", "status", docSkip, "router not up", "")
-		add("router", "clients", docSkip, "router not up", "")
 		return nil
 	}
 
@@ -676,17 +692,95 @@ func doctorRouterChecks(add addCheck, adminAddr string, state portState) *doctor
 	if !ok {
 		add("router", "status", docFail, fmt.Sprintf("admin /v1/admin/status unreachable at %s", adminAddr),
 			"check the router log; restart with 'baseten-switch restart'")
-		add("router", "clients", docSkip, "admin status unavailable", "")
 		return nil
 	}
 	var st doctorAdminStatus
 	if err := json.Unmarshal([]byte(body), &st); err != nil {
 		add("router", "status", docFail, fmt.Sprintf("admin status does not parse: %v", err),
 			"version mismatch between CLI and router? restart with 'baseten-switch restart'")
-		add("router", "clients", docSkip, "admin status unavailable", "")
 		return nil
 	}
 	add("router", "status", docOK, "admin status parses", "")
+	return &st
+}
+
+// doctorMutationRecoveryCheck reports the read-only status classification.
+// It intentionally exposes only reviewed messages and never raw paths, target
+// values, journal bytes, or underlying filesystem and admin errors.
+func doctorMutationRecoveryCheck(add addCheck, configPath string) {
+	status, err := doctorInspectRoutingMutationStatus(configPath)
+	doctorMutationRecoveryCheckForStatus(add, status, err)
+}
+
+func doctorMutationRecoveryCheckForStatus(add addCheck, status routingMutationStatus, err error) {
+	if err != nil {
+		add("router", "mutation_recovery", docFail,
+			"routing mutation recovery state could not be inspected",
+			"run 'baseten-switch mutation status' and preserve the recovery files for manual review")
+		return
+	}
+
+	switch status.Classification {
+	case mutationStatusNone:
+		add("router", "mutation_recovery", docOK, "no unfinished routing mutation", "")
+	case mutationStatusDesiredActive:
+		add("router", "mutation_recovery", docFail,
+			"a previous routing change is active but its recovery record still needs cleanup",
+			"baseten-switch mutation recover", "mutation", "recover")
+	case mutationStatusPriorActive:
+		add("router", "mutation_recovery", docFail,
+			"a previous routing change was not applied; the prior routing state is active and its recovery record still needs cleanup",
+			"baseten-switch mutation recover", "mutation", "recover")
+	case mutationStatusCleanupPending:
+		add("router", "mutation_recovery", docFail,
+			"a completed routing change has stale recovery cleanup state",
+			"baseten-switch mutation recover", "mutation", "recover")
+	case mutationStatusDesiredPending:
+		add("router", "mutation_recovery", docFail,
+			"a pending routing change is present but is not the active router configuration",
+			"review 'baseten-switch mutation status'; explicit reconciliation is required")
+	case mutationStatusPriorPending:
+		add("router", "mutation_recovery", docFail,
+			"a pending routing change still has its prior configuration on disk",
+			"review 'baseten-switch mutation status'; explicit reconciliation is required")
+	case mutationStatusRouterUnavailable:
+		add("router", "mutation_recovery", docFail,
+			"the router is unavailable to confirm a pending routing change",
+			"start the router, then rerun 'baseten-switch doctor --fix'")
+	case mutationStatusRouterUnsupported:
+		add("router", "mutation_recovery", docFail,
+			"the running router cannot report authoritative mutation recovery state",
+			"restart with the current baseten-switch binary, then rerun doctor")
+	case mutationStatusExternalChange:
+		add("router", "mutation_recovery", docFail,
+			"the configuration changed outside the pending routing operation; both states were preserved",
+			"review 'baseten-switch mutation status' before explicit reconciliation")
+	case mutationStatusCommitRecoveryRequired:
+		add("router", "mutation_recovery", docFail,
+			"an interrupted exact-config commit requires explicit recovery",
+			"review 'baseten-switch mutation status' before explicit reconciliation")
+	case mutationStatusJournalInvalid:
+		add("router", "mutation_recovery", docFail,
+			"routing mutation recovery state is invalid",
+			"run 'baseten-switch mutation status' and preserve the recovery files for manual review")
+	case mutationStatusJournalConflict:
+		add("router", "mutation_recovery", docFail,
+			"multiple or conflicting routing mutation records require manual recovery",
+			"run 'baseten-switch mutation status' and preserve the recovery files for manual review")
+	default:
+		add("router", "mutation_recovery", docFail,
+			"routing mutation recovery state has an unsupported classification",
+			"run 'baseten-switch mutation status' and preserve the recovery files for manual review")
+	}
+}
+
+// doctorRouterClientChecks checks every enabled client: bound, valid route,
+// sane fallback_route, and a listener that actually accepts TCP.
+func doctorRouterClientChecks(add addCheck, st *doctorAdminStatus) {
+	if st == nil {
+		add("router", "clients", docSkip, "admin status unavailable", "")
+		return
+	}
 
 	checked := 0
 	for _, c := range st.Clients {
@@ -719,7 +813,6 @@ func doctorRouterChecks(add addCheck, adminAddr string, state portState) *doctor
 	if checked == 0 {
 		add("router", "clients", docSkip, "no enabled clients to check (see config section)", "")
 	}
-	return &st
 }
 
 func dialOK(addr string) bool {
@@ -735,7 +828,7 @@ func dialOK(addr string) bool {
 // ours/foreign/down semantics) and verifies the live door's router
 // target is an addr some bound client actually listens on. Returns
 // which ports answered as ours, for the supervision and e2e sections.
-func doctorDoorChecks(add addCheck, doorSpecs []door.Config, haveStatus bool, boundAddrs map[string]bool) map[string]bool {
+func doctorDoorChecks(add addCheck, doorSpecs []door.Config, haveStatus bool, boundAddrs map[string]bool, allowStartupFix bool) map[string]bool {
 	doorUp := map[string]bool{}
 	if len(doorSpecs) == 0 {
 		add("door", "ports", docSkip, "no usable door ports (see config section)", "")
@@ -745,7 +838,12 @@ func doctorDoorChecks(add addCheck, doorSpecs []door.Config, haveStatus bool, bo
 		port := portOf(sp.ListenAddr)
 		switch probePort(sp.ListenAddr, doorHealthPath, doorHealthMarker) {
 		case portDown:
-			add("door", "doorz:"+port, docFail, fmt.Sprintf("door not running (nothing listens on %s)", sp.ListenAddr), "baseten-switch up", "up")
+			if allowStartupFix {
+				add("door", "doorz:"+port, docFail, fmt.Sprintf("door not running (nothing listens on %s)", sp.ListenAddr), "baseten-switch up", "up")
+			} else {
+				add("door", "doorz:"+port, docFail, fmt.Sprintf("door not running (nothing listens on %s)", sp.ListenAddr),
+					"resolve the routing mutation recovery state before running 'baseten-switch up'")
+			}
 			add("door", "wiring:"+port, docSkip, "door not up", "")
 			continue
 		case portForeign:
@@ -1409,7 +1507,7 @@ func doctorPortTarget(raw, desiredPort string) (status, finding string) {
 // doctorSupervisionChecks reports the launchd state per label. Skipped
 // entirely under BASETEN_SWITCH_LAUNCHD=off or off darwin, matching the rest of
 // the CLI's launchd seam.
-func doctorSupervisionChecks(add addCheck, routerState portState, doorSpecs []door.Config, doorUp map[string]bool) {
+func doctorSupervisionChecks(add addCheck, routerState portState, doorSpecs []door.Config, doorUp map[string]bool, allowStartupFix bool) {
 	if runtime.GOOS != "darwin" || launchdDisabled() {
 		add("supervision", "launchd", docSkip, "launchd interaction disabled (BASETEN_SWITCH_LAUNCHD=off or non-darwin)", "")
 		return
@@ -1429,10 +1527,16 @@ func doctorSupervisionChecks(add addCheck, routerState portState, doorSpecs []do
 		case s.supervised():
 			add("supervision", c.name, docOK, "launchd job "+c.label+" loaded", "")
 		case s.installed:
-			add("supervision", c.name, docWarn,
-				"launchd plist installed but "+c.label+" is not loaded (a login-items approval in System Settings may be pending)",
-				"baseten-switch up   (re-bootstraps the job; approve it in System Settings > General > Login Items if prompted)",
-				"up")
+			if allowStartupFix {
+				add("supervision", c.name, docWarn,
+					"launchd plist installed but "+c.label+" is not loaded (a login-items approval in System Settings may be pending)",
+					"baseten-switch up   (re-bootstraps the job; approve it in System Settings > General > Login Items if prompted)",
+					"up")
+			} else {
+				add("supervision", c.name, docWarn,
+					"launchd plist installed but "+c.label+" is not loaded (a login-items approval in System Settings may be pending)",
+					"resolve the routing mutation recovery state before re-bootstrapping the job")
+			}
 		case c.up:
 			add("supervision", c.name, docWarn, c.name+" is running unsupervised (no LaunchAgent installed)",
 				"baseten-switch up --install")

--- a/gateway/cmd/baseten-switch/doctor_test.go
+++ b/gateway/cmd/baseten-switch/doctor_test.go
@@ -1318,6 +1318,114 @@ func TestDoctorRouterDownDependentsSkip(t *testing.T) {
 	}
 }
 
+func TestDoctorMutationRecoveryClassificationPolicy(t *testing.T) {
+	tests := []struct {
+		name        string
+		class       string
+		wantStatus  string
+		wantFix     bool
+		wantFinding string
+	}{
+		{name: "none", class: mutationStatusNone, wantStatus: docOK},
+		{name: "desired active", class: mutationStatusDesiredActive, wantStatus: docFail, wantFix: true},
+		{name: "prior active", class: mutationStatusPriorActive, wantStatus: docFail, wantFix: true, wantFinding: "was not applied; the prior routing state is active"},
+		{name: "cleanup pending", class: mutationStatusCleanupPending, wantStatus: docFail, wantFix: true},
+		{name: "desired pending", class: mutationStatusDesiredPending, wantStatus: docFail},
+		{name: "prior pending", class: mutationStatusPriorPending, wantStatus: docFail},
+		{name: "router unavailable", class: mutationStatusRouterUnavailable, wantStatus: docFail},
+		{name: "router unsupported", class: mutationStatusRouterUnsupported, wantStatus: docFail},
+		{name: "external change", class: mutationStatusExternalChange, wantStatus: docFail},
+		{name: "commit recovery required", class: mutationStatusCommitRecoveryRequired, wantStatus: docFail},
+		{name: "journal invalid", class: mutationStatusJournalInvalid, wantStatus: docFail},
+		{name: "journal conflict", class: mutationStatusJournalConflict, wantStatus: docFail},
+		{name: "unknown", class: "future_state", wantStatus: docFail},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldInspect := doctorInspectRoutingMutationStatus
+			doctorInspectRoutingMutationStatus = func(string) (routingMutationStatus, error) {
+				return routingMutationStatus{Classification: tt.class}, nil
+			}
+			t.Cleanup(func() { doctorInspectRoutingMutationStatus = oldInspect })
+
+			var checks []doctorCheck
+			doctorMutationRecoveryCheck(func(section, name, status, finding, fix string, fixArgv ...string) {
+				checks = append(checks, doctorCheck{
+					Section: section,
+					Name:    name,
+					Status:  status,
+					Finding: finding,
+					Fix:     fix,
+					fixArgv: fixArgv,
+				})
+			}, "/private/config/path")
+
+			if len(checks) != 1 {
+				t.Fatalf("checks = %+v, want one", checks)
+			}
+			check := checks[0]
+			if check.Section != "router" || check.Name != "mutation_recovery" || check.Status != tt.wantStatus {
+				t.Errorf("check = %+v, want router/mutation_recovery %s", check, tt.wantStatus)
+			}
+			if tt.wantFinding != "" && !strings.Contains(check.Finding, tt.wantFinding) {
+				t.Errorf("finding = %q, want text %q", check.Finding, tt.wantFinding)
+			}
+			if tt.wantFix {
+				if got := strings.Join(check.fixArgv, " "); got != "mutation recover" {
+					t.Errorf("fixArgv = %q, want mutation recover", got)
+				}
+			} else if len(check.fixArgv) != 0 {
+				t.Errorf("manual-only classification got fixArgv %v", check.fixArgv)
+			}
+			if strings.Contains(check.Finding, "/private/config/path") || strings.Contains(check.Fix, "/private/config/path") {
+				t.Errorf("check leaked config path: %+v", check)
+			}
+		})
+	}
+}
+
+func TestDoctorMutationRecoveryInspectionErrorIsSanitized(t *testing.T) {
+	oldInspect := doctorInspectRoutingMutationStatus
+	doctorInspectRoutingMutationStatus = func(string) (routingMutationStatus, error) {
+		return routingMutationStatus{}, fmt.Errorf("open /private/config/path.mutation-journal: permission denied")
+	}
+	t.Cleanup(func() { doctorInspectRoutingMutationStatus = oldInspect })
+
+	var check doctorCheck
+	doctorMutationRecoveryCheck(func(section, name, status, finding, fix string, fixArgv ...string) {
+		check = doctorCheck{Section: section, Name: name, Status: status, Finding: finding, Fix: fix, fixArgv: fixArgv}
+	}, "/private/config/path")
+	if check.Status != docFail || len(check.fixArgv) != 0 {
+		t.Fatalf("check = %+v, want manual-only failure", check)
+	}
+	if strings.Contains(check.Finding, "/private/") || strings.Contains(check.Fix, "/private/") || strings.Contains(check.Finding, "permission denied") {
+		t.Errorf("inspection failure leaked raw error or path: %+v", check)
+	}
+}
+
+func TestDoctorMutationRecoveryCheckOrdering(t *testing.T) {
+	newDoctorFixture(t, nil)
+	oldInspect := doctorInspectRoutingMutationStatus
+	doctorInspectRoutingMutationStatus = func(string) (routingMutationStatus, error) {
+		return routingMutationStatus{Classification: mutationStatusNone}, nil
+	}
+	t.Cleanup(func() { doctorInspectRoutingMutationStatus = oldInspect })
+
+	rep := runDoctor(doctorOpts{})
+	indices := map[string]int{}
+	for i, check := range rep.Checks {
+		indices[check.Section+"/"+check.Name] = i
+	}
+	reachable := indices["router/reachable"]
+	status := indices["router/status"]
+	recovery := indices["router/mutation_recovery"]
+	client := indices["router/client:claude-code"]
+	if !(reachable < status && status < recovery && recovery < client) {
+		t.Fatalf("router check order = reachable:%d status:%d recovery:%d client:%d", reachable, status, recovery, client)
+	}
+}
+
 func TestDoctorForeignAdminPort(t *testing.T) {
 	newDoctorFixture(t, func(c *doctorFixtureCfg) { c.adminForeign = true })
 	rep := runDoctor(doctorOpts{})
@@ -1484,6 +1592,86 @@ func TestDoctorFixRouterDownAppliedAndResolved(t *testing.T) {
 	}
 	if !strings.Contains(out, "all checks passed") {
 		t.Errorf("final green report missing:\n%s", out)
+	}
+}
+
+func TestDoctorFixRouterDownWithActiveMutationDoesNotStartRouter(t *testing.T) {
+	fx := newDoctorFixture(t, nil)
+	journal := legacyJournalForTest(t, fx.cfgPath, "doctor-blocks-up")
+	if err := writeMutationJournal(journal); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(fx.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	takeRouterDown(t)
+	calls := setDoctorFixSeams(t, false, "", nil)
+	out, code := captureStdout(t, func() int { return cmdDoctor([]string{"--fix", "--yes"}) })
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 with recovery still pending\n%s", code, out)
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("router-down recovery state executed fixes: %v", *calls)
+	}
+	if strings.Contains(out, "will run:") || !strings.Contains(out, "resolve the routing mutation recovery state") {
+		t.Fatalf("doctor offered startup before recovery:\n%s", out)
+	}
+	after, err := os.ReadFile(fx.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatal("doctor changed the routing config while recovery was pending")
+	}
+	if _, err := os.Stat(mutationJournalPath(fx.cfgPath, journal.OperationID)); err != nil {
+		t.Fatalf("doctor changed the active recovery journal: %v", err)
+	}
+}
+
+func TestDoctorFixMutationRecoveryRunsOnlyRecover(t *testing.T) {
+	newDoctorFixture(t, nil)
+	classification := mutationStatusDesiredActive
+	oldInspect := doctorInspectRoutingMutationStatus
+	doctorInspectRoutingMutationStatus = func(string) (routingMutationStatus, error) {
+		return routingMutationStatus{Classification: classification}, nil
+	}
+	t.Cleanup(func() { doctorInspectRoutingMutationStatus = oldInspect })
+
+	calls := setDoctorFixSeams(t, false, "", func(argv []string) error {
+		classification = mutationStatusNone
+		return nil
+	})
+	out, code := captureStdout(t, func() int { return cmdDoctor([]string{"--fix", "--yes"}) })
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 after recovery cleanup\n%s", code, out)
+	}
+	if len(*calls) != 1 || strings.Join((*calls)[0], " ") != "mutation recover" {
+		t.Fatalf("fix argvs = %v, want exactly ['mutation', 'recover']", *calls)
+	}
+	if strings.Contains(out, "mutation reconcile") {
+		t.Errorf("doctor --fix proposed full reconciliation:\n%s", out)
+	}
+}
+
+func TestDoctorFixYesCannotReconcileUnsafeMutation(t *testing.T) {
+	newDoctorFixture(t, nil)
+	oldInspect := doctorInspectRoutingMutationStatus
+	doctorInspectRoutingMutationStatus = func(string) (routingMutationStatus, error) {
+		return routingMutationStatus{Classification: mutationStatusDesiredPending}, nil
+	}
+	t.Cleanup(func() { doctorInspectRoutingMutationStatus = oldInspect })
+
+	calls := setDoctorFixSeams(t, false, "", nil)
+	out, code := captureStdout(t, func() int { return cmdDoctor([]string{"--fix", "--yes"}) })
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 with manual reconciliation pending\n%s", code, out)
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("unsafe status executed fixes: %v", *calls)
+	}
+	if !strings.Contains(out, "no automatable fix for router/mutation_recovery") {
+		t.Errorf("manual-only guidance missing:\n%s", out)
 	}
 }
 

--- a/gateway/cmd/baseten-switch/main.go
+++ b/gateway/cmd/baseten-switch/main.go
@@ -199,9 +199,14 @@ rejected. Machine callers may place these options before or after the verb:
   --if-active-token TOKEN
   --if-config-hash HASH
 `},
-	{"mutation", "Reconcile an interrupted routing policy mutation", `Usage: baseten-switch mutation reconcile <operation-id> [--json]
+	{"mutation", "Inspect or recover a routing policy mutation", `Usage:
+  baseten-switch mutation status [--json]
+  baseten-switch mutation recover [--json]
+  baseten-switch mutation reconcile <operation-id> [--json]
 
-Finish or safely roll back an interrupted routing policy mutation.
+status classifies local recovery state without changing config or routing.
+recover removes only recovery state whose exact outcome is already confirmed.
+reconcile may finish or safely roll back the named interrupted mutation.
 `},
 	{"menubar", "Install or refresh and open the macOS menubar app", `Usage: baseten-switch menubar [--which]
 

--- a/gateway/cmd/baseten-switch/reasoning.go
+++ b/gateway/cmd/baseten-switch/reasoning.go
@@ -24,6 +24,30 @@ type reasoningPreflightResult struct {
 	Warning string
 }
 
+func reasoningTerminalReplayRequest(clientName string, args []string) (mutationOptions, journaledMutationSpec, error) {
+	opts, positional, err := parseReasoningCommandOptions(args)
+	if err != nil {
+		return opts.Mutation, journaledMutationSpec{}, err
+	}
+	_, modelID, policy, useDefault, err := parseReasoningPolicy(positional)
+	if err != nil {
+		return opts.Mutation, journaledMutationSpec{}, err
+	}
+	target := "default"
+	if !useDefault {
+		target = string(policy.Mode)
+		if policy.Effort != "" {
+			target = "effort:" + policy.Effort
+		}
+	}
+	return opts.Mutation, journaledMutationSpec{
+		Operation:       "set_model_reasoning",
+		RequestedTarget: target,
+		Client:          clientName,
+		Key:             modelID,
+	}, nil
+}
+
 type reasoningPreflightClient interface {
 	Check(adminAddr, clientName, provider, modelID string, policy config.ReasoningPolicy) (reasoningPreflightResult, error)
 }
@@ -31,6 +55,7 @@ type reasoningPreflightClient interface {
 var activeReasoningPreflightClient reasoningPreflightClient = httpReasoningPreflightClient{}
 
 func runClientReasoning(
+	surface string,
 	clientName string,
 	args []string,
 	out io.Writer,
@@ -105,6 +130,7 @@ func runClientReasoning(
 
 	spec := journaledMutationSpec{
 		Operation:       "set_model_reasoning",
+		Surface:         surface,
 		RequestedTarget: result.RequestedTarget,
 		Client:          clientName,
 		Key:             modelID,

--- a/gateway/cmd/baseten-switch/reasoning_test.go
+++ b/gateway/cmd/baseten-switch/reasoning_test.go
@@ -80,7 +80,7 @@ clients:
 	preflight := &failingReasoningPreflight{}
 	installReasoningPreflight(t, preflight)
 	var out strings.Builder
-	rc := runClientReasoning("claude-code", []string{
+	rc := runClientReasoning(mutationSurfaceClaude, "claude-code", []string{
 		"baseten", "zai-org/GLM-5.2", "default",
 		"--operation-id", "reasoning-default-test",
 	}, &out)
@@ -120,6 +120,7 @@ clients:
 	installReasoningPreflight(t, preflight)
 	var out strings.Builder
 	rc := runClientReasoning(
+		mutationSurfaceClaude,
 		"claude-code",
 		[]string{"baseten", "zai-org/GLM-5.2", "off"},
 		&out,

--- a/gateway/cmd/baseten-switch/routing_mutation.go
+++ b/gateway/cmd/baseten-switch/routing_mutation.go
@@ -20,6 +20,12 @@ import (
 
 const mutationJournalVersion = 1
 
+const (
+	mutationSurfaceSwitch = "switch"
+	mutationSurfaceClaude = "claude"
+	mutationSurfaceCodex  = "codex"
+)
+
 var (
 	mutationLockTimeout = 2 * time.Second
 	mutationHTTPTimeout = 500 * time.Millisecond
@@ -68,6 +74,8 @@ type mutationOptions struct {
 	IfActiveToken  string
 	IfConfigHash   string
 	hasOperationID bool
+	hasActiveToken bool
+	hasConfigHash  bool
 }
 
 type mutationError struct {
@@ -92,6 +100,11 @@ type mutationResult struct {
 	ActiveConfigHash          string         `json:"active_config_hash"`
 	Applied                   bool           `json:"applied"`
 	ReconciliationRequired    bool           `json:"reconciliation_required,omitempty"`
+	BlockingOperationID       string         `json:"blocking_operation_id,omitempty"`
+	Outcome                   string         `json:"outcome,omitempty"`
+	RequestFingerprint        string         `json:"request_fingerprint,omitempty"`
+	IdentityStrength          string         `json:"identity_strength,omitempty"`
+	CleanupPending            bool           `json:"cleanup_pending,omitempty"`
 	Error                     *mutationError `json:"error"`
 }
 
@@ -117,6 +130,7 @@ type routingMutationJournal struct {
 	Version             int       `json:"version"`
 	OperationID         string    `json:"operation_id"`
 	Operation           string    `json:"operation"`
+	Surface             string    `json:"surface,omitempty"`
 	ConfigPath          string    `json:"config_path"`
 	Requested           bool      `json:"requested"`
 	RequestedTarget     string    `json:"requested_target,omitempty"`
@@ -128,6 +142,9 @@ type routingMutationJournal struct {
 	PreviousConfigHash  string    `json:"previous_config_hash"`
 	DesiredConfigHash   string    `json:"desired_config_hash"`
 	PreviousActiveToken string    `json:"previous_active_token"`
+	IfConfigHash        string    `json:"if_config_hash,omitempty"`
+	IfActiveToken       string    `json:"if_active_token,omitempty"`
+	RequestFingerprint  string    `json:"request_fingerprint,omitempty"`
 	CreatedAt           time.Time `json:"created_at"`
 }
 
@@ -246,16 +263,20 @@ func parseMutationOptions(args []string) (mutationOptions, []string, error) {
 			}
 			i++
 			opts.IfActiveToken = args[i]
+			opts.hasActiveToken = true
 		case strings.HasPrefix(arg, "--if-active-token="):
 			opts.IfActiveToken = strings.TrimPrefix(arg, "--if-active-token=")
+			opts.hasActiveToken = true
 		case arg == "--if-config-hash":
 			if i+1 >= len(args) {
 				return opts, nil, fmt.Errorf("--if-config-hash requires a value")
 			}
 			i++
 			opts.IfConfigHash = args[i]
+			opts.hasConfigHash = true
 		case strings.HasPrefix(arg, "--if-config-hash="):
 			opts.IfConfigHash = strings.TrimPrefix(arg, "--if-config-hash=")
+			opts.hasConfigHash = true
 		case strings.HasPrefix(arg, "-"):
 			return opts, nil, fmt.Errorf("unknown mutation option %q", arg)
 		default:
@@ -271,8 +292,14 @@ func parseMutationOptions(args []string) (mutationOptions, []string, error) {
 	if err := validateOperationID(opts.OperationID); err != nil {
 		return opts, nil, err
 	}
+	if opts.hasConfigHash && opts.IfConfigHash == "" {
+		return opts, nil, fmt.Errorf("--if-config-hash cannot be empty")
+	}
 	if opts.IfConfigHash != "" && !validConfigHash(opts.IfConfigHash) {
 		return opts, nil, fmt.Errorf("--if-config-hash must be sha256 followed by 64 lowercase hexadecimal characters")
+	}
+	if opts.hasActiveToken && opts.IfActiveToken == "" {
+		return opts, nil, fmt.Errorf("--if-active-token cannot be empty")
 	}
 	return opts, positional, nil
 }
@@ -323,6 +350,9 @@ func emitMutationResult(out io.Writer, result mutationResult) {
 func failMutation(opts mutationOptions, out io.Writer, result mutationResult, code, message string, retryable bool, rc int) int {
 	result.OK = false
 	result.OperationID = opts.OperationID
+	if opts.JSON || reviewedMutationFailureCode(code) {
+		message = reviewedMutationMessage(code)
+	}
 	result.Error = &mutationError{Code: code, Message: message, Retryable: retryable}
 	if opts.JSON {
 		emitMutationResult(out, result)
@@ -330,6 +360,16 @@ func failMutation(opts mutationOptions, out io.Writer, result mutationResult, co
 		fmt.Fprintln(os.Stderr, message)
 	}
 	return rc
+}
+
+func reviewedMutationFailureCode(code string) bool {
+	switch code {
+	case "usage", "client_scoped_switch_removed", "invalid_operation_id",
+		"invalid_route_key", "invalid_route_target", "invalid_subagent_target":
+		return false
+	default:
+		return true
+	}
 }
 
 func readExactConfig(path string) ([]byte, os.FileMode, error) {
@@ -355,9 +395,15 @@ func readExactConfig(path string) ([]byte, os.FileMode, error) {
 	if !os.SameFile(info, openedInfo) {
 		return nil, 0, fmt.Errorf("%s changed while it was being opened", path)
 	}
-	data, err := io.ReadAll(file)
+	if openedInfo.Size() > mutationConfigReadLimit {
+		return nil, 0, fmt.Errorf("config exceeds the 4 MiB mutation read limit")
+	}
+	data, err := io.ReadAll(io.LimitReader(file, mutationConfigReadLimit+1))
 	if err != nil {
 		return nil, 0, err
+	}
+	if len(data) > mutationConfigReadLimit {
+		return nil, 0, fmt.Errorf("config exceeds the 4 MiB mutation read limit")
 	}
 	return data, openedInfo.Mode().Perm(), nil
 }
@@ -396,10 +442,7 @@ func mutationJournalPath(configPath, operationID string) string {
 
 func writeMutationJournal(journal routingMutationJournal) error {
 	dir := mutationJournalDir(journal.ConfigPath)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return fmt.Errorf("create transaction journal directory: %w", err)
-	}
-	if err := os.Chmod(dir, 0o700); err != nil {
+	if err := secureDirectory(dir, true); err != nil {
 		return fmt.Errorf("secure transaction journal directory: %w", err)
 	}
 	entries, err := os.ReadDir(dir)
@@ -407,6 +450,9 @@ func writeMutationJournal(journal routingMutationJournal) error {
 		return fmt.Errorf("inspect transaction journal directory: %w", err)
 	}
 	for _, entry := range entries {
+		if entry.Name() == "completed" && entry.IsDir() {
+			continue
+		}
 		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") {
 			return fmt.Errorf("unfinished routing mutation %q must be reconciled before starting another", strings.TrimSuffix(entry.Name(), ".json"))
 		}
@@ -422,6 +468,9 @@ func writeMutationJournal(journal routingMutationJournal) error {
 		return fmt.Errorf("encode transaction journal: %w", err)
 	}
 	data = append(data, '\n')
+	if len(data) > mutationJournalReadLimit {
+		return fmt.Errorf("transaction journal exceeds the size limit")
+	}
 	if err := atomicWriteFile(path, data, 0o600); err != nil {
 		return fmt.Errorf("write transaction journal: %w", err)
 	}
@@ -430,8 +479,11 @@ func writeMutationJournal(journal routingMutationJournal) error {
 
 func readMutationJournal(configPath, operationID string) (routingMutationJournal, error) {
 	var journal routingMutationJournal
+	if err := validateMutationStateDirectories(configPath, false); err != nil {
+		return journal, err
+	}
 	path := mutationJournalPath(configPath, operationID)
-	data, err := os.ReadFile(path)
+	data, err := readBoundedRegularFile(path, mutationJournalReadLimit, 0o600)
 	if err != nil {
 		return journal, err
 	}
@@ -442,6 +494,38 @@ func readMutationJournal(configPath, operationID string) (routingMutationJournal
 		journal.OperationID != operationID ||
 		canonicalPath(journal.ConfigPath) != canonicalPath(configPath) {
 		return journal, fmt.Errorf("transaction journal identity does not match this config and operation")
+	}
+	if journal.Operation == "" || !validConfigHash(journal.PreviousConfigHash) ||
+		!validConfigHash(journal.DesiredConfigHash) ||
+		exactConfigHash(journal.PreviousConfig) != journal.PreviousConfigHash ||
+		journal.CreatedAt.IsZero() {
+		return journal, fmt.Errorf("transaction journal contents are invalid")
+	}
+	if journal.RequestFingerprint != "" {
+		if !validConfigHash(journal.RequestFingerprint) {
+			return journal, fmt.Errorf("transaction journal fingerprint is invalid")
+		}
+		if !validMutationSurface(journal.Operation, journal.Surface) {
+			return journal, fmt.Errorf("transaction journal surface is invalid")
+		}
+		expected, err := mutationRequestFingerprint(journal.ConfigPath, mutationOptions{
+			IfConfigHash:   journal.IfConfigHash,
+			IfActiveToken:  journal.IfActiveToken,
+			hasConfigHash:  journal.IfConfigHash != "",
+			hasActiveToken: journal.IfActiveToken != "",
+		}, journaledMutationSpec{
+			Operation:       journal.Operation,
+			Surface:         journal.Surface,
+			Requested:       journal.Requested,
+			RequestedTarget: journal.RequestedTarget,
+			Client:          journal.Client,
+			Key:             journal.Key,
+		})
+		if err != nil || expected != journal.RequestFingerprint {
+			return journal, fmt.Errorf("transaction journal fingerprint does not match its contents")
+		}
+	} else if journal.Surface != "" {
+		return journal, fmt.Errorf("legacy transaction journal surface is invalid")
 	}
 	return journal, nil
 }
@@ -498,6 +582,23 @@ func canonicalPath(path string) string {
 	}
 	if evaluated, err := filepath.EvalSymlinks(absolute); err == nil {
 		return evaluated
+	}
+	// Replay identity must remain stable after the config is removed. Resolve
+	// the longest existing parent (for example macOS /var -> /private/var),
+	// then append the missing suffix without following nonexistent entries.
+	parent := absolute
+	var suffix []string
+	for {
+		if evaluated, err := filepath.EvalSymlinks(parent); err == nil {
+			parts := append([]string{evaluated}, suffix...)
+			return filepath.Join(parts...)
+		}
+		next := filepath.Dir(parent)
+		if next == parent {
+			break
+		}
+		suffix = append([]string{filepath.Base(parent)}, suffix...)
+		parent = next
 	}
 	return absolute
 }
@@ -623,6 +724,7 @@ func signalVerifiedRouter(expected routingAdminStatus, adminAddr string) (int, e
 
 type journaledMutationSpec struct {
 	Operation       string
+	Surface         string
 	Requested       bool
 	RequestedTarget string
 	Client          string
@@ -1159,16 +1261,30 @@ func unfinishedMutationOperation(configPath string) (string, error) {
 func runJournaledMutationLocked(path string, prior []byte, mode os.FileMode, opts mutationOptions, out io.Writer, spec journaledMutationSpec) int {
 	priorHash := exactConfigHash(prior)
 	result := mutationResultForSpec(spec, opts.OperationID, path, priorHash)
+	fingerprint, err := mutationRequestFingerprint(path, opts, spec)
+	if err != nil {
+		return failMutation(opts, out, result, "fingerprint_failed", "could not identify the routing mutation request", false, 1)
+	}
+	result.RequestFingerprint = fingerprint
+	result.IdentityStrength = mutationIdentityExact
+	if replay, found, rc, replayErr := replayTerminalForRequest(path, opts, spec); found {
+		_ = gcMutationTerminals(path, time.Now().UTC())
+		if replayErr != nil && replayErr.Error() != "operation_id_conflict" && replayErr.Error() != "operation_id_legacy" &&
+			replayErr.Error() != "mutation_not_applied" && replayErr.Error() != "activation_failed_rolled_back" {
+			replayErr = fmt.Errorf("terminal_conflict")
+		}
+		return emitTerminalReplay(opts, out, replay, rc, replayErr)
+	}
 	if opts.IfConfigHash != "" && opts.IfConfigHash != priorHash {
 		return failMutation(opts, out, result, "stale_config_hash",
 			fmt.Sprintf("config changed: expected %s, found %s", opts.IfConfigHash, priorHash), true, 1)
 	}
-	if operationID, err := unfinishedMutationOperation(path); err != nil {
-		return failMutation(opts, out, result, "journal_read_failed", err.Error(), true, 1)
-	} else if operationID != "" {
-		result.ReconciliationRequired = true
+	if activeJournal, found, err := singleActiveMutation(path); err != nil {
+		return failMutation(opts, out, result, "journal_read_failed", reviewedMutationMessage("journal_invalid"), true, 1)
+	} else if found {
+		result.BlockingOperationID = activeJournal.OperationID
 		return failMutation(opts, out, result, "unfinished_mutation",
-			fmt.Sprintf("unfinished routing mutation %q must be reconciled before starting another", operationID), true, 1)
+			"another routing mutation must be reconciled before starting this operation", true, 1)
 	}
 
 	adminAddr := envDefault("BASETEN_SWITCH_ADMIN_ADDR", gateway.DefaultAdminAddr)
@@ -1209,6 +1325,9 @@ func runJournaledMutationLocked(path string, prior []byte, mode os.FileMode, opt
 		return failMutation(opts, out, result, "config_edit_failed",
 			fmt.Sprintf("prepare config edit: %v", err), false, 1)
 	}
+	if len(desired) > mutationConfigReadLimit {
+		return failMutation(opts, out, result, "config_size_limit", reviewedMutationMessage("config_size_limit"), false, 1)
+	}
 	desiredHash := exactConfigHash(desired)
 	result.DesiredConfigHash = desiredHash
 	if err := validateConfigBytesForRouter(path, desired, mode); err != nil {
@@ -1218,6 +1337,21 @@ func runJournaledMutationLocked(path string, prior []byte, mode os.FileMode, opt
 	if desiredHash == priorHash {
 		result.OK = true
 		result.Applied = routerRunning
+		result.Outcome = mutationOutcomeUnchanged
+		journal := routingMutationJournal{
+			Version: mutationJournalVersion, OperationID: opts.OperationID, Operation: spec.Operation,
+			Surface: spec.Surface, ConfigPath: path, Requested: spec.Requested, RequestedTarget: spec.RequestedTarget,
+			Client: spec.Client, Key: spec.Key, PreviousConfigHash: priorHash,
+			DesiredConfigHash: desiredHash, PreviousActiveToken: before.activeToken(),
+			IfConfigHash: opts.IfConfigHash, IfActiveToken: opts.IfActiveToken,
+			RequestFingerprint: fingerprint, CreatedAt: time.Now().UTC(),
+		}
+		published, publishErr := publishMutationTerminal(path, terminalFromJournal(journal, mutationOutcomeUnchanged, before, "", false), nil)
+		if publishErr != nil {
+			result.OK = false
+			return failMutation(opts, out, result, "terminal_write_failed", reviewedMutationMessage("terminal_write_failed"), true, 1)
+		}
+		result.CleanupPending = published.CleanupPending
 		if opts.JSON {
 			emitMutationResult(out, result)
 		} else if spec.HumanSuccess != "" {
@@ -1230,6 +1364,7 @@ func runJournaledMutationLocked(path string, prior []byte, mode os.FileMode, opt
 		Version:             mutationJournalVersion,
 		OperationID:         opts.OperationID,
 		Operation:           spec.Operation,
+		Surface:             spec.Surface,
 		ConfigPath:          path,
 		Requested:           spec.Requested,
 		RequestedTarget:     spec.RequestedTarget,
@@ -1240,6 +1375,9 @@ func runJournaledMutationLocked(path string, prior []byte, mode os.FileMode, opt
 		PreviousConfigHash:  priorHash,
 		DesiredConfigHash:   desiredHash,
 		PreviousActiveToken: before.activeToken(),
+		IfConfigHash:        opts.IfConfigHash,
+		IfActiveToken:       opts.IfActiveToken,
+		RequestFingerprint:  fingerprint,
 		CreatedAt:           time.Now().UTC(),
 	}
 	if err := writeMutationJournal(journal); err != nil {
@@ -1252,7 +1390,14 @@ func runJournaledMutationLocked(path string, prior []byte, mode os.FileMode, opt
 			return failMutation(opts, out, result, "activation_indeterminate",
 				fmt.Sprintf("exact config commit was interrupted: %v; run mutation reconcile %s", err, opts.OperationID), true, 1)
 		}
-		_ = clearMutationJournal(path, opts.OperationID)
+		terminal := terminalFromJournal(journal, mutationOutcomeRejected, before, "stale_config_hash", true)
+		published, terminalErr := publishMutationTerminal(path, terminal, &journal)
+		if terminalErr != nil {
+			result.ReconciliationRequired = true
+			return failMutation(opts, out, result, "terminal_write_failed", reviewedMutationMessage("terminal_write_failed"), true, 1)
+		}
+		result.Outcome = mutationOutcomeRejected
+		result.CleanupPending = published.CleanupPending
 		return failMutation(opts, out, result, "stale_config_hash", err.Error(), true, 1)
 	}
 
@@ -1277,12 +1422,14 @@ func runJournaledMutationLocked(path string, prior []byte, mode os.FileMode, opt
 		result.Applied = true
 		result.ActiveToken = active.activeToken()
 		result.ActiveConfigHash = active.ActiveConfigHash
-		if err := clearMutationJournal(path, opts.OperationID); err != nil {
+		published, err := publishMutationTerminal(path, terminalFromJournal(journal, mutationOutcomeApplied, active, "", false), &journal)
+		if err != nil {
 			result.ReconciliationRequired = true
-			return failMutation(opts, out, result, "journal_clear_failed",
-				fmt.Sprintf("config activated but transaction journal could not be cleared: %v", err), true, 1)
+			return failMutation(opts, out, result, "terminal_write_failed", reviewedMutationMessage("terminal_write_failed"), true, 1)
 		}
 		result.OK = true
+		result.Outcome = mutationOutcomeApplied
+		result.CleanupPending = published.CleanupPending
 		if opts.JSON {
 			emitMutationResult(out, result)
 		} else {
@@ -1306,7 +1453,6 @@ func rollbackJournaledMutation(path string, journal routingMutationJournal, befo
 		return failMutation(opts, out, result, "activation_indeterminate",
 			fmt.Sprintf("%s; refusing to overwrite a concurrent config change while restoring: %v; run mutation reconcile %s", cause, err, journal.OperationID), true, 1)
 	}
-	result.DesiredConfigHash = journal.PreviousConfigHash
 	if active, alreadyActive := waitConfigHashActivation(adminAddr, path, journal.PreviousConfigHash, "", false, 250*time.Millisecond); alreadyActive {
 		result.ActiveToken = active.activeToken()
 		result.ActiveConfigHash = active.ActiveConfigHash
@@ -1324,13 +1470,16 @@ func rollbackJournaledMutation(path string, journal routingMutationJournal, befo
 		return failMutation(opts, out, result, "activation_indeterminate",
 			fmt.Sprintf("%s; prior config was restored but not confirmed active; run mutation reconcile %s", cause, journal.OperationID), true, 1)
 	}
-	if err := clearMutationJournal(path, journal.OperationID); err != nil {
+	published, err := publishMutationTerminal(path,
+		terminalFromJournal(journal, mutationOutcomeRolledBack, active, "activation_failed_rolled_back", false), &journal)
+	if err != nil {
 		result.ReconciliationRequired = true
-		return failMutation(opts, out, result, "journal_clear_failed",
-			fmt.Sprintf("%s; prior config is active but journal cleanup failed: %v", cause, err), true, 1)
+		return failMutation(opts, out, result, "terminal_write_failed", reviewedMutationMessage("terminal_write_failed"), true, 1)
 	}
 	result.ActiveToken = active.activeToken()
 	result.ActiveConfigHash = active.ActiveConfigHash
+	result.Outcome = mutationOutcomeRolledBack
+	result.CleanupPending = published.CleanupPending
 	return failMutation(opts, out, result, "activation_failed_rolled_back",
 		cause+"; restored and reactivated the prior exact config", false, 1)
 }
@@ -1339,7 +1488,7 @@ func runGlobalSwitchLocked(verb, path string, file *config.File, prior []byte, m
 	requested := verb == "on"
 	if file.Global.RoutingEnabled == nil {
 		return failMutation(opts, out, mutationResultForSpec(journaledMutationSpec{
-			Operation: "set_global_routing", Requested: requested,
+			Operation: "set_global_routing", Surface: mutationSurfaceSwitch, Requested: requested,
 		}, opts.OperationID, path, exactConfigHash(prior)), "invalid_routing_policy",
 			"config has no explicit global.routing_enabled", false, 1)
 	}
@@ -1349,6 +1498,7 @@ func runGlobalSwitchLocked(verb, path string, file *config.File, prior []byte, m
 	}
 	return runJournaledMutationLocked(path, prior, mode, opts, out, journaledMutationSpec{
 		Operation: "set_global_routing",
+		Surface:   mutationSurfaceSwitch,
 		Requested: requested,
 		Apply: func(editPath string) error {
 			return config.SetGlobalRoutingEnabled(editPath, requested)
@@ -1358,6 +1508,14 @@ func runGlobalSwitchLocked(verb, path string, file *config.File, prior []byte, m
 }
 
 func cmdMutation(args []string) int {
+	if len(args) > 0 {
+		switch args[0] {
+		case "status":
+			return cmdMutationStatus(args[1:])
+		case "recover":
+			return cmdMutationRecover(args[1:])
+		}
+	}
 	opts, positional, err := parseMutationOptions(args)
 	if err != nil {
 		return failMutation(opts, os.Stdout, mutationResult{Operation: "reconcile_routing_mutation"},
@@ -1390,12 +1548,41 @@ func cmdMutation(args []string) int {
 	}
 	lock, err := acquireConfigMutationLock(path)
 	if err != nil {
-		return failMutation(opts, os.Stdout, result, "mutation_locked", err.Error(), true, 1)
+		return failMutation(opts, os.Stdout, result, "mutation_locked", reviewedMutationMessage("mutation_locked"), true, 1)
 	}
 	defer lock.close()
+	if terminal, terminalErr := readMutationTerminal(path, operationID); terminalErr == nil {
+		_ = gcMutationTerminals(path, time.Now().UTC())
+		result = resultFromTerminal(path, terminal, false, journaledMutationSpec{})
+		result.OperationID = operationID
+		cleanupPending, cleanupErr := terminalCleanupPending(path, terminal)
+		if cleanupErr != nil {
+			return failMutation(opts, os.Stdout, result, "terminal_conflict", reviewedMutationMessage("terminal_conflict"), false, 1)
+		}
+		result.CleanupPending = cleanupPending
+		switch terminal.Outcome {
+		case mutationOutcomeApplied, mutationOutcomeUnchanged, mutationOutcomeNotApplied, mutationOutcomeRolledBack:
+			result.OK = true
+			result.Error = nil
+			if opts.JSON {
+				emitMutationResult(os.Stdout, result)
+			} else {
+				fmt.Fprintf(os.Stdout, "mutation %s replayed (%s)\n", operationID, terminal.Outcome)
+			}
+			return 0
+		default:
+			code := terminal.ErrorCode
+			if code == "" {
+				code = "mutation_rejected"
+			}
+			return failMutation(opts, os.Stdout, result, code, reviewedMutationMessage(code), terminal.ErrorRetryable, 1)
+		}
+	} else if !errors.Is(terminalErr, os.ErrNotExist) {
+		return failMutation(opts, os.Stdout, result, "terminal_conflict", reviewedMutationMessage("terminal_conflict"), false, 1)
+	}
 	if err := recoverInterruptedExactConfigCommit(path); err != nil {
 		result.ReconciliationRequired = true
-		return failMutation(opts, os.Stdout, result, "commit_recovery_failed", err.Error(), true, 1)
+		return failMutation(opts, os.Stdout, result, "commit_recovery_failed", reviewedMutationMessage("commit_recovery_failed"), true, 1)
 	}
 	journal, err := readMutationJournal(path, operationID)
 	if err != nil {
@@ -1403,7 +1590,11 @@ func cmdMutation(args []string) int {
 		if errors.Is(err, os.ErrNotExist) {
 			code = "journal_not_found"
 		}
-		return failMutation(opts, os.Stdout, result, code, err.Error(), false, 1)
+		message := reviewedMutationMessage(code)
+		if code != "journal_not_found" {
+			message = reviewedMutationMessage("journal_invalid")
+		}
+		return failMutation(opts, os.Stdout, result, code, message, false, 1)
 	}
 	result.Requested = journal.Requested
 	result.RequestedTarget = journal.RequestedTarget
@@ -1413,36 +1604,45 @@ func cmdMutation(args []string) int {
 	result.PreviousActiveToken = journal.PreviousActiveToken
 	result.PreviousDesiredConfigHash = journal.PreviousConfigHash
 	result.DesiredConfigHash = journal.DesiredConfigHash
+	result.RequestFingerprint = journal.RequestFingerprint
+	result.IdentityStrength = mutationIdentityLegacy
+	if journal.RequestFingerprint != "" {
+		result.IdentityStrength = mutationIdentityExact
+	}
 	current, _, err := readExactConfig(path)
 	if err != nil {
-		return failMutation(opts, os.Stdout, result, "config_read_failed", err.Error(), true, 1)
+		return failMutation(opts, os.Stdout, result, "config_read_failed", reviewedMutationMessage("config_read_failed"), true, 1)
 	}
 	currentHash := exactConfigHash(current)
 	if currentHash != journal.DesiredConfigHash && currentHash != journal.PreviousConfigHash {
 		return failMutation(opts, os.Stdout, result, "external_config_change",
-			fmt.Sprintf("current config hash %s matches neither the intended hash %s nor prior hash %s; journal left intact", currentHash, journal.DesiredConfigHash, journal.PreviousConfigHash), false, 1)
+			reviewedMutationMessage("external_config_change"), false, 1)
 	}
 	switch state, pid := classifyPidfile(gatewayPidfilePath()); state {
 	case pidfileAlive:
 		adminAddr := envDefault("BASETEN_SWITCH_ADMIN_ADDR", gateway.DefaultAdminAddr)
 		before, statusErr := fetchRoutingAdminStatus(adminAddr)
 		if statusErr != nil {
-			return failMutation(opts, os.Stdout, result, "router_unavailable", statusErr.Error(), true, 1)
+			return failMutation(opts, os.Stdout, result, "router_unavailable", reviewedMutationMessage("router_unavailable"), true, 1)
 		}
 		if before.ConfigPath == "" || canonicalPath(before.ConfigPath) != canonicalPath(path) {
 			return failMutation(opts, os.Stdout, result, "router_state_mismatch",
-				fmt.Sprintf("running router config path %q does not match %s", before.ConfigPath, path), false, 1)
+				reviewedMutationMessage("router_state_mismatch"), false, 1)
 		}
 		if err := validateManagedRouterIdentity(before, pid); err != nil {
-			return failMutation(opts, os.Stdout, result, "router_identity_mismatch", err.Error(), false, 1)
+			return failMutation(opts, os.Stdout, result, "router_identity_mismatch", reviewedMutationMessage("router_identity_mismatch"), false, 1)
 		}
 		if currentHash == journal.DesiredConfigHash {
 			if active, ok := waitConfigHashActivation(adminAddr, path, journal.DesiredConfigHash, "", false, 250*time.Millisecond); ok {
-				if err := clearMutationJournal(path, operationID); err != nil {
-					return failMutation(opts, os.Stdout, result, "journal_clear_failed", err.Error(), true, 1)
+				published, err := publishMutationTerminal(path, terminalFromJournal(journal, mutationOutcomeApplied, active, "", false), &journal)
+				if err != nil {
+					result.ReconciliationRequired = true
+					return failMutation(opts, os.Stdout, result, "terminal_write_failed", reviewedMutationMessage("terminal_write_failed"), true, 1)
 				}
 				result.OK = true
 				result.Applied = true
+				result.Outcome = mutationOutcomeApplied
+				result.CleanupPending = published.CleanupPending
 				result.ActiveToken = active.activeToken()
 				result.ActiveConfigHash = active.ActiveConfigHash
 				if opts.JSON {
@@ -1454,11 +1654,15 @@ func cmdMutation(args []string) int {
 			}
 			if _, err := signalVerifiedRouter(before, adminAddr); err == nil {
 				if active, ok := waitConfigHashActivation(adminAddr, path, journal.DesiredConfigHash, journal.PreviousActiveToken, true, routeApplyTimeout); ok {
-					if err := clearMutationJournal(path, operationID); err != nil {
-						return failMutation(opts, os.Stdout, result, "journal_clear_failed", err.Error(), true, 1)
+					published, err := publishMutationTerminal(path, terminalFromJournal(journal, mutationOutcomeApplied, active, "", false), &journal)
+					if err != nil {
+						result.ReconciliationRequired = true
+						return failMutation(opts, os.Stdout, result, "terminal_write_failed", reviewedMutationMessage("terminal_write_failed"), true, 1)
 					}
 					result.OK = true
 					result.Applied = true
+					result.Outcome = mutationOutcomeApplied
+					result.CleanupPending = published.CleanupPending
 					result.ActiveToken = active.activeToken()
 					result.ActiveConfigHash = active.ActiveConfigHash
 					if opts.JSON {
@@ -1472,7 +1676,6 @@ func cmdMutation(args []string) int {
 			return rollbackJournaledMutation(path, journal, before, adminAddr, opts, os.Stdout, result,
 				"reconciliation could not activate the intended config")
 		}
-		result.DesiredConfigHash = journal.PreviousConfigHash
 		if _, alreadyActive := waitConfigHashActivation(adminAddr, path, journal.PreviousConfigHash, "", false, 250*time.Millisecond); !alreadyActive {
 			_, _ = signalVerifiedRouter(before, adminAddr)
 		}
@@ -1482,11 +1685,15 @@ func cmdMutation(args []string) int {
 			return failMutation(opts, os.Stdout, result, "reconcile_failed",
 				"prior config is present but could not be confirmed active; journal left intact", true, 1)
 		}
-		if err := clearMutationJournal(path, operationID); err != nil {
-			return failMutation(opts, os.Stdout, result, "journal_clear_failed", err.Error(), true, 1)
+		published, err := publishMutationTerminal(path, terminalFromJournal(journal, mutationOutcomeNotApplied, active, "", false), &journal)
+		if err != nil {
+			result.ReconciliationRequired = true
+			return failMutation(opts, os.Stdout, result, "terminal_write_failed", reviewedMutationMessage("terminal_write_failed"), true, 1)
 		}
 		result.OK = true
 		result.Applied = false
+		result.Outcome = mutationOutcomeNotApplied
+		result.CleanupPending = published.CleanupPending
 		result.ActiveToken = active.activeToken()
 		result.ActiveConfigHash = active.ActiveConfigHash
 		if opts.JSON {

--- a/gateway/cmd/baseten-switch/routing_mutation_recovery.go
+++ b/gateway/cmd/baseten-switch/routing_mutation_recovery.go
@@ -1,0 +1,1227 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/basetenlabs/baseten-switch/gateway/cmd/gateway"
+)
+
+var (
+	mutationTerminalLink       = os.Link
+	mutationTerminalRemove     = os.Remove
+	mutationTerminalSync       = syncDirectory
+	errMutationJournalConflict = errors.New("multiple active mutation journals")
+)
+
+const (
+	mutationTerminalVersion    = 2
+	mutationFingerprintVersion = 2
+
+	mutationOutcomeApplied    = "applied"
+	mutationOutcomeUnchanged  = "unchanged"
+	mutationOutcomeNotApplied = "not_applied"
+	mutationOutcomeRolledBack = "rolled_back"
+	mutationOutcomeRejected   = "rejected"
+
+	mutationIdentityExact  = "exact"
+	mutationIdentityLegacy = "legacy"
+
+	mutationStatusNone                   = "none"
+	mutationStatusDesiredActive          = "desired_active"
+	mutationStatusPriorActive            = "prior_active"
+	mutationStatusDesiredPending         = "desired_pending"
+	mutationStatusPriorPending           = "prior_pending"
+	mutationStatusRouterUnavailable      = "router_unavailable"
+	mutationStatusRouterUnsupported      = "router_unsupported"
+	mutationStatusExternalChange         = "external_change"
+	mutationStatusCommitRecoveryRequired = "commit_recovery_required"
+	mutationStatusJournalInvalid         = "journal_invalid"
+	mutationStatusJournalConflict        = "journal_conflict"
+	mutationStatusCleanupPending         = "cleanup_pending"
+
+	mutationConfigReadLimit   = 4 << 20
+	mutationJournalReadLimit  = 6 << 20
+	mutationTerminalReadLimit = 64 << 10
+	mutationCompletedScanMax  = 4096
+	mutationTerminalRetain    = 30 * 24 * time.Hour
+)
+
+type mutationFingerprintInput struct {
+	FingerprintVersion      int    `json:"fingerprint_version"`
+	CanonicalConfigIdentity string `json:"canonical_config_identity"`
+	Operation               string `json:"operation"`
+	Surface                 string `json:"surface"`
+	Client                  string `json:"client,omitempty"`
+	Key                     string `json:"key,omitempty"`
+	RequestedPresent        bool   `json:"requested_present"`
+	Requested               bool   `json:"requested"`
+	RequestedTarget         string `json:"requested_target,omitempty"`
+	IfConfigHash            string `json:"if_config_hash,omitempty"`
+	IfActiveToken           string `json:"if_active_token,omitempty"`
+}
+
+type mutationTerminalRecord struct {
+	Version             int       `json:"version"`
+	OperationID         string    `json:"operation_id"`
+	IdentityStrength    string    `json:"identity_strength"`
+	ConfigIdentityHash  string    `json:"config_identity_hash"`
+	RequestFingerprint  string    `json:"request_fingerprint,omitempty"`
+	KeyHash             string    `json:"key_hash,omitempty"`
+	RequestedTargetHash string    `json:"requested_target_hash,omitempty"`
+	Operation           string    `json:"operation"`
+	Surface             string    `json:"surface,omitempty"`
+	Client              string    `json:"client,omitempty"`
+	RequestedPresent    bool      `json:"requested_present"`
+	Requested           bool      `json:"requested"`
+	Outcome             string    `json:"outcome"`
+	PreviousConfigHash  string    `json:"previous_config_hash"`
+	DesiredConfigHash   string    `json:"desired_config_hash"`
+	ActiveConfigHash    string    `json:"active_config_hash"`
+	PreviousActiveToken string    `json:"previous_active_token,omitempty"`
+	ActiveToken         string    `json:"active_token,omitempty"`
+	ErrorCode           string    `json:"error_code,omitempty"`
+	ErrorRetryable      bool      `json:"error_retryable,omitempty"`
+	CompletedAt         time.Time `json:"completed_at"`
+}
+
+type routingMutationStatus struct {
+	Classification      string         `json:"classification"`
+	BlockingOperationID string         `json:"blocking_operation_id,omitempty"`
+	Error               *mutationError `json:"error,omitempty"`
+}
+
+type terminalPublishResult struct {
+	Record         mutationTerminalRecord
+	CleanupPending bool
+}
+
+type mutationRecoveryResult struct {
+	OK                 bool           `json:"ok"`
+	Classification     string         `json:"classification"`
+	OperationID        string         `json:"operation_id,omitempty"`
+	Outcome            string         `json:"outcome,omitempty"`
+	Applied            bool           `json:"applied"`
+	IdentityStrength   string         `json:"identity_strength,omitempty"`
+	RequestFingerprint string         `json:"request_fingerprint,omitempty"`
+	CleanupPending     bool           `json:"cleanup_pending,omitempty"`
+	Error              *mutationError `json:"error,omitempty"`
+}
+
+func requestedPresent(operation string) bool {
+	return operation == "set_global_routing"
+}
+
+func domainHash(domain, value string) string {
+	sum := sha256.Sum256([]byte(domain + "\x00" + value))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func configIdentityHash(path string) string {
+	return domainHash("config-identity-v1", canonicalPath(path))
+}
+
+func mutationRequestFingerprint(path string, opts mutationOptions, spec journaledMutationSpec) (string, error) {
+	if !validMutationSurface(spec.Operation, spec.Surface) {
+		return "", fmt.Errorf("invalid mutation surface")
+	}
+	input := mutationFingerprintInput{
+		FingerprintVersion:      mutationFingerprintVersion,
+		CanonicalConfigIdentity: canonicalPath(path),
+		Operation:               spec.Operation,
+		Surface:                 spec.Surface,
+		Client:                  spec.Client,
+		Key:                     spec.Key,
+		RequestedPresent:        requestedPresent(spec.Operation),
+		Requested:               spec.Requested,
+		RequestedTarget:         spec.RequestedTarget,
+	}
+	if opts.hasConfigHash {
+		input.IfConfigHash = opts.IfConfigHash
+	}
+	if opts.hasActiveToken {
+		input.IfActiveToken = opts.IfActiveToken
+	}
+	data, err := json.Marshal(input)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func mutationCompletedDir(configPath string) string {
+	return filepath.Join(mutationJournalDir(configPath), "completed")
+}
+
+func mutationTerminalPath(configPath, operationID string) string {
+	return filepath.Join(mutationCompletedDir(configPath), operationID+".json")
+}
+
+func secureDirectory(path string, create bool) error {
+	if create {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			return err
+		}
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() || info.Mode().Perm() != 0o700 {
+		return fmt.Errorf("mutation state directory is not a secure regular directory")
+	}
+	return nil
+}
+
+func readBoundedRegularFile(path string, limit int64, requireMode os.FileMode) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("mutation state entry is not a regular file")
+	}
+	if requireMode != 0 && info.Mode().Perm() != requireMode.Perm() {
+		return nil, fmt.Errorf("mutation state entry has unsafe permissions")
+	}
+	if info.Size() > limit {
+		return nil, fmt.Errorf("mutation state entry exceeds the size limit")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	opened, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !os.SameFile(info, opened) {
+		return nil, fmt.Errorf("mutation state entry changed while opening")
+	}
+	data, err := io.ReadAll(io.LimitReader(file, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("mutation state entry exceeds the size limit")
+	}
+	return data, nil
+}
+
+func validateMutationStateDirectories(configPath string, completed bool) error {
+	if err := secureDirectory(mutationJournalDir(configPath), false); err != nil {
+		return err
+	}
+	if completed {
+		return secureDirectory(mutationCompletedDir(configPath), false)
+	}
+	return nil
+}
+
+func validTerminalOperationShape(record mutationTerminalRecord) bool {
+	if record.RequestedPresent != requestedPresent(record.Operation) {
+		return false
+	}
+	switch record.Operation {
+	case "set_global_routing":
+		return validMutationSurface(record.Operation, record.Surface) && record.Client == "" && record.KeyHash == "" && record.RequestedTargetHash == ""
+	case "set_claude_route", "set_claude_subagents":
+		return validMutationSurface(record.Operation, record.Surface) && !record.Requested && record.Client != "" && validConfigHash(record.KeyHash) && validConfigHash(record.RequestedTargetHash)
+	case "set_codex_route":
+		return validMutationSurface(record.Operation, record.Surface) && !record.Requested && record.Client != "" && validConfigHash(record.KeyHash) && validConfigHash(record.RequestedTargetHash)
+	case "set_model_reasoning":
+		return validMutationSurface(record.Operation, record.Surface) &&
+			!record.Requested && record.Client != "" && validConfigHash(record.KeyHash) && validConfigHash(record.RequestedTargetHash)
+	default:
+		return false
+	}
+}
+
+func validMutationSurface(operation, surface string) bool {
+	switch operation {
+	case "set_global_routing":
+		return surface == mutationSurfaceSwitch
+	case "set_claude_route", "set_claude_subagents":
+		return surface == mutationSurfaceClaude
+	case "set_codex_route":
+		return surface == mutationSurfaceCodex
+	case "set_model_reasoning":
+		return surface == mutationSurfaceClaude || surface == mutationSurfaceCodex
+	default:
+		return false
+	}
+}
+
+func validLegacyTerminalOperationShape(record mutationTerminalRecord) bool {
+	if record.Surface != "" || record.RequestedPresent != requestedPresent(record.Operation) {
+		return false
+	}
+	switch record.Operation {
+	case "set_global_routing":
+		return record.Client == "" && record.KeyHash == "" && record.RequestedTargetHash == ""
+	case "set_claude_route", "set_claude_subagents", "set_codex_route", "set_model_reasoning":
+		return !record.Requested && record.Client != "" && validConfigHash(record.KeyHash) && validConfigHash(record.RequestedTargetHash)
+	default:
+		return false
+	}
+}
+
+func validMutationActiveToken(token string) bool {
+	separator := strings.LastIndexByte(token, ':')
+	if separator <= 0 || separator == len(token)-1 || strings.Contains(token[:separator], ":") {
+		return false
+	}
+	generation, err := strconv.ParseUint(token[separator+1:], 10, 64)
+	return err == nil && generation > 0
+}
+
+func validateTerminalRecord(record mutationTerminalRecord, path, operationID string) error {
+	if record.Version != mutationTerminalVersion || record.OperationID != operationID ||
+		record.ConfigIdentityHash != configIdentityHash(path) || !validConfigHash(record.ConfigIdentityHash) ||
+		record.CompletedAt.IsZero() || record.CompletedAt.After(time.Now().UTC()) {
+		return fmt.Errorf("terminal record identity is invalid")
+	}
+	if record.IdentityStrength != mutationIdentityExact && record.IdentityStrength != mutationIdentityLegacy {
+		return fmt.Errorf("terminal record identity strength is invalid")
+	}
+	if record.IdentityStrength == mutationIdentityExact {
+		if !validConfigHash(record.RequestFingerprint) {
+			return fmt.Errorf("terminal record fingerprint is invalid")
+		}
+		if !validTerminalOperationShape(record) {
+			return fmt.Errorf("terminal record surface is invalid")
+		}
+	} else {
+		if record.RequestFingerprint != "" {
+			return fmt.Errorf("legacy terminal record cannot contain an exact fingerprint")
+		}
+		if !validLegacyTerminalOperationShape(record) {
+			return fmt.Errorf("legacy terminal record surface is invalid")
+		}
+	}
+	switch record.Outcome {
+	case mutationOutcomeApplied, mutationOutcomeUnchanged, mutationOutcomeNotApplied, mutationOutcomeRolledBack, mutationOutcomeRejected:
+	default:
+		return fmt.Errorf("terminal record outcome is invalid")
+	}
+	if !validConfigHash(record.PreviousConfigHash) || !validConfigHash(record.DesiredConfigHash) {
+		return fmt.Errorf("terminal record hashes are invalid")
+	}
+	if record.ActiveConfigHash != "" && !validConfigHash(record.ActiveConfigHash) {
+		return fmt.Errorf("terminal record active hash is invalid")
+	}
+	if (record.PreviousActiveToken != "" && !validMutationActiveToken(record.PreviousActiveToken)) ||
+		(record.ActiveToken != "" && !validMutationActiveToken(record.ActiveToken)) {
+		return fmt.Errorf("terminal record active token is invalid")
+	}
+	if (record.ActiveToken == "") != (record.ActiveConfigHash == "") {
+		return fmt.Errorf("terminal record active token and hash are inconsistent")
+	}
+	if record.ErrorRetryable && record.ErrorCode == "" {
+		return fmt.Errorf("terminal record error state is inconsistent")
+	}
+	switch record.Outcome {
+	case mutationOutcomeApplied:
+		if record.ActiveConfigHash != record.DesiredConfigHash || record.ActiveToken == "" || record.ErrorCode != "" ||
+			record.ErrorRetryable || record.PreviousConfigHash == record.DesiredConfigHash || record.ActiveToken == record.PreviousActiveToken {
+			return fmt.Errorf("applied terminal record is inconsistent")
+		}
+	case mutationOutcomeUnchanged:
+		if record.PreviousConfigHash != record.DesiredConfigHash || record.ErrorCode != "" || record.ErrorRetryable ||
+			(record.ActiveConfigHash != "" && record.ActiveConfigHash != record.DesiredConfigHash) || record.ActiveToken != record.PreviousActiveToken {
+			return fmt.Errorf("unchanged terminal record is inconsistent")
+		}
+	case mutationOutcomeNotApplied:
+		if record.ActiveConfigHash != record.PreviousConfigHash || record.ActiveToken == "" || record.ErrorCode != "" || record.ErrorRetryable {
+			return fmt.Errorf("not-applied terminal record is inconsistent")
+		}
+	case mutationOutcomeRolledBack:
+		if record.ActiveConfigHash != record.PreviousConfigHash || record.ActiveToken == "" ||
+			record.ErrorCode != "activation_failed_rolled_back" || record.ErrorRetryable {
+			return fmt.Errorf("rolled-back terminal record is inconsistent")
+		}
+	case mutationOutcomeRejected:
+		if record.ErrorCode != "stale_config_hash" || !record.ErrorRetryable ||
+			record.PreviousConfigHash == record.DesiredConfigHash ||
+			(record.ActiveConfigHash != "" && record.ActiveConfigHash != record.PreviousConfigHash) ||
+			record.ActiveToken != record.PreviousActiveToken {
+			return fmt.Errorf("rejected terminal record is inconsistent")
+		}
+	}
+	return nil
+}
+
+func readMutationTerminal(configPath, operationID string) (mutationTerminalRecord, error) {
+	var record mutationTerminalRecord
+	if err := validateMutationStateDirectories(configPath, true); err != nil {
+		return record, err
+	}
+	data, err := readBoundedRegularFile(mutationTerminalPath(configPath, operationID), mutationTerminalReadLimit, 0o600)
+	if err != nil {
+		return record, err
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	if err := decoder.Decode(&record); err != nil {
+		return record, fmt.Errorf("decode terminal record: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return record, fmt.Errorf("decode terminal record: trailing JSON content")
+	}
+	if err := validateTerminalRecord(record, configPath, operationID); err != nil {
+		return record, err
+	}
+	return record, nil
+}
+
+func terminalRecordsEqual(a, b mutationTerminalRecord) bool {
+	// completed_at belongs to the first durable publication. A retry must
+	// validate every replay-affecting field and reuse that original timestamp.
+	b.CompletedAt = a.CompletedAt
+	left, _ := json.Marshal(a)
+	right, _ := json.Marshal(b)
+	return string(left) == string(right)
+}
+
+func terminalMatchesJournal(record mutationTerminalRecord, journal routingMutationJournal) bool {
+	if record.OperationID != journal.OperationID ||
+		record.ConfigIdentityHash != configIdentityHash(journal.ConfigPath) ||
+		record.Operation != journal.Operation || record.Surface != journal.Surface || record.Client != journal.Client ||
+		record.RequestedPresent != requestedPresent(journal.Operation) || record.Requested != journal.Requested ||
+		record.PreviousConfigHash != journal.PreviousConfigHash || record.DesiredConfigHash != journal.DesiredConfigHash ||
+		record.PreviousActiveToken != journal.PreviousActiveToken {
+		return false
+	}
+	if journal.Key != "" && record.KeyHash != domainHash("mutation-key-v1", journal.Key) {
+		return false
+	}
+	if journal.Key == "" && record.KeyHash != "" {
+		return false
+	}
+	if journal.RequestedTarget != "" && record.RequestedTargetHash != domainHash("requested-target-v1", journal.RequestedTarget) {
+		return false
+	}
+	if journal.RequestedTarget == "" && record.RequestedTargetHash != "" {
+		return false
+	}
+	if journal.RequestFingerprint == "" {
+		return record.IdentityStrength == mutationIdentityLegacy && record.RequestFingerprint == ""
+	}
+	return record.IdentityStrength == mutationIdentityExact && record.RequestFingerprint == journal.RequestFingerprint
+}
+
+func terminalFromJournal(journal routingMutationJournal, outcome string, active routingAdminStatus, errorCode string, retryable bool) mutationTerminalRecord {
+	strength := mutationIdentityLegacy
+	if journal.RequestFingerprint != "" {
+		strength = mutationIdentityExact
+	}
+	record := mutationTerminalRecord{
+		Version:             mutationTerminalVersion,
+		OperationID:         journal.OperationID,
+		IdentityStrength:    strength,
+		ConfigIdentityHash:  configIdentityHash(journal.ConfigPath),
+		RequestFingerprint:  journal.RequestFingerprint,
+		Operation:           journal.Operation,
+		Surface:             journal.Surface,
+		Client:              journal.Client,
+		RequestedPresent:    requestedPresent(journal.Operation),
+		Requested:           journal.Requested,
+		Outcome:             outcome,
+		PreviousConfigHash:  journal.PreviousConfigHash,
+		DesiredConfigHash:   journal.DesiredConfigHash,
+		ActiveConfigHash:    active.ActiveConfigHash,
+		PreviousActiveToken: journal.PreviousActiveToken,
+		ActiveToken:         active.activeToken(),
+		ErrorCode:           errorCode,
+		ErrorRetryable:      retryable,
+		CompletedAt:         time.Now().UTC(),
+	}
+	if journal.Key != "" {
+		record.KeyHash = domainHash("mutation-key-v1", journal.Key)
+	}
+	if journal.RequestedTarget != "" {
+		record.RequestedTargetHash = domainHash("requested-target-v1", journal.RequestedTarget)
+	}
+	return record
+}
+
+func publishMutationTerminal(configPath string, record mutationTerminalRecord, active *routingMutationJournal) (terminalPublishResult, error) {
+	result := terminalPublishResult{Record: record}
+	if err := validateTerminalRecord(record, configPath, record.OperationID); err != nil {
+		return result, err
+	}
+	journalDir := mutationJournalDir(configPath)
+	if err := secureDirectory(journalDir, true); err != nil {
+		return result, fmt.Errorf("prepare mutation journal directory: %w", err)
+	}
+	completedDir := mutationCompletedDir(configPath)
+	created := false
+	if _, err := os.Lstat(completedDir); errors.Is(err, os.ErrNotExist) {
+		created = true
+	}
+	if err := secureDirectory(completedDir, true); err != nil {
+		return result, fmt.Errorf("prepare completed mutation directory: %w", err)
+	}
+	if created {
+		if err := mutationTerminalSync(journalDir); err != nil {
+			return result, fmt.Errorf("sync mutation journal directory: %w", err)
+		}
+	}
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return result, err
+	}
+	data = append(data, '\n')
+	if len(data) > mutationTerminalReadLimit {
+		return result, fmt.Errorf("terminal record exceeds the size limit")
+	}
+	temp, err := os.CreateTemp(completedDir, ".terminal-*")
+	if err != nil {
+		return result, err
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+	if err := temp.Chmod(0o600); err != nil {
+		temp.Close()
+		return result, err
+	}
+	if _, err := temp.Write(data); err != nil {
+		temp.Close()
+		return result, err
+	}
+	if err := temp.Sync(); err != nil {
+		temp.Close()
+		return result, err
+	}
+	if err := temp.Close(); err != nil {
+		return result, err
+	}
+	finalPath := mutationTerminalPath(configPath, record.OperationID)
+	if err := mutationTerminalLink(tempPath, finalPath); err != nil {
+		if !errors.Is(err, os.ErrExist) {
+			return result, err
+		}
+		existing, readErr := readMutationTerminal(configPath, record.OperationID)
+		if readErr != nil || !terminalRecordsEqual(existing, record) {
+			return result, fmt.Errorf("terminal_conflict")
+		}
+		result.Record = existing
+	}
+	if err := mutationTerminalRemove(tempPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return result, err
+	}
+	if err := mutationTerminalSync(completedDir); err != nil {
+		return result, err
+	}
+	if active != nil {
+		current, err := readMutationJournal(configPath, active.OperationID)
+		if err != nil || !terminalMatchesJournal(result.Record, current) {
+			result.CleanupPending = true
+			return result, nil
+		}
+		if err := mutationTerminalRemove(mutationJournalPath(configPath, active.OperationID)); err != nil && !errors.Is(err, os.ErrNotExist) {
+			result.CleanupPending = true
+			return result, nil
+		}
+		if err := mutationTerminalSync(journalDir); err != nil {
+			result.CleanupPending = true
+			return result, nil
+		}
+	}
+	_ = gcMutationTerminals(configPath, time.Now().UTC())
+	return result, nil
+}
+
+func gcMutationTerminals(configPath string, now time.Time) error {
+	dir := mutationCompletedDir(configPath)
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if len(entries) > mutationCompletedScanMax {
+		return fmt.Errorf("completed mutation directory exceeds the scan limit")
+	}
+	activeOperationIDs, err := activeMutationOperationIDsForGC(configPath)
+	if err != nil {
+		return err
+	}
+	type candidate struct {
+		name string
+		when time.Time
+	}
+	var old []candidate
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		operationID := strings.TrimSuffix(entry.Name(), ".json")
+		if _, active := activeOperationIDs[operationID]; active {
+			continue
+		}
+		record, readErr := readMutationTerminal(configPath, operationID)
+		if readErr != nil || record.CompletedAt.After(now) || now.Sub(record.CompletedAt) < mutationTerminalRetain {
+			continue
+		}
+		old = append(old, candidate{name: entry.Name(), when: record.CompletedAt})
+	}
+	sort.Slice(old, func(i, j int) bool { return old[i].when.Before(old[j].when) })
+	if len(old) == 0 {
+		return nil
+	}
+	for _, candidate := range old {
+		if err := os.Remove(filepath.Join(dir, candidate.name)); err != nil {
+			return err
+		}
+	}
+	return syncDirectory(dir)
+}
+
+// activeMutationOperationIDsForGC identifies every terminal that must be
+// retained because top-level recovery state still exists. It validates all
+// active entries before GC can delete anything, so malformed or ambiguous
+// recovery state makes retention fail closed.
+func activeMutationOperationIDsForGC(configPath string) (map[string]struct{}, error) {
+	dir := mutationJournalDir(configPath)
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return map[string]struct{}{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if err := secureDirectory(dir, false); err != nil {
+		return nil, err
+	}
+	operationIDs := make(map[string]struct{})
+	for _, entry := range entries {
+		if entry.Name() == "completed" && entry.IsDir() {
+			if err := secureDirectory(filepath.Join(dir, entry.Name()), false); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		if !entry.Type().IsRegular() || !strings.HasSuffix(entry.Name(), ".json") {
+			return nil, fmt.Errorf("unexpected mutation journal entry")
+		}
+		operationID := strings.TrimSuffix(entry.Name(), ".json")
+		if err := validateOperationID(operationID); err != nil {
+			return nil, fmt.Errorf("invalid mutation journal operation ID")
+		}
+		if _, err := readMutationJournal(configPath, operationID); err != nil {
+			return nil, err
+		}
+		operationIDs[operationID] = struct{}{}
+	}
+	if len(operationIDs) > 1 {
+		return nil, errMutationJournalConflict
+	}
+	return operationIDs, nil
+}
+
+func resultFromTerminal(path string, record mutationTerminalRecord, includeRequest bool, spec journaledMutationSpec) mutationResult {
+	result := mutationResult{
+		OperationID:               record.OperationID,
+		Operation:                 record.Operation,
+		Client:                    record.Client,
+		ConfigPath:                path,
+		Requested:                 record.Requested,
+		PreviousActiveToken:       record.PreviousActiveToken,
+		PreviousDesiredConfigHash: record.PreviousConfigHash,
+		DesiredConfigHash:         record.DesiredConfigHash,
+		ActiveToken:               record.ActiveToken,
+		ActiveConfigHash:          record.ActiveConfigHash,
+		Outcome:                   record.Outcome,
+		RequestFingerprint:        record.RequestFingerprint,
+		IdentityStrength:          record.IdentityStrength,
+	}
+	if includeRequest {
+		result.Key = spec.Key
+		result.RequestedTarget = spec.RequestedTarget
+	}
+	switch record.Outcome {
+	case mutationOutcomeApplied:
+		result.OK, result.Applied = true, true
+	case mutationOutcomeUnchanged:
+		result.OK = true
+		result.Applied = record.ActiveConfigHash == record.DesiredConfigHash && record.ActiveConfigHash != ""
+	case mutationOutcomeNotApplied, mutationOutcomeRolledBack:
+		result.Applied = false
+	case mutationOutcomeRejected:
+		result.Applied = false
+	}
+	return result
+}
+
+// terminalCleanupPending preserves the recovery state represented by a
+// terminal record whose matching active journal could not be removed. A
+// terminal record is authoritative for the mutation outcome, but it is not
+// proof that the active journal cleanup completed.
+func terminalCleanupPending(path string, record mutationTerminalRecord) (bool, error) {
+	journal, err := readMutationJournal(path, record.OperationID)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if !terminalMatchesJournal(record, journal) {
+		return false, fmt.Errorf("terminal_conflict")
+	}
+	return true, nil
+}
+
+func replayTerminalForRequest(path string, opts mutationOptions, spec journaledMutationSpec) (mutationResult, bool, int, error) {
+	record, err := readMutationTerminal(path, opts.OperationID)
+	if errors.Is(err, os.ErrNotExist) {
+		return mutationResult{}, false, 0, nil
+	}
+	if err != nil {
+		return mutationResult{}, true, 1, err
+	}
+	baseResult := resultFromTerminal(path, record, true, spec)
+	if record.IdentityStrength != mutationIdentityExact {
+		return baseResult, true, 1, fmt.Errorf("operation_id_legacy")
+	}
+	if record.Surface != spec.Surface {
+		return baseResult, true, 1, fmt.Errorf("operation_id_conflict")
+	}
+	if spec.Client == "" && spec.Surface != mutationSurfaceSwitch {
+		spec.Client = record.Client
+		baseResult.Client = record.Client
+	}
+	fingerprint, err := mutationRequestFingerprint(path, opts, spec)
+	if err != nil {
+		return mutationResult{}, true, 1, err
+	}
+	if record.RequestFingerprint != fingerprint {
+		return baseResult, true, 1, fmt.Errorf("operation_id_conflict")
+	}
+	result := baseResult
+	cleanupPending, err := terminalCleanupPending(path, record)
+	if err != nil {
+		return result, true, 1, err
+	}
+	result.CleanupPending = cleanupPending
+	switch record.Outcome {
+	case mutationOutcomeApplied, mutationOutcomeUnchanged:
+		return result, true, 0, nil
+	case mutationOutcomeNotApplied:
+		return result, true, 1, fmt.Errorf("mutation_not_applied")
+	case mutationOutcomeRolledBack:
+		return result, true, 1, fmt.Errorf("activation_failed_rolled_back")
+	default:
+		code := record.ErrorCode
+		if code == "" {
+			code = "mutation_rejected"
+		}
+		return result, true, 1, fmt.Errorf("%s", code)
+	}
+}
+
+// preflightTerminalReplay is the small adapter-entry hook that enforces the
+// replay-before-config-loading contract. A missing terminal is not authority:
+// the caller continues through its normal config load and locked mutation.
+func preflightTerminalReplay(path string, opts mutationOptions, spec journaledMutationSpec, out io.Writer) (bool, int) {
+	if !opts.hasOperationID {
+		return false, 0
+	}
+	if _, err := os.Lstat(mutationTerminalPath(path, opts.OperationID)); errors.Is(err, os.ErrNotExist) {
+		return false, 0
+	} else if err != nil {
+		result := mutationResultForSpec(spec, opts.OperationID, path, "")
+		return true, failMutation(opts, out, result, "terminal_conflict", reviewedMutationMessage("terminal_conflict"), false, 1)
+	}
+	lock, err := acquireConfigMutationLock(path)
+	if err != nil {
+		result := mutationResultForSpec(spec, opts.OperationID, path, "")
+		return true, failMutation(opts, out, result, "mutation_locked", "routing mutation replay is temporarily unavailable", true, 1)
+	}
+	defer lock.close()
+	replay, found, rc, replayErr := replayTerminalForRequest(path, opts, spec)
+	if !found {
+		return false, 0
+	}
+	_ = gcMutationTerminals(path, time.Now().UTC())
+	if replayErr != nil && replayErr.Error() != "operation_id_conflict" && replayErr.Error() != "operation_id_legacy" &&
+		replayErr.Error() != "mutation_not_applied" && replayErr.Error() != "activation_failed_rolled_back" {
+		replayErr = fmt.Errorf("terminal_conflict")
+	}
+	return true, emitTerminalReplay(opts, out, replay, rc, replayErr)
+}
+
+func emitTerminalReplay(opts mutationOptions, out io.Writer, result mutationResult, rc int, replayErr error) int {
+	if replayErr != nil {
+		code := replayErr.Error()
+		message := reviewedMutationMessage(code)
+		result.Error = &mutationError{Code: code, Message: message, Retryable: false}
+		result.OK = false
+	}
+	if opts.JSON {
+		emitMutationResult(out, result)
+	} else if replayErr != nil {
+		fmt.Fprintln(os.Stderr, reviewedMutationMessage(replayErr.Error()))
+	} else {
+		fmt.Fprintf(out, "mutation %s replayed (%s)\n", result.OperationID, result.Outcome)
+	}
+	return rc
+}
+
+func reviewedMutationMessage(code string) string {
+	switch code {
+	case "operation_id_conflict":
+		return "that operation ID belongs to a different routing mutation"
+	case "operation_id_legacy":
+		return "that operation ID has legacy recovery state and cannot replay an original command"
+	case "mutation_not_applied":
+		return "the routing mutation was not applied; the prior routing state is active"
+	case "activation_failed_rolled_back":
+		return "routing activation failed and the prior routing state was restored"
+	case "journal_not_found":
+		return "no routing mutation recovery state exists for that operation ID"
+	case "terminal_conflict":
+		return "routing mutation completion state conflicts with active recovery state"
+	case "terminal_write_failed":
+		return "routing changed, but durable completion could not be recorded"
+	case "router_unavailable":
+		return "the router is unavailable; routing recovery state was preserved"
+	case "router_unsupported":
+		return "the router does not expose the state required for safe automatic cleanup"
+	case "mutation_locked":
+		return "another routing mutation is in progress; retry this operation"
+	case "stale_config_hash", "stale_active_token":
+		return "routing state changed before this mutation could be applied"
+	case "journal_read_failed", "journal_write_failed":
+		return "routing mutation recovery state could not be safely accessed"
+	case "config_read_failed", "config_load_failed", "config_edit_failed", "config_validation_failed", "invalid_routing_policy":
+		return "the routing config could not be safely prepared"
+	case "router_state_mismatch", "router_identity_mismatch":
+		return "the running router does not match the managed routing config"
+	case "commit_recovery_failed":
+		return "an interrupted config commit could not be safely recovered"
+	case "reconcile_failed", "activation_indeterminate":
+		return "the routing result could not be confirmed; recovery state was preserved"
+	case "reasoning_preflight_failed":
+		return "the reasoning policy could not be validated against the running router"
+	case "fingerprint_failed":
+		return "the routing request could not be identified safely"
+	case "cleanup_predicate_changed":
+		return "routing state changed during cleanup; retry the cleanup operation"
+	case "unfinished_mutation":
+		return "another routing mutation must be reconciled before starting this operation"
+	case "config_size_limit":
+		return "the edited routing config exceeds the mutation size limit"
+	case "invalid_subagent_state":
+		return "set a subagent model before enabling subagent routing"
+	case "external_config_change":
+		return "the config changed outside this routing mutation; recovery state was preserved"
+	case "commit_recovery_required":
+		return "an interrupted config commit requires explicit reconciliation"
+	case "journal_invalid":
+		return "routing mutation recovery state is invalid and was preserved"
+	case "journal_conflict":
+		return "multiple or conflicting routing mutation records were preserved"
+	default:
+		return "the routing mutation could not be completed"
+	}
+}
+
+func hasInterruptedExactCommit(path string) (bool, error) {
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		return false, err
+	}
+	prefix := exactCommitDirPrefix(path)
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), prefix) && entry.IsDir() {
+			if _, err := os.Lstat(filepath.Join(filepath.Dir(path), entry.Name(), "state.json")); err == nil {
+				return true, nil
+			} else if !errors.Is(err, os.ErrNotExist) {
+				return false, err
+			}
+		}
+	}
+	return false, nil
+}
+
+func singleActiveMutation(configPath string) (routingMutationJournal, bool, error) {
+	var empty routingMutationJournal
+	dir := mutationJournalDir(configPath)
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return empty, false, nil
+	}
+	if err != nil {
+		return empty, false, err
+	}
+	if err := secureDirectory(dir, false); err != nil {
+		return empty, false, err
+	}
+	var operationIDs []string
+	for _, entry := range entries {
+		if entry.Name() == "completed" && entry.IsDir() {
+			if err := secureDirectory(filepath.Join(dir, entry.Name()), false); err != nil {
+				return empty, false, err
+			}
+			continue
+		}
+		if entry.IsDir() || entry.Type()&os.ModeSymlink != 0 || !strings.HasSuffix(entry.Name(), ".json") {
+			return empty, false, fmt.Errorf("unexpected mutation journal entry")
+		}
+		operationIDs = append(operationIDs, strings.TrimSuffix(entry.Name(), ".json"))
+	}
+	if len(operationIDs) == 0 {
+		return empty, false, nil
+	}
+	if len(operationIDs) != 1 {
+		return empty, false, errMutationJournalConflict
+	}
+	journal, err := readMutationJournal(configPath, operationIDs[0])
+	if err != nil {
+		return empty, false, err
+	}
+	return journal, true, nil
+}
+
+func validateCompletedMutationRecords(configPath string, now time.Time) error {
+	dir := mutationCompletedDir(configPath)
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if err := secureDirectory(dir, false); err != nil {
+		return err
+	}
+	if len(entries) > mutationCompletedScanMax {
+		return fmt.Errorf("completed mutation directory exceeds the scan limit")
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || entry.Type()&os.ModeSymlink != 0 || !strings.HasSuffix(entry.Name(), ".json") {
+			return fmt.Errorf("unexpected completed mutation entry")
+		}
+		operationID := strings.TrimSuffix(entry.Name(), ".json")
+		record, err := readMutationTerminal(configPath, operationID)
+		if err != nil {
+			return err
+		}
+		if record.CompletedAt.After(now) {
+			return fmt.Errorf("completed mutation record is future-dated")
+		}
+	}
+	return nil
+}
+
+func inspectRoutingMutationStatus(configPath string) (routingMutationStatus, error) {
+	lock, err := acquireConfigMutationLock(configPath)
+	if err != nil {
+		return routingMutationStatus{}, err
+	}
+	defer lock.close()
+	return inspectRoutingMutationStatusLocked(configPath)
+}
+
+func inspectRoutingMutationStatusLocked(configPath string) (routingMutationStatus, error) {
+	status := routingMutationStatus{Classification: mutationStatusNone}
+	if err := validateCompletedMutationRecords(configPath, time.Now().UTC()); err != nil {
+		status.Classification = mutationStatusJournalInvalid
+		status.Error = &mutationError{Code: mutationStatusJournalInvalid, Message: reviewedMutationMessage(mutationStatusJournalInvalid)}
+		return status, nil
+	}
+	journal, found, err := singleActiveMutation(configPath)
+	if err != nil {
+		if errors.Is(err, errMutationJournalConflict) {
+			status.Classification = mutationStatusJournalConflict
+			status.Error = &mutationError{Code: mutationStatusJournalConflict, Message: reviewedMutationMessage(mutationStatusJournalConflict)}
+			return status, nil
+		}
+		status.Classification = mutationStatusJournalInvalid
+		status.Error = &mutationError{Code: mutationStatusJournalInvalid, Message: reviewedMutationMessage(mutationStatusJournalInvalid)}
+		return status, nil
+	}
+	if found {
+		status.BlockingOperationID = journal.OperationID
+	}
+	interrupted, err := hasInterruptedExactCommit(configPath)
+	if err != nil {
+		return routingMutationStatus{}, err
+	}
+	if interrupted {
+		status.Classification = mutationStatusCommitRecoveryRequired
+		return status, nil
+	}
+	if !found {
+		return status, nil
+	}
+	terminal, terminalErr := readMutationTerminal(configPath, journal.OperationID)
+	if terminalErr == nil {
+		if terminalMatchesJournal(terminal, journal) {
+			status.Classification = mutationStatusCleanupPending
+			return status, nil
+		}
+		status.Classification = mutationStatusJournalConflict
+		status.Error = &mutationError{Code: mutationStatusJournalConflict, Message: reviewedMutationMessage(mutationStatusJournalConflict)}
+		return status, nil
+	}
+	if !errors.Is(terminalErr, os.ErrNotExist) {
+		status.Classification = mutationStatusJournalConflict
+		status.Error = &mutationError{Code: mutationStatusJournalConflict, Message: reviewedMutationMessage(mutationStatusJournalConflict)}
+		return status, nil
+	}
+	data, _, err := readExactConfig(configPath)
+	if err != nil {
+		status.Classification = mutationStatusJournalInvalid
+		status.Error = &mutationError{Code: mutationStatusJournalInvalid, Message: reviewedMutationMessage(mutationStatusJournalInvalid)}
+		return status, nil
+	}
+	diskHash := exactConfigHash(data)
+	state, managedPID := classifyPidfile(gatewayPidfilePath())
+	if state != pidfileAlive {
+		status.Classification = mutationStatusRouterUnavailable
+		status.Error = &mutationError{Code: mutationStatusRouterUnavailable, Message: reviewedMutationMessage(mutationStatusRouterUnavailable), Retryable: true}
+		return status, nil
+	}
+	admin, err := fetchRoutingAdminStatus(envDefault("BASETEN_SWITCH_ADMIN_ADDR", gateway.DefaultAdminAddr))
+	if err != nil {
+		status.Classification = mutationStatusRouterUnavailable
+		status.Error = &mutationError{Code: mutationStatusRouterUnavailable, Message: reviewedMutationMessage(mutationStatusRouterUnavailable), Retryable: true}
+		return status, nil
+	}
+	if admin.RouterBootID == "" || admin.ActiveGeneration == 0 || admin.ActiveConfigHash == "" || admin.DesiredConfigHash == "" ||
+		admin.ConfigPath == "" || canonicalPath(admin.ConfigPath) != canonicalPath(configPath) || validateManagedRouterIdentity(admin, managedPID) != nil {
+		status.Classification = mutationStatusRouterUnsupported
+		status.Error = &mutationError{Code: mutationStatusRouterUnsupported, Message: reviewedMutationMessage(mutationStatusRouterUnsupported)}
+		return status, nil
+	}
+	if diskHash != journal.PreviousConfigHash && diskHash != journal.DesiredConfigHash {
+		status.Classification = mutationStatusExternalChange
+		status.Error = &mutationError{Code: mutationStatusExternalChange, Message: reviewedMutationMessage(mutationStatusExternalChange)}
+		return status, nil
+	}
+	if diskHash == journal.DesiredConfigHash {
+		if admin.DesiredConfigHash == diskHash && admin.ActiveConfigHash == diskHash {
+			status.Classification = mutationStatusDesiredActive
+		} else {
+			status.Classification = mutationStatusDesiredPending
+		}
+		return status, nil
+	}
+	if admin.DesiredConfigHash == diskHash && admin.ActiveConfigHash == diskHash {
+		status.Classification = mutationStatusPriorActive
+	} else {
+		status.Classification = mutationStatusPriorPending
+	}
+	return status, nil
+}
+
+func cleanupPendingMutation(configPath string, status routingMutationStatus) (terminalPublishResult, error) {
+	journal, found, err := singleActiveMutation(configPath)
+	if err != nil || !found || journal.OperationID != status.BlockingOperationID {
+		return terminalPublishResult{}, fmt.Errorf("cleanup predicate changed")
+	}
+	terminal, err := readMutationTerminal(configPath, journal.OperationID)
+	if err != nil || !terminalMatchesJournal(terminal, journal) {
+		return terminalPublishResult{}, fmt.Errorf("cleanup predicate changed")
+	}
+	interrupted, err := hasInterruptedExactCommit(configPath)
+	if err != nil || interrupted {
+		return terminalPublishResult{}, fmt.Errorf("cleanup predicate changed")
+	}
+	published, err := publishMutationTerminal(configPath, terminal, &journal)
+	if err != nil {
+		return terminalPublishResult{}, err
+	}
+	return published, nil
+}
+
+// finalCleanupSnapshot rechecks every cleanup predicate and returns the exact
+// router observation used to build the terminal record. Callers must not fetch
+// router state again between this snapshot and durable publication.
+func finalCleanupSnapshot(configPath string, expected routingMutationStatus) (routingMutationJournal, routingAdminStatus, error) {
+	journal, found, err := singleActiveMutation(configPath)
+	if err != nil || !found || journal.OperationID != expected.BlockingOperationID {
+		return routingMutationJournal{}, routingAdminStatus{}, fmt.Errorf("cleanup predicate changed")
+	}
+	if _, err := readMutationTerminal(configPath, journal.OperationID); !errors.Is(err, os.ErrNotExist) {
+		return routingMutationJournal{}, routingAdminStatus{}, fmt.Errorf("cleanup predicate changed")
+	}
+	interrupted, err := hasInterruptedExactCommit(configPath)
+	if err != nil || interrupted {
+		return routingMutationJournal{}, routingAdminStatus{}, fmt.Errorf("cleanup predicate changed")
+	}
+	data, _, err := readExactConfig(configPath)
+	if err != nil {
+		return routingMutationJournal{}, routingAdminStatus{}, fmt.Errorf("cleanup predicate changed")
+	}
+	diskHash := exactConfigHash(data)
+	state, managedPID := classifyPidfile(gatewayPidfilePath())
+	if state != pidfileAlive {
+		return routingMutationJournal{}, routingAdminStatus{}, fmt.Errorf("cleanup predicate changed")
+	}
+	admin, err := fetchRoutingAdminStatus(envDefault("BASETEN_SWITCH_ADMIN_ADDR", gateway.DefaultAdminAddr))
+	if err != nil || admin.RouterBootID == "" || admin.ActiveGeneration == 0 ||
+		admin.ActiveConfigHash == "" || admin.DesiredConfigHash == "" || admin.ConfigPath == "" ||
+		canonicalPath(admin.ConfigPath) != canonicalPath(configPath) || validateManagedRouterIdentity(admin, managedPID) != nil {
+		return routingMutationJournal{}, routingAdminStatus{}, fmt.Errorf("cleanup predicate changed")
+	}
+	classification := mutationStatusPriorPending
+	if diskHash == journal.DesiredConfigHash {
+		classification = mutationStatusDesiredPending
+		if admin.DesiredConfigHash == diskHash && admin.ActiveConfigHash == diskHash {
+			classification = mutationStatusDesiredActive
+		}
+	} else if diskHash == journal.PreviousConfigHash {
+		if admin.DesiredConfigHash == diskHash && admin.ActiveConfigHash == diskHash {
+			classification = mutationStatusPriorActive
+		}
+	} else {
+		classification = mutationStatusExternalChange
+	}
+	if classification != expected.Classification {
+		return routingMutationJournal{}, routingAdminStatus{}, fmt.Errorf("cleanup predicate changed")
+	}
+	return journal, admin, nil
+}
+
+func recoverRoutingMutationLocked(configPath string) (routingMutationStatus, terminalPublishResult, error) {
+	status, err := inspectRoutingMutationStatusLocked(configPath)
+	if err != nil {
+		return status, terminalPublishResult{}, err
+	}
+	switch status.Classification {
+	case mutationStatusNone:
+		return status, terminalPublishResult{}, nil
+	case mutationStatusCleanupPending:
+		published, err := cleanupPendingMutation(configPath, status)
+		return status, published, err
+	case mutationStatusDesiredActive, mutationStatusPriorActive:
+		journal, admin, err := finalCleanupSnapshot(configPath, status)
+		if err != nil {
+			return status, terminalPublishResult{}, err
+		}
+		outcome := mutationOutcomeApplied
+		if status.Classification == mutationStatusPriorActive {
+			outcome = mutationOutcomeNotApplied
+		}
+		record := terminalFromJournal(journal, outcome, admin, "", false)
+		published, err := publishMutationTerminal(configPath, record, &journal)
+		if err != nil {
+			return status, terminalPublishResult{}, err
+		}
+		return status, published, nil
+	default:
+		return status, terminalPublishResult{}, fmt.Errorf("%s", status.Classification)
+	}
+}
+
+func parseReadOnlyMutationArgs(command string, args []string) (bool, error) {
+	jsonOutput := false
+	for _, arg := range args {
+		if arg != "--json" || jsonOutput {
+			return false, fmt.Errorf("usage: baseten-switch mutation %s [--json]", command)
+		}
+		jsonOutput = true
+	}
+	return jsonOutput, nil
+}
+
+func cmdMutationStatus(args []string) int {
+	jsonOutput, err := parseReadOnlyMutationArgs("status", args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	path, _ := resolveConfigPath()
+	status, err := inspectRoutingMutationStatus(path)
+	if err != nil {
+		status = routingMutationStatus{
+			Classification: mutationStatusJournalInvalid,
+			Error:          &mutationError{Code: "mutation_locked", Message: "routing mutation status is temporarily unavailable", Retryable: true},
+		}
+	}
+	if jsonOutput {
+		_ = json.NewEncoder(os.Stdout).Encode(status)
+	} else if status.Classification == mutationStatusNone {
+		fmt.Fprintln(os.Stdout, "no active routing mutation")
+	} else {
+		fmt.Fprintf(os.Stdout, "routing mutation status: %s\n", status.Classification)
+	}
+	if err != nil {
+		return 1
+	}
+	return 0
+}
+
+func cmdMutationRecover(args []string) int {
+	jsonOutput, err := parseReadOnlyMutationArgs("recover", args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	path, _ := resolveConfigPath()
+	lock, err := acquireConfigMutationLock(path)
+	if err != nil {
+		result := mutationRecoveryResult{Classification: mutationStatusJournalInvalid, Error: &mutationError{Code: "mutation_locked", Message: "routing mutation cleanup is temporarily unavailable", Retryable: true}}
+		if jsonOutput {
+			_ = json.NewEncoder(os.Stdout).Encode(result)
+		} else {
+			fmt.Fprintln(os.Stderr, result.Error.Message)
+		}
+		return 1
+	}
+	defer lock.close()
+	status, published, recoverErr := recoverRoutingMutationLocked(path)
+	terminal := published.Record
+	result := mutationRecoveryResult{
+		OK:                 recoverErr == nil,
+		Classification:     status.Classification,
+		OperationID:        status.BlockingOperationID,
+		Outcome:            terminal.Outcome,
+		Applied:            terminal.Outcome == mutationOutcomeApplied,
+		IdentityStrength:   terminal.IdentityStrength,
+		RequestFingerprint: terminal.RequestFingerprint,
+		CleanupPending:     published.CleanupPending,
+	}
+	if recoverErr != nil {
+		code := recoverErr.Error()
+		switch code {
+		case mutationStatusRouterUnavailable, mutationStatusRouterUnsupported, mutationStatusExternalChange,
+			mutationStatusCommitRecoveryRequired, mutationStatusJournalInvalid, mutationStatusJournalConflict,
+			mutationStatusDesiredPending, mutationStatusPriorPending:
+		default:
+			code = "cleanup_predicate_changed"
+		}
+		result.Error = &mutationError{Code: code, Message: reviewedMutationMessage(code), Retryable: code == mutationStatusRouterUnavailable || code == "cleanup_predicate_changed"}
+	}
+	if jsonOutput {
+		_ = json.NewEncoder(os.Stdout).Encode(result)
+	} else if result.OK {
+		if result.OperationID == "" {
+			fmt.Fprintln(os.Stdout, "no active routing mutation")
+		} else {
+			fmt.Fprintf(os.Stdout, "routing mutation %s cleanup complete\n", result.OperationID)
+		}
+	} else {
+		fmt.Fprintln(os.Stderr, result.Error.Message)
+	}
+	if recoverErr != nil {
+		return 1
+	}
+	return 0
+}

--- a/gateway/cmd/baseten-switch/routing_mutation_recovery_test.go
+++ b/gateway/cmd/baseten-switch/routing_mutation_recovery_test.go
@@ -1,0 +1,1357 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/pidfile"
+)
+
+func installTerminalPublicationSeams(t *testing.T) {
+	t.Helper()
+	oldLink := mutationTerminalLink
+	oldRemove := mutationTerminalRemove
+	oldSync := mutationTerminalSync
+	t.Cleanup(func() {
+		mutationTerminalLink = oldLink
+		mutationTerminalRemove = oldRemove
+		mutationTerminalSync = oldSync
+	})
+}
+
+func legacyJournalForTest(t *testing.T, path, operationID string) routingMutationJournal {
+	t.Helper()
+	prior, mode, err := readExactConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	desired, err := previewExactConfigEdit(path, prior, mode, func(editPath string) error {
+		return config.SetGlobalRoutingEnabled(editPath, false)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return routingMutationJournal{
+		Version:             mutationJournalVersion,
+		OperationID:         operationID,
+		Operation:           "set_global_routing",
+		ConfigPath:          path,
+		Requested:           false,
+		PreviousRouting:     true,
+		PreviousConfig:      prior,
+		PreviousMode:        uint32(mode),
+		PreviousConfigHash:  exactConfigHash(prior),
+		DesiredConfigHash:   exactConfigHash(desired),
+		PreviousActiveToken: "boot:4",
+		CreatedAt:           time.Now().UTC(),
+	}
+}
+
+func TestRoutingMutationPublishesTerminalAndReplaysExactRequest(t *testing.T) {
+	installRoutingMutationSeams(t)
+	path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+	priorHash := exactFileHash(t, path)
+	if err := pidfile.WriteAt(pidfile.Path(), os.Getpid()); err != nil {
+		t.Fatal(err)
+	}
+	var signals atomic.Int32
+	signalRouter = func(int) error {
+		signals.Add(1)
+		return nil
+	}
+	fetchRoutingAdminStatus = func(string) (routingAdminStatus, error) {
+		if signals.Load() == 0 {
+			return liveRoutingStatus(path, priorHash, true, 4), nil
+		}
+		return liveRoutingStatus(path, exactFileHash(t, path), false, 5), nil
+	}
+	args := []string{"--json", "--operation-id", "terminal-replay", "--if-config-hash", priorHash}
+	var first strings.Builder
+	if rc := runSwitch("off", args, &first); rc != 0 {
+		t.Fatalf("first rc = %d: %s", rc, first.String())
+	}
+	record, err := readMutationTerminal(path, "terminal-replay")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.Outcome != mutationOutcomeApplied || record.Surface != mutationSurfaceSwitch ||
+		record.IdentityStrength != mutationIdentityExact || record.RequestFingerprint == "" {
+		t.Fatalf("terminal = %+v", record)
+	}
+	if _, err := os.Stat(mutationJournalPath(path, "terminal-replay")); !os.IsNotExist(err) {
+		t.Fatalf("active journal remains: %v", err)
+	}
+	terminalBytes, err := os.ReadFile(mutationTerminalPath(path, "terminal-replay"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(terminalBytes), path) || strings.Contains(string(terminalBytes), globalRoutingFixtureYAML) {
+		t.Fatalf("terminal retained config path or bytes: %s", terminalBytes)
+	}
+	firstSignals := signals.Load()
+	var replay strings.Builder
+	if rc := runSwitch("off", args, &replay); rc != 0 {
+		t.Fatalf("replay rc = %d: %s", rc, replay.String())
+	}
+	if signals.Load() != firstSignals {
+		t.Fatal("terminal replay signaled the router")
+	}
+	replayed := decodeMutationResult(t, replay.String())
+	if !replayed.OK || replayed.Outcome != mutationOutcomeApplied || replayed.RequestFingerprint != record.RequestFingerprint {
+		t.Fatalf("replay = %+v", replayed)
+	}
+
+	var conflict strings.Builder
+	conflictArgs := []string{"--json", "--operation-id", "terminal-replay"}
+	if rc := runSwitch("off", conflictArgs, &conflict); rc != 1 {
+		t.Fatalf("conflict rc = %d: %s", rc, conflict.String())
+	}
+	conflicted := decodeMutationResult(t, conflict.String())
+	if conflicted.Error == nil || conflicted.Error.Code != "operation_id_conflict" {
+		t.Fatalf("conflict = %+v", conflicted)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	var missingConfigReplay strings.Builder
+	if rc := runSwitch("off", args, &missingConfigReplay); rc != 0 {
+		t.Fatalf("pre-config replay rc = %d: %s", rc, missingConfigReplay.String())
+	}
+}
+
+func publishExactUnchangedTerminalForTest(t *testing.T, path, client string, opts mutationOptions, spec journaledMutationSpec) routingMutationJournal {
+	t.Helper()
+	prior, _, err := readExactConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fingerprint, err := mutationRequestFingerprint(path, opts, spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	journal := routingMutationJournal{
+		Version: mutationJournalVersion, OperationID: opts.OperationID, Operation: spec.Operation,
+		Surface: spec.Surface, ConfigPath: path, Requested: spec.Requested, RequestedTarget: spec.RequestedTarget,
+		Client: client, Key: spec.Key, PreviousConfig: prior, PreviousMode: 0o600,
+		PreviousConfigHash: exactConfigHash(prior), DesiredConfigHash: exactConfigHash(prior),
+		RequestFingerprint: fingerprint, CreatedAt: time.Now().UTC(),
+	}
+	record := terminalFromJournal(journal, mutationOutcomeUnchanged, routingAdminStatus{}, "", false)
+	if _, err := publishMutationTerminal(path, record, nil); err != nil {
+		t.Fatal(err)
+	}
+	return journal
+}
+
+func TestTerminalReplayPreservesCleanupPendingContract(t *testing.T) {
+	installRoutingMutationSeams(t)
+	setup := func(t *testing.T, operationID string) (string, mutationOptions, journaledMutationSpec) {
+		t.Helper()
+		path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+		opts := mutationOptions{JSON: true, OperationID: operationID, hasOperationID: true}
+		spec := journaledMutationSpec{Operation: "set_global_routing", Surface: mutationSurfaceSwitch, Requested: true}
+		journal := publishExactUnchangedTerminalForTest(t, path, "", opts, spec)
+		if err := writeMutationJournal(journal); err != nil {
+			t.Fatal(err)
+		}
+		return path, opts, spec
+	}
+
+	t.Run("original command", func(t *testing.T) {
+		path, opts, spec := setup(t, "cleanup-pending-original")
+		var out strings.Builder
+		replayed, rc := preflightTerminalReplay(path, opts, spec, &out)
+		if !replayed || rc != 0 {
+			t.Fatalf("replayed=%v rc=%d out=%s", replayed, rc, out.String())
+		}
+		result := decodeMutationResult(t, out.String())
+		if !result.OK || !result.CleanupPending || result.Outcome != mutationOutcomeUnchanged {
+			t.Fatalf("result=%+v", result)
+		}
+		if _, err := os.Stat(mutationJournalPath(path, opts.OperationID)); err != nil {
+			t.Fatalf("active journal was not preserved: %v", err)
+		}
+	})
+
+	t.Run("reconcile", func(t *testing.T) {
+		path, opts, _ := setup(t, "cleanup-pending-reconcile")
+		stdout, rc := captureStdout(t, func() int {
+			return cmdMutation([]string{"reconcile", opts.OperationID, "--json"})
+		})
+		if rc != 0 {
+			t.Fatalf("reconcile rc=%d out=%s", rc, stdout)
+		}
+		result := decodeMutationResult(t, stdout)
+		if !result.OK || !result.CleanupPending || result.Outcome != mutationOutcomeUnchanged {
+			t.Fatalf("result=%+v", result)
+		}
+		if _, err := os.Stat(mutationJournalPath(path, opts.OperationID)); err != nil {
+			t.Fatalf("active journal was not preserved: %v", err)
+		}
+	})
+}
+
+func TestAdapterTerminalReplayPrecedesConfigLoading(t *testing.T) {
+	installRoutingMutationSeams(t)
+	t.Run("claude route", func(t *testing.T) {
+		path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+		opts, _, err := parseMutationOptions([]string{"--json", "--operation-id", "claude-preload"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		spec := journaledMutationSpec{Operation: "set_claude_route", Surface: mutationSurfaceClaude, Client: "claude-code", Key: "sonnet", RequestedTarget: "native"}
+		publishExactUnchangedTerminalForTest(t, path, spec.Client, opts, spec)
+		if err := os.Remove(path); err != nil {
+			t.Fatal(err)
+		}
+		stdout, rc := captureStdout(t, func() int {
+			return cmdClaude([]string{"route", "sonnet", "native", "--json", "--operation-id", "claude-preload"})
+		})
+		if rc != 0 {
+			t.Fatalf("rc = %d: %s", rc, stdout)
+		}
+		result := decodeMutationResult(t, stdout)
+		if !result.OK || result.Outcome != mutationOutcomeUnchanged || result.Client != "claude-code" {
+			t.Fatalf("result = %+v", result)
+		}
+	})
+	t.Run("codex route", func(t *testing.T) {
+		path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+		opts, _, err := parseMutationOptions([]string{"--json", "--operation-id", "codex-preload"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		spec := journaledMutationSpec{Operation: "set_codex_route", Surface: mutationSurfaceCodex, Client: "codex", Key: "default_model", RequestedTarget: "example/model"}
+		publishExactUnchangedTerminalForTest(t, path, spec.Client, opts, spec)
+		if err := os.Remove(path); err != nil {
+			t.Fatal(err)
+		}
+		stdout, rc := captureStdout(t, func() int {
+			return cmdCodex([]string{"route", "example/model", "--json", "--operation-id", "codex-preload"})
+		})
+		if rc != 0 {
+			t.Fatalf("rc = %d: %s", rc, stdout)
+		}
+		result := decodeMutationResult(t, stdout)
+		if !result.OK || result.Outcome != mutationOutcomeUnchanged || result.Client != "codex" {
+			t.Fatalf("result = %+v", result)
+		}
+	})
+}
+
+func TestAdapterTerminalReplayUsesSelectedFallbackClientIdentity(t *testing.T) {
+	installRoutingMutationSeams(t)
+	fixture := strings.ReplaceAll(globalRoutingFixtureYAML, "claude-code", "anthropic-fallback") + `
+  - name: openai-fallback
+    enabled: true
+    bind_addr: 127.0.0.1:18082
+    protocol_shape: openai
+    default_model: example/model
+`
+	path := writeSwitchFixture(t, fixture)
+
+	t.Run("claude reasoning", func(t *testing.T) {
+		opts := mutationOptions{JSON: true, OperationID: "fallback-claude-reasoning", hasOperationID: true}
+		spec := journaledMutationSpec{
+			Operation: "set_model_reasoning", Surface: mutationSurfaceClaude, Client: "anthropic-fallback",
+			Key: "example/model", RequestedTarget: "default",
+		}
+		publishExactUnchangedTerminalForTest(t, path, spec.Client, opts, spec)
+		stdout, rc := captureStdout(t, func() int {
+			return cmdClaude([]string{
+				"reasoning", "baseten", "example/model", "default",
+				"--json", "--operation-id", opts.OperationID,
+			})
+		})
+		if rc != 0 {
+			t.Fatalf("rc=%d out=%s", rc, stdout)
+		}
+		result := decodeMutationResult(t, stdout)
+		if result.Client != spec.Client || result.Outcome != mutationOutcomeUnchanged {
+			t.Fatalf("result=%+v", result)
+		}
+
+		conflict, conflictRC := captureStdout(t, func() int {
+			return cmdCodex([]string{
+				"reasoning", "baseten", "example/model", "default",
+				"--json", "--operation-id", opts.OperationID,
+			})
+		})
+		if conflictRC != 1 || decodeMutationResult(t, conflict).Error.Code != "operation_id_conflict" {
+			t.Fatalf("cross-adapter rc=%d out=%s", conflictRC, conflict)
+		}
+	})
+
+	t.Run("codex reasoning", func(t *testing.T) {
+		opts := mutationOptions{JSON: true, OperationID: "fallback-codex-reasoning", hasOperationID: true}
+		spec := journaledMutationSpec{
+			Operation: "set_model_reasoning", Surface: mutationSurfaceCodex, Client: "openai-fallback",
+			Key: "example/model", RequestedTarget: "default",
+		}
+		publishExactUnchangedTerminalForTest(t, path, spec.Client, opts, spec)
+		stdout, rc := captureStdout(t, func() int {
+			return cmdCodex([]string{
+				"reasoning", "baseten", "example/model", "default",
+				"--json", "--operation-id", opts.OperationID,
+			})
+		})
+		if rc != 0 {
+			t.Fatalf("rc=%d out=%s", rc, stdout)
+		}
+		result := decodeMutationResult(t, stdout)
+		if result.Client != spec.Client || result.Outcome != mutationOutcomeUnchanged {
+			t.Fatalf("result=%+v", result)
+		}
+	})
+}
+
+func TestCustomFallbackTerminalReplayIsConfigIndependentAndSurfaceBound(t *testing.T) {
+	installRoutingMutationSeams(t)
+	reasoningArgs := func(operationID string) []string {
+		return []string{
+			"reasoning", "baseten", "example/model", "default",
+			"--json", "--operation-id", operationID,
+		}
+	}
+	setup := func(t *testing.T, operationID, surface, client string) string {
+		t.Helper()
+		path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+		opts := mutationOptions{JSON: true, OperationID: operationID, hasOperationID: true}
+		spec := journaledMutationSpec{
+			Operation: "set_model_reasoning", Surface: surface, Client: client,
+			Key: "example/model", RequestedTarget: "default",
+		}
+		publishExactUnchangedTerminalForTest(t, path, client, opts, spec)
+		return path
+	}
+
+	t.Run("claude missing config", func(t *testing.T) {
+		const operationID = "fallback-claude-missing"
+		path := setup(t, operationID, mutationSurfaceClaude, "anthropic-fallback")
+		if err := os.Remove(path); err != nil {
+			t.Fatal(err)
+		}
+		stdout, rc := captureStdout(t, func() int { return cmdClaude(reasoningArgs(operationID)) })
+		result := decodeMutationResult(t, stdout)
+		if rc != 0 || !result.OK || result.Client != "anthropic-fallback" || result.Outcome != mutationOutcomeUnchanged {
+			t.Fatalf("rc=%d result=%+v", rc, result)
+		}
+	})
+
+	t.Run("codex malformed config", func(t *testing.T) {
+		const operationID = "fallback-codex-malformed"
+		path := setup(t, operationID, mutationSurfaceCodex, "openai-fallback")
+		if err := os.WriteFile(path, []byte("global: [\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		stdout, rc := captureStdout(t, func() int { return cmdCodex(reasoningArgs(operationID)) })
+		result := decodeMutationResult(t, stdout)
+		if rc != 0 || !result.OK || result.Client != "openai-fallback" || result.Outcome != mutationOutcomeUnchanged {
+			t.Fatalf("rc=%d result=%+v", rc, result)
+		}
+	})
+
+	t.Run("cross surface conflict without config", func(t *testing.T) {
+		const operationID = "fallback-cross-surface"
+		path := setup(t, operationID, mutationSurfaceClaude, "shared-fallback")
+		if err := os.Remove(path); err != nil {
+			t.Fatal(err)
+		}
+		stdout, rc := captureStdout(t, func() int { return cmdCodex(reasoningArgs(operationID)) })
+		result := decodeMutationResult(t, stdout)
+		if rc != 1 || result.Error == nil || result.Error.Code != "operation_id_conflict" {
+			t.Fatalf("rc=%d result=%+v", rc, result)
+		}
+	})
+}
+
+func TestMutationStatusAndCleanupRecoverDesiredActive(t *testing.T) {
+	installRoutingMutationSeams(t)
+	path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+	var mutationOut strings.Builder
+	if rc := runSwitch("off", []string{"--json", "--operation-id", "cleanup-applied"}, &mutationOut); rc != 0 {
+		t.Fatalf("offline mutation rc = %d: %s", rc, mutationOut.String())
+	}
+	desiredHash := exactFileHash(t, path)
+	if err := pidfile.WriteAt(pidfile.Path(), os.Getpid()); err != nil {
+		t.Fatal(err)
+	}
+	fetchRoutingAdminStatus = func(string) (routingAdminStatus, error) {
+		return liveRoutingStatus(path, desiredHash, false, 8), nil
+	}
+	status, err := inspectRoutingMutationStatus(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Classification != mutationStatusDesiredActive || status.BlockingOperationID != "cleanup-applied" {
+		t.Fatalf("status = %+v", status)
+	}
+	stdout, rc := captureStdout(t, func() int { return cmdMutation([]string{"recover", "--json"}) })
+	if rc != 0 {
+		t.Fatalf("recover rc = %d: %s", rc, stdout)
+	}
+	var recovered mutationRecoveryResult
+	if err := json.Unmarshal([]byte(stdout), &recovered); err != nil {
+		t.Fatal(err)
+	}
+	if !recovered.OK || recovered.Outcome != mutationOutcomeApplied || !recovered.Applied {
+		t.Fatalf("recover = %+v", recovered)
+	}
+	if _, err := os.Stat(mutationJournalPath(path, "cleanup-applied")); !os.IsNotExist(err) {
+		t.Fatalf("active journal remains: %v", err)
+	}
+	status, err = inspectRoutingMutationStatus(path)
+	if err != nil || status.Classification != mutationStatusNone {
+		t.Fatalf("post-cleanup status = %+v err=%v", status, err)
+	}
+}
+
+func TestCleanupPriorActiveRecordsNotAppliedNotRollback(t *testing.T) {
+	installRoutingMutationSeams(t)
+	path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+	journal := legacyJournalForTest(t, path, "pre-cas-crash")
+	if err := writeMutationJournal(journal); err != nil {
+		t.Fatal(err)
+	}
+	if err := pidfile.WriteAt(pidfile.Path(), os.Getpid()); err != nil {
+		t.Fatal(err)
+	}
+	fetchRoutingAdminStatus = func(string) (routingAdminStatus, error) {
+		return liveRoutingStatus(path, journal.PreviousConfigHash, true, 4), nil
+	}
+	status, err := inspectRoutingMutationStatus(path)
+	if err != nil || status.Classification != mutationStatusPriorActive {
+		t.Fatalf("status = %+v err=%v", status, err)
+	}
+	stdout, rc := captureStdout(t, func() int { return cmdMutation([]string{"recover", "--json"}) })
+	if rc != 0 {
+		t.Fatalf("recover rc = %d: %s", rc, stdout)
+	}
+	record, err := readMutationTerminal(path, journal.OperationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.Outcome != mutationOutcomeNotApplied || record.ErrorCode == "activation_failed_rolled_back" || record.IdentityStrength != mutationIdentityLegacy {
+		t.Fatalf("terminal = %+v", record)
+	}
+}
+
+func TestCleanupPendingUsesTerminalWithoutRouter(t *testing.T) {
+	installRoutingMutationSeams(t)
+	path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+	journal := legacyJournalForTest(t, path, "terminal-residue")
+	if err := writeMutationJournal(journal); err != nil {
+		t.Fatal(err)
+	}
+	active := liveRoutingStatus(path, journal.PreviousConfigHash, true, 5)
+	record := terminalFromJournal(journal, mutationOutcomeNotApplied, active, "", false)
+	if _, err := publishMutationTerminal(path, record, nil); err != nil {
+		t.Fatal(err)
+	}
+	status, err := inspectRoutingMutationStatus(path)
+	if err != nil || status.Classification != mutationStatusCleanupPending {
+		t.Fatalf("status = %+v err=%v", status, err)
+	}
+	stdout, rc := captureStdout(t, func() int { return cmdMutation([]string{"recover", "--json"}) })
+	if rc != 0 {
+		t.Fatalf("recover rc = %d: %s", rc, stdout)
+	}
+	if _, err := os.Stat(mutationJournalPath(path, journal.OperationID)); !os.IsNotExist(err) {
+		t.Fatalf("cleanup residue remains: %v", err)
+	}
+}
+
+func TestMutationStatusClassifiesPriorAndDesiredPending(t *testing.T) {
+	installRoutingMutationSeams(t)
+	path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+	journal := legacyJournalForTest(t, path, "pending-matrix")
+	if err := writeMutationJournal(journal); err != nil {
+		t.Fatal(err)
+	}
+	if err := pidfile.WriteAt(pidfile.Path(), os.Getpid()); err != nil {
+		t.Fatal(err)
+	}
+	fetchRoutingAdminStatus = func(string) (routingAdminStatus, error) {
+		return liveRoutingStatus(path, journal.DesiredConfigHash, false, 5), nil
+	}
+	status, err := inspectRoutingMutationStatus(path)
+	if err != nil || status.Classification != mutationStatusPriorPending {
+		t.Fatalf("prior pending = %+v err=%v", status, err)
+	}
+	prior, mode, err := readExactConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	desired, err := previewExactConfigEdit(path, prior, mode, func(editPath string) error {
+		return config.SetGlobalRoutingEnabled(editPath, false)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, desired, mode); err != nil {
+		t.Fatal(err)
+	}
+	fetchRoutingAdminStatus = func(string) (routingAdminStatus, error) {
+		return liveRoutingStatus(path, journal.PreviousConfigHash, true, 6), nil
+	}
+	status, err = inspectRoutingMutationStatus(path)
+	if err != nil || status.Classification != mutationStatusDesiredPending {
+		t.Fatalf("desired pending = %+v err=%v", status, err)
+	}
+}
+
+func TestMutationStatusAuthorityPrecedesExternalChange(t *testing.T) {
+	t.Run("router unavailable", func(t *testing.T) {
+		installRoutingMutationSeams(t)
+		path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+		journal := legacyJournalForTest(t, path, "external-without-router")
+		if err := writeMutationJournal(journal); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, append(journal.PreviousConfig, []byte("# external\n")...), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		status, err := inspectRoutingMutationStatus(path)
+		if err != nil || status.Classification != mutationStatusRouterUnavailable {
+			t.Fatalf("status=%+v err=%v", status, err)
+		}
+	})
+
+	t.Run("router unsupported", func(t *testing.T) {
+		installRoutingMutationSeams(t)
+		path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+		journal := legacyJournalForTest(t, path, "external-unsupported-router")
+		if err := writeMutationJournal(journal); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, append(journal.PreviousConfig, []byte("# external\n")...), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := pidfile.WriteAt(pidfile.Path(), os.Getpid()); err != nil {
+			t.Fatal(err)
+		}
+		fetchRoutingAdminStatus = func(string) (routingAdminStatus, error) {
+			status := liveRoutingStatus(path, journal.PreviousConfigHash, true, 4)
+			status.RouterBootID = ""
+			return status, nil
+		}
+		status, err := inspectRoutingMutationStatus(path)
+		if err != nil || status.Classification != mutationStatusRouterUnsupported {
+			t.Fatalf("status=%+v err=%v", status, err)
+		}
+	})
+}
+
+func TestMutationStatusClassifiesMultipleActiveJournalsAsConflict(t *testing.T) {
+	installRoutingMutationSeams(t)
+	path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+	first := legacyJournalForTest(t, path, "active-one")
+	if err := writeMutationJournal(first); err != nil {
+		t.Fatal(err)
+	}
+	second := first
+	second.OperationID = "active-two"
+	data, err := json.MarshalIndent(second, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mutationJournalPath(path, second.OperationID), append(data, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	status, err := inspectRoutingMutationStatus(path)
+	if err != nil || status.Classification != mutationStatusJournalConflict || status.Error == nil || status.Error.Code != mutationStatusJournalConflict {
+		t.Fatalf("status=%+v err=%v", status, err)
+	}
+}
+
+func TestMutationTerminalGCRetainsYoungAndFutureRecords(t *testing.T) {
+	installRoutingMutationSeams(t)
+	path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+	now := time.Now().UTC()
+	for _, item := range []struct {
+		id   string
+		when time.Time
+	}{
+		{id: "old-terminal", when: now.Add(-31 * 24 * time.Hour)},
+		{id: "young-terminal", when: now.Add(-29 * 24 * time.Hour)},
+		{id: "future-terminal", when: now.Add(time.Hour)},
+	} {
+		journal := legacyJournalForTest(t, path, item.id)
+		record := terminalFromJournal(journal, mutationOutcomeUnchanged, routingAdminStatus{}, "", false)
+		record.DesiredConfigHash = record.PreviousConfigHash
+		record.PreviousActiveToken = ""
+		future := item.when.After(now)
+		if future {
+			record.CompletedAt = now
+		} else {
+			record.CompletedAt = item.when
+		}
+		if _, err := publishMutationTerminal(path, record, nil); err != nil {
+			t.Fatal(err)
+		}
+		if future {
+			record.CompletedAt = item.when
+			data, err := json.Marshal(record)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(mutationTerminalPath(path, item.id), append(data, '\n'), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := gcMutationTerminals(path, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(mutationTerminalPath(path, "old-terminal")); !os.IsNotExist(err) {
+		t.Fatalf("old terminal was not collected: %v", err)
+	}
+	for _, id := range []string{"young-terminal", "future-terminal"} {
+		if _, err := os.Stat(mutationTerminalPath(path, id)); err != nil {
+			t.Fatalf("%s was removed: %v", id, err)
+		}
+	}
+	status, err := inspectRoutingMutationStatus(path)
+	if err != nil || status.Classification != mutationStatusJournalInvalid {
+		t.Fatalf("future terminal status = %+v err=%v", status, err)
+	}
+}
+
+func TestMutationTerminalPublicationCrashSeams(t *testing.T) {
+	installRoutingMutationSeams(t)
+	t.Run("before link preserves active", func(t *testing.T) {
+		installTerminalPublicationSeams(t)
+		path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+		journal := legacyJournalForTest(t, path, "before-link")
+		if err := writeMutationJournal(journal); err != nil {
+			t.Fatal(err)
+		}
+		record := terminalFromJournal(journal, mutationOutcomeNotApplied,
+			liveRoutingStatus(path, journal.PreviousConfigHash, true, 5), "", false)
+		mutationTerminalLink = func(string, string) error { return errors.New("injected pre-publication stop") }
+		if _, err := publishMutationTerminal(path, record, &journal); err == nil {
+			t.Fatal("publication unexpectedly succeeded")
+		}
+		if _, err := os.Stat(mutationJournalPath(path, journal.OperationID)); err != nil {
+			t.Fatalf("active journal was not preserved: %v", err)
+		}
+		if _, err := os.Stat(mutationTerminalPath(path, journal.OperationID)); !os.IsNotExist(err) {
+			t.Fatalf("terminal unexpectedly exists: %v", err)
+		}
+	})
+
+	t.Run("after link before directory sync preserves active", func(t *testing.T) {
+		installTerminalPublicationSeams(t)
+		path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+		journal := legacyJournalForTest(t, path, "before-completed-sync")
+		if err := writeMutationJournal(journal); err != nil {
+			t.Fatal(err)
+		}
+		record := terminalFromJournal(journal, mutationOutcomeNotApplied,
+			liveRoutingStatus(path, journal.PreviousConfigHash, true, 5), "", false)
+		realSync := mutationTerminalSync
+		mutationTerminalSync = func(dir string) error {
+			if dir == mutationCompletedDir(path) {
+				return errors.New("injected completed sync stop")
+			}
+			return realSync(dir)
+		}
+		if _, err := publishMutationTerminal(path, record, &journal); err == nil {
+			t.Fatal("publication unexpectedly succeeded")
+		}
+		if _, err := os.Stat(mutationJournalPath(path, journal.OperationID)); err != nil {
+			t.Fatalf("active journal was not preserved: %v", err)
+		}
+		if _, err := os.Stat(mutationTerminalPath(path, journal.OperationID)); err != nil {
+			t.Fatalf("published link should remain for idempotent retry: %v", err)
+		}
+		mutationTerminalSync = realSync
+		lock, err := acquireConfigMutationLock(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, recovered, err := recoverRoutingMutationLocked(path)
+		lock.close()
+		if err != nil || recovered.Record.OperationID != journal.OperationID {
+			t.Fatalf("idempotent recovery record=%+v err=%v", recovered, err)
+		}
+	})
+
+	t.Run("after terminal durability reports cleanup pending", func(t *testing.T) {
+		installTerminalPublicationSeams(t)
+		path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+		journal := legacyJournalForTest(t, path, "active-unlink-stop")
+		if err := writeMutationJournal(journal); err != nil {
+			t.Fatal(err)
+		}
+		record := terminalFromJournal(journal, mutationOutcomeNotApplied,
+			liveRoutingStatus(path, journal.PreviousConfigHash, true, 5), "", false)
+		realRemove := mutationTerminalRemove
+		mutationTerminalRemove = func(target string) error {
+			if target == mutationJournalPath(path, journal.OperationID) {
+				return errors.New("injected active unlink stop")
+			}
+			return realRemove(target)
+		}
+		published, err := publishMutationTerminal(path, record, &journal)
+		if err != nil || !published.CleanupPending {
+			t.Fatalf("publication=%+v err=%v", published, err)
+		}
+		if _, err := os.Stat(mutationTerminalPath(path, journal.OperationID)); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(mutationJournalPath(path, journal.OperationID)); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestMutationTerminalSameIDIdempotenceAndConflict(t *testing.T) {
+	installRoutingMutationSeams(t)
+	path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+	journal := legacyJournalForTest(t, path, "same-terminal-id")
+	record := terminalFromJournal(journal, mutationOutcomeNotApplied,
+		liveRoutingStatus(path, journal.PreviousConfigHash, true, 5), "", false)
+	first, err := publishMutationTerminal(path, record, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	retry := record
+	retry.CompletedAt = time.Now().UTC()
+	second, err := publishMutationTerminal(path, retry, nil)
+	if err != nil || !second.Record.CompletedAt.Equal(first.Record.CompletedAt) {
+		t.Fatalf("idempotent retry=%+v err=%v", second, err)
+	}
+	conflict := record
+	conflict.Outcome = mutationOutcomeApplied
+	conflict.ActiveConfigHash = conflict.DesiredConfigHash
+	if _, err := publishMutationTerminal(path, conflict, nil); err == nil || !strings.Contains(err.Error(), "terminal_conflict") {
+		t.Fatalf("divergent same-ID publication error = %v", err)
+	}
+}
+
+func TestMutationTerminalConcurrentSameIDPublication(t *testing.T) {
+	installRoutingMutationSeams(t)
+	path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+	journal := legacyJournalForTest(t, path, "concurrent-terminal-id")
+	record := terminalFromJournal(journal, mutationOutcomeNotApplied,
+		liveRoutingStatus(path, journal.PreviousConfigHash, true, 5), "", false)
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var ready sync.WaitGroup
+	ready.Add(2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			ready.Done()
+			<-start
+			_, err := publishMutationTerminal(path, record, nil)
+			errs <- err
+		}()
+	}
+	ready.Wait()
+	close(start)
+	for i := 0; i < 2; i++ {
+		if err := <-errs; err != nil {
+			t.Fatalf("concurrent idempotent publication failed: %v", err)
+		}
+	}
+	stored, err := readMutationTerminal(path, journal.OperationID)
+	if err != nil || !terminalRecordsEqual(stored, record) {
+		t.Fatalf("stored=%+v err=%v", stored, err)
+	}
+}
+
+func TestMutationRecoverySizeAndScanLimits(t *testing.T) {
+	installRoutingMutationSeams(t)
+	t.Run("oversize active journal", func(t *testing.T) {
+		path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+		if err := os.Mkdir(mutationJournalDir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		activePath := mutationJournalPath(path, "oversize-active")
+		file, err := os.OpenFile(activePath, os.O_CREATE|os.O_WRONLY, 0o600)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := file.Truncate(mutationJournalReadLimit + 1); err != nil {
+			t.Fatal(err)
+		}
+		file.Close()
+		status, err := inspectRoutingMutationStatus(path)
+		if err != nil || status.Classification != mutationStatusJournalInvalid {
+			t.Fatalf("status=%+v err=%v", status, err)
+		}
+	})
+
+	t.Run("oversize terminal", func(t *testing.T) {
+		path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+		if err := os.MkdirAll(mutationCompletedDir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(mutationJournalDir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		terminalPath := mutationTerminalPath(path, "oversize-terminal")
+		file, err := os.OpenFile(terminalPath, os.O_CREATE|os.O_WRONLY, 0o600)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := file.Truncate(mutationTerminalReadLimit + 1); err != nil {
+			t.Fatal(err)
+		}
+		file.Close()
+		status, err := inspectRoutingMutationStatus(path)
+		if err != nil || status.Classification != mutationStatusJournalInvalid {
+			t.Fatalf("status=%+v err=%v", status, err)
+		}
+	})
+
+	t.Run("completed scan bound", func(t *testing.T) {
+		path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+		if err := os.MkdirAll(mutationCompletedDir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(mutationJournalDir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i <= mutationCompletedScanMax; i++ {
+			name := filepath.Join(mutationCompletedDir(path), newOperationID()+".json")
+			if err := os.WriteFile(name, nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		status, err := inspectRoutingMutationStatus(path)
+		if err != nil || status.Classification != mutationStatusJournalInvalid {
+			t.Fatalf("status=%+v err=%v", status, err)
+		}
+	})
+}
+
+func TestLegacyActiveV1AndCompletedDirectoryCompatibility(t *testing.T) {
+	installRoutingMutationSeams(t)
+	path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+	journal := legacyJournalForTest(t, path, "legacy-v1")
+	if journal.Version != 1 {
+		t.Fatalf("legacy journal version=%d, want 1", journal.Version)
+	}
+	if err := writeMutationJournal(journal); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(mutationJournalPath(path, journal.OperationID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "request_fingerprint") || strings.Contains(string(data), "if_config_hash") ||
+		strings.Contains(string(data), `"surface"`) {
+		t.Fatalf("legacy fixture unexpectedly contains new fields: %s", data)
+	}
+	readBack, err := readMutationJournal(path, journal.OperationID)
+	if err != nil || readBack.RequestFingerprint != "" {
+		t.Fatalf("legacy read=%+v err=%v", readBack, err)
+	}
+	if err := os.Mkdir(mutationCompletedDir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if operationID, err := unfinishedMutationOperation(path); err != nil || operationID != journal.OperationID {
+		t.Fatalf("old scanner operation=%q err=%v", operationID, err)
+	}
+}
+
+func TestMutationHelpDocumentsStatusRecoverAndReconcile(t *testing.T) {
+	var out strings.Builder
+	if !printCommandHelp(&out, "mutation") {
+		t.Fatal("mutation help unavailable")
+	}
+	for _, command := range []string{"mutation status", "mutation recover", "mutation reconcile"} {
+		if !strings.Contains(out.String(), command) {
+			t.Fatalf("mutation help missing %q:\n%s", command, out.String())
+		}
+	}
+	if filepath.Base(mutationCompletedDir("/tmp/example.yaml")) != "completed" {
+		t.Fatal("completed directory path changed unexpectedly")
+	}
+}
+
+func TestRecoveryRevalidatesAuthoritativeCleanupSnapshot(t *testing.T) {
+	installRoutingMutationSeams(t)
+	path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+	journal := legacyJournalForTest(t, path, "cleanup-snapshot-change")
+	if err := writeMutationJournal(journal); err != nil {
+		t.Fatal(err)
+	}
+	if err := pidfile.WriteAt(pidfile.Path(), os.Getpid()); err != nil {
+		t.Fatal(err)
+	}
+	var calls int
+	fetchRoutingAdminStatus = func(string) (routingAdminStatus, error) {
+		calls++
+		status := liveRoutingStatus(path, journal.PreviousConfigHash, true, 4)
+		if calls > 1 {
+			status.ActiveConfigHash = domainHash("changed-active", "config")
+		}
+		return status, nil
+	}
+	lock, err := acquireConfigMutationLock(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, recoverErr := recoverRoutingMutationLocked(path)
+	lock.close()
+	if recoverErr == nil || !strings.Contains(recoverErr.Error(), "cleanup predicate changed") {
+		t.Fatalf("recovery error = %v", recoverErr)
+	}
+	if _, err := os.Stat(mutationJournalPath(path, journal.OperationID)); err != nil {
+		t.Fatalf("active journal was removed: %v", err)
+	}
+	if _, err := os.Stat(mutationTerminalPath(path, journal.OperationID)); !os.IsNotExist(err) {
+		t.Fatalf("terminal unexpectedly published: %v", err)
+	}
+}
+
+func TestRecoveryPublishesFromFinalValidatedSnapshot(t *testing.T) {
+	installRoutingMutationSeams(t)
+	path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+	journal := legacyJournalForTest(t, path, "cleanup-final-snapshot")
+	if err := writeMutationJournal(journal); err != nil {
+		t.Fatal(err)
+	}
+	if err := pidfile.WriteAt(pidfile.Path(), os.Getpid()); err != nil {
+		t.Fatal(err)
+	}
+	var calls int
+	fetchRoutingAdminStatus = func(string) (routingAdminStatus, error) {
+		calls++
+		generation := uint64(4 + calls - 1)
+		if calls > 2 {
+			generation = 99
+		}
+		return liveRoutingStatus(path, journal.PreviousConfigHash, true, generation), nil
+	}
+	lock, err := acquireConfigMutationLock(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, published, recoverErr := recoverRoutingMutationLocked(path)
+	lock.close()
+	if recoverErr != nil {
+		t.Fatal(recoverErr)
+	}
+	if calls != 2 || !strings.HasSuffix(published.Record.ActiveToken, ":5") {
+		t.Fatalf("admin calls=%d terminal=%+v", calls, published.Record)
+	}
+}
+
+func TestDirectMutationReadersRejectSymlinkedStateDirectories(t *testing.T) {
+	installRoutingMutationSeams(t)
+	t.Run("journal", func(t *testing.T) {
+		path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+		journal := legacyJournalForTest(t, path, "symlink-journal-dir")
+		if err := writeMutationJournal(journal); err != nil {
+			t.Fatal(err)
+		}
+		dir := mutationJournalDir(path)
+		realDir := dir + ".real"
+		if err := os.Rename(dir, realDir); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(realDir, dir); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := readMutationJournal(path, journal.OperationID); err == nil {
+			t.Fatal("journal reader accepted a symlinked parent directory")
+		}
+	})
+	t.Run("terminal", func(t *testing.T) {
+		path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+		journal := legacyJournalForTest(t, path, "symlink-terminal-dir")
+		record := terminalFromJournal(journal, mutationOutcomeUnchanged, routingAdminStatus{}, "", false)
+		record.DesiredConfigHash = record.PreviousConfigHash
+		record.PreviousActiveToken = ""
+		if _, err := publishMutationTerminal(path, record, nil); err != nil {
+			t.Fatal(err)
+		}
+		dir := mutationCompletedDir(path)
+		realDir := dir + ".real"
+		if err := os.Rename(dir, realDir); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(realDir, dir); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := readMutationTerminal(path, journal.OperationID); err == nil {
+			t.Fatal("terminal reader accepted a symlinked parent directory")
+		}
+	})
+}
+
+func TestExactJournalFingerprintIsRecomputed(t *testing.T) {
+	installRoutingMutationSeams(t)
+	path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+	prior, mode, err := readExactConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts := mutationOptions{OperationID: "fingerprint-tamper", hasOperationID: true, IfConfigHash: exactConfigHash(prior), hasConfigHash: true}
+	spec := journaledMutationSpec{Operation: "set_claude_route", Surface: mutationSurfaceClaude, Client: "claude-code", Key: "opus", RequestedTarget: "native"}
+	fingerprint, err := mutationRequestFingerprint(path, opts, spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	journal := routingMutationJournal{
+		Version: mutationJournalVersion, OperationID: opts.OperationID, Operation: spec.Operation,
+		Surface: spec.Surface, ConfigPath: path, Client: spec.Client, Key: spec.Key, RequestedTarget: spec.RequestedTarget,
+		PreviousConfig: prior, PreviousMode: uint32(mode), PreviousConfigHash: exactConfigHash(prior),
+		DesiredConfigHash: exactConfigHash(prior), IfConfigHash: opts.IfConfigHash,
+		RequestFingerprint: fingerprint, CreatedAt: time.Now().UTC(),
+	}
+	if err := writeMutationJournal(journal); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(mutationJournalPath(path, opts.OperationID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = bytes.Replace(data, []byte(`"client": "claude-code"`), []byte(`"client": "codex"`), 1)
+	if err := os.WriteFile(mutationJournalPath(path, opts.OperationID), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readMutationJournal(path, opts.OperationID); err == nil || !strings.Contains(err.Error(), "fingerprint") {
+		t.Fatalf("tampered exact journal error = %v", err)
+	}
+}
+
+func TestReplayDoesNotAdoptTerminalClient(t *testing.T) {
+	installRoutingMutationSeams(t)
+	path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+	opts := mutationOptions{JSON: true, OperationID: "cross-client", hasOperationID: true}
+	codex := journaledMutationSpec{Operation: "set_model_reasoning", Surface: mutationSurfaceCodex, Client: "codex", Key: "example/model", RequestedTarget: "default"}
+	publishExactUnchangedTerminalForTest(t, path, codex.Client, opts, codex)
+	claude := codex
+	claude.Client = "claude-code"
+	result, found, rc, err := replayTerminalForRequest(path, opts, claude)
+	if !found || rc != 1 || err == nil || err.Error() != "operation_id_conflict" || result.Client != "codex" {
+		t.Fatalf("cross-client replay result=%+v found=%v rc=%d err=%v", result, found, rc, err)
+	}
+}
+
+func TestMutationStatusFindsCommitArtifactWithoutActiveJournal(t *testing.T) {
+	installRoutingMutationSeams(t)
+	path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+	dir := filepath.Join(filepath.Dir(path), exactCommitDirPrefix(path)+"orphan")
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	status, err := inspectRoutingMutationStatus(path)
+	if err != nil || status.Classification != mutationStatusCommitRecoveryRequired || status.BlockingOperationID != "" {
+		t.Fatalf("status=%+v err=%v", status, err)
+	}
+}
+
+func TestTerminalReaderRejectsTrailingAndInconsistentJSON(t *testing.T) {
+	installRoutingMutationSeams(t)
+	for _, testCase := range []struct {
+		name   string
+		mutate func(*mutationTerminalRecord)
+		extra  []byte
+	}{
+		{name: "trailing", extra: []byte("{}\n")},
+		{name: "future completion", mutate: func(record *mutationTerminalRecord) { record.CompletedAt = time.Now().UTC().Add(time.Hour) }},
+		{name: "requested presence", mutate: func(record *mutationTerminalRecord) { record.RequestedPresent = true }},
+		{name: "requested value", mutate: func(record *mutationTerminalRecord) { record.Requested = true }},
+		{name: "command surface", mutate: func(record *mutationTerminalRecord) { record.Surface = mutationSurfaceClaude }},
+		{name: "unchanged hashes", mutate: func(record *mutationTerminalRecord) { record.DesiredConfigHash = domainHash("other", "value") }},
+		{name: "malformed previous token", mutate: func(record *mutationTerminalRecord) { record.PreviousActiveToken = "not-a-token" }},
+		{name: "token without hash", mutate: func(record *mutationTerminalRecord) {
+			record.PreviousActiveToken = "boot:1"
+			record.ActiveToken = "boot:1"
+		}},
+		{name: "unchanged token mismatch", mutate: func(record *mutationTerminalRecord) {
+			record.ActiveConfigHash = record.DesiredConfigHash
+			record.PreviousActiveToken = "boot:1"
+			record.ActiveToken = "boot:2"
+		}},
+		{name: "rejected error code", mutate: func(record *mutationTerminalRecord) {
+			record.Outcome = mutationOutcomeRejected
+			record.DesiredConfigHash = domainHash("desired", "different")
+			record.ErrorCode = "terminal_write_failed"
+			record.ErrorRetryable = true
+		}},
+		{name: "rejected retryability", mutate: func(record *mutationTerminalRecord) {
+			record.Outcome = mutationOutcomeRejected
+			record.DesiredConfigHash = domainHash("desired", "different")
+			record.ErrorCode = "stale_config_hash"
+			record.ErrorRetryable = false
+		}},
+		{name: "rejected unchanged hash", mutate: func(record *mutationTerminalRecord) {
+			record.Outcome = mutationOutcomeRejected
+			record.ErrorCode = "stale_config_hash"
+			record.ErrorRetryable = true
+		}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+			opts := mutationOptions{OperationID: "terminal-shape", hasOperationID: true}
+			spec := journaledMutationSpec{Operation: "set_codex_route", Surface: mutationSurfaceCodex, Client: "codex", Key: "default_model", RequestedTarget: "example/model"}
+			publishExactUnchangedTerminalForTest(t, path, spec.Client, opts, spec)
+			record, err := readMutationTerminal(path, opts.OperationID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if testCase.mutate != nil {
+				testCase.mutate(&record)
+			}
+			data, err := json.Marshal(record)
+			if err != nil {
+				t.Fatal(err)
+			}
+			data = append(append(data, '\n'), testCase.extra...)
+			if err := os.WriteFile(mutationTerminalPath(path, opts.OperationID), data, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := readMutationTerminal(path, opts.OperationID); err == nil {
+				t.Fatal("terminal reader accepted inconsistent content")
+			}
+		})
+	}
+}
+
+func TestMutationWritersEnforceReaderBoundsBeforeCommit(t *testing.T) {
+	installRoutingMutationSeams(t)
+	t.Run("journal", func(t *testing.T) {
+		path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+		journal := legacyJournalForTest(t, path, "oversize-writer")
+		journal.PreviousConfig = bytes.Repeat([]byte("x"), mutationJournalReadLimit)
+		journal.PreviousConfigHash = exactConfigHash(journal.PreviousConfig)
+		if err := writeMutationJournal(journal); err == nil || !strings.Contains(err.Error(), "size limit") {
+			t.Fatalf("oversize journal error = %v", err)
+		}
+		if _, err := os.Stat(mutationJournalPath(path, journal.OperationID)); !os.IsNotExist(err) {
+			t.Fatalf("oversize journal was written: %v", err)
+		}
+	})
+	t.Run("desired config", func(t *testing.T) {
+		path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+		prior, mode, err := readExactConfig(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var out strings.Builder
+		opts := mutationOptions{JSON: true, OperationID: "oversize-desired", hasOperationID: true}
+		rc := runJournaledMutationLocked(path, prior, mode, opts, &out, journaledMutationSpec{
+			Operation: "set_global_routing", Surface: mutationSurfaceSwitch, Apply: func(editPath string) error {
+				return os.WriteFile(editPath, bytes.Repeat([]byte("x"), mutationConfigReadLimit+1), mode)
+			},
+		})
+		result := decodeMutationResult(t, out.String())
+		if rc != 1 || result.Error == nil || result.Error.Code != "config_size_limit" || exactFileHash(t, path) != exactConfigHash(prior) {
+			t.Fatalf("oversize desired rc=%d result=%+v", rc, result)
+		}
+	})
+}
+
+func writeOldTerminalForReplayTest(t *testing.T, path, operationID string) {
+	t.Helper()
+	if err := secureDirectory(mutationJournalDir(path), true); err != nil {
+		t.Fatal(err)
+	}
+	if err := secureDirectory(mutationCompletedDir(path), true); err != nil {
+		t.Fatal(err)
+	}
+	journal := legacyJournalForTest(t, path, operationID)
+	record := terminalFromJournal(journal, mutationOutcomeUnchanged, routingAdminStatus{}, "", false)
+	record.DesiredConfigHash = record.PreviousConfigHash
+	record.PreviousActiveToken = ""
+	record.CompletedAt = time.Now().UTC().Add(-mutationTerminalRetain - time.Hour)
+	data, err := json.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mutationTerminalPath(path, operationID), append(data, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func ageTerminalForReplayTest(t *testing.T, path, operationID string) {
+	t.Helper()
+	record, err := readMutationTerminal(path, operationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record.CompletedAt = time.Now().UTC().Add(-mutationTerminalRetain - time.Hour)
+	data, err := json.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mutationTerminalPath(path, operationID), append(data, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAgedCleanupPendingTerminalSurvivesReplayGC(t *testing.T) {
+	installRoutingMutationSeams(t)
+	setup := func(t *testing.T, operationID string) (string, mutationOptions, journaledMutationSpec) {
+		t.Helper()
+		path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+		opts := mutationOptions{JSON: true, OperationID: operationID, hasOperationID: true}
+		spec := journaledMutationSpec{Operation: "set_global_routing", Surface: mutationSurfaceSwitch, Requested: true}
+		journal := publishExactUnchangedTerminalForTest(t, path, "", opts, spec)
+		if err := writeMutationJournal(journal); err != nil {
+			t.Fatal(err)
+		}
+		ageTerminalForReplayTest(t, path, operationID)
+		return path, opts, spec
+	}
+	assertResidue := func(t *testing.T, path, operationID string) {
+		t.Helper()
+		if _, err := os.Stat(mutationTerminalPath(path, operationID)); err != nil {
+			t.Fatalf("aged cleanup-pending terminal was removed: %v", err)
+		}
+		if _, err := os.Stat(mutationJournalPath(path, operationID)); err != nil {
+			t.Fatalf("active cleanup journal was removed: %v", err)
+		}
+	}
+
+	t.Run("original command", func(t *testing.T) {
+		path, opts, spec := setup(t, "aged-cleanup-original")
+		var out strings.Builder
+		replayed, rc := preflightTerminalReplay(path, opts, spec, &out)
+		result := decodeMutationResult(t, out.String())
+		if !replayed || rc != 0 || !result.OK || !result.CleanupPending {
+			t.Fatalf("replayed=%v rc=%d result=%+v", replayed, rc, result)
+		}
+		assertResidue(t, path, opts.OperationID)
+	})
+
+	t.Run("reconcile", func(t *testing.T) {
+		path, opts, _ := setup(t, "aged-cleanup-reconcile")
+		stdout, rc := captureStdout(t, func() int {
+			return cmdMutation([]string{"reconcile", opts.OperationID, "--json"})
+		})
+		result := decodeMutationResult(t, stdout)
+		if rc != 0 || !result.OK || !result.CleanupPending {
+			t.Fatalf("rc=%d result=%+v", rc, result)
+		}
+		assertResidue(t, path, opts.OperationID)
+	})
+}
+
+func TestTerminalGCFailsClosedOnInvalidOrAmbiguousActiveState(t *testing.T) {
+	installRoutingMutationSeams(t)
+	assertProtected := func(t *testing.T, path, operationID string) {
+		t.Helper()
+		if err := gcMutationTerminals(path, time.Now().UTC()); err == nil {
+			t.Fatal("GC accepted unsafe active mutation state")
+		}
+		if _, err := os.Stat(mutationTerminalPath(path, operationID)); err != nil {
+			t.Fatalf("GC deleted a terminal after unsafe active state: %v", err)
+		}
+	}
+
+	t.Run("invalid", func(t *testing.T) {
+		path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+		const terminalID = "gc-protected-by-invalid-state"
+		writeOldTerminalForReplayTest(t, path, terminalID)
+		if err := os.WriteFile(mutationJournalPath(path, "invalid-active"), []byte("{\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		assertProtected(t, path, terminalID)
+	})
+
+	t.Run("multiple", func(t *testing.T) {
+		path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+		const terminalID = "gc-protected-by-ambiguous-state"
+		writeOldTerminalForReplayTest(t, path, terminalID)
+		for _, operationID := range []string{"active-one", "active-two"} {
+			journal := legacyJournalForTest(t, path, operationID)
+			data, err := json.Marshal(journal)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(mutationJournalPath(path, operationID), append(data, '\n'), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		assertProtected(t, path, terminalID)
+	})
+}
+
+func TestTerminalReplayRunsBestEffortGC(t *testing.T) {
+	installRoutingMutationSeams(t)
+	t.Run("original command", func(t *testing.T) {
+		path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+		opts := mutationOptions{JSON: true, OperationID: "gc-original", hasOperationID: true}
+		spec := journaledMutationSpec{Operation: "set_global_routing", Surface: mutationSurfaceSwitch, Requested: true}
+		publishExactUnchangedTerminalForTest(t, path, "", opts, spec)
+		writeOldTerminalForReplayTest(t, path, "gc-old-original")
+		var out strings.Builder
+		replayed, rc := preflightTerminalReplay(path, opts, spec, &out)
+		if !replayed || rc != 0 {
+			t.Fatalf("replay=%v rc=%d out=%s", replayed, rc, out.String())
+		}
+		if _, err := os.Stat(mutationTerminalPath(path, "gc-old-original")); !os.IsNotExist(err) {
+			t.Fatalf("old terminal was not collected: %v", err)
+		}
+	})
+	t.Run("reconcile", func(t *testing.T) {
+		path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+		opts := mutationOptions{JSON: true, OperationID: "gc-reconcile", hasOperationID: true}
+		spec := journaledMutationSpec{Operation: "set_global_routing", Surface: mutationSurfaceSwitch, Requested: true}
+		publishExactUnchangedTerminalForTest(t, path, "", opts, spec)
+		writeOldTerminalForReplayTest(t, path, "gc-old-reconcile")
+		stdout, rc := captureStdout(t, func() int {
+			return cmdMutation([]string{"reconcile", opts.OperationID, "--json"})
+		})
+		if rc != 0 {
+			t.Fatalf("reconcile rc=%d out=%s", rc, stdout)
+		}
+		if _, err := os.Stat(mutationTerminalPath(path, "gc-old-reconcile")); !os.IsNotExist(err) {
+			t.Fatalf("old terminal was not collected: %v", err)
+		}
+	})
+}
+
+func TestJSONMutationErrorsUseReviewedMessages(t *testing.T) {
+	installRoutingMutationSeams(t)
+	path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+	hidden := path + ".private-detail"
+	var out strings.Builder
+	opts := mutationOptions{JSON: true, OperationID: "reviewed-error", hasOperationID: true}
+	result := mutationResult{Operation: "reconcile_routing_mutation", ConfigPath: path}
+	if rc := failMutation(opts, &out, result, "config_read_failed", "read "+hidden+": permission denied", true, 1); rc != 1 {
+		t.Fatalf("rc = %d", rc)
+	}
+	decoded := decodeMutationResult(t, out.String())
+	if decoded.Error == nil || decoded.Error.Message != reviewedMutationMessage("config_read_failed") ||
+		strings.Contains(decoded.Error.Message, hidden) || strings.Contains(decoded.Error.Message, "permission denied") {
+		t.Fatalf("reviewed error = %+v", decoded.Error)
+	}
+}
+
+func TestHumanMutationFailuresUseReviewedMessages(t *testing.T) {
+	installRoutingMutationSeams(t)
+	path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+	hidden := path + ".private-detail"
+	opts := mutationOptions{OperationID: "reviewed-human-error", hasOperationID: true}
+	result := mutationResult{Operation: "set_global_routing", ConfigPath: path}
+	stderr := captureStderr(t, func() {
+		if rc := failMutation(opts, io.Discard, result, "config_read_failed", "read "+hidden+": backend target example/private", true, 1); rc != 1 {
+			t.Fatalf("rc = %d", rc)
+		}
+	})
+	if stderr != reviewedMutationMessage("config_read_failed")+"\n" || strings.Contains(stderr, hidden) || strings.Contains(stderr, "example/private") {
+		t.Fatalf("human error = %q", stderr)
+	}
+}

--- a/gateway/cmd/baseten-switch/routing_mutation_test.go
+++ b/gateway/cmd/baseten-switch/routing_mutation_test.go
@@ -226,7 +226,7 @@ func TestRoutingMutationCASAndStatusPreconditionsFailClosed(t *testing.T) {
 				return []string{"--json", "--operation-id", "missing-path", "--if-config-hash", hash}
 			},
 			wantCode:   "router_state_mismatch",
-			wantPhrase: "active config path",
+			wantPhrase: "managed routing config",
 		},
 		{
 			name: "wrong active config path",
@@ -237,7 +237,7 @@ func TestRoutingMutationCASAndStatusPreconditionsFailClosed(t *testing.T) {
 				return []string{"--json", "--operation-id", "wrong-path", "--if-config-hash", hash}
 			},
 			wantCode:   "router_state_mismatch",
-			wantPhrase: "running router uses config",
+			wantPhrase: "managed routing config",
 		},
 	}
 	for _, testCase := range cases {
@@ -406,7 +406,7 @@ func TestRoutingMutationUnfinishedJournalBlocksNextMutation(t *testing.T) {
 	}
 	result := decodeMutationResult(t, second.String())
 	if result.Error == nil || result.Error.Code != "unfinished_mutation" ||
-		!strings.Contains(result.Error.Message, "first-offline") {
+		result.BlockingOperationID != "first-offline" || result.ReconciliationRequired {
 		t.Fatalf("result = %+v", result)
 	}
 	if routingEnabledFromFile(t, path) {
@@ -689,8 +689,22 @@ func TestRoutingMutationClaudeRouteOfflineReconcilePreservesReceipt(t *testing.T
 		result.Operation != "set_claude_route" ||
 		result.Client != "claude-code" ||
 		result.Key != "sonnet" ||
-		result.RequestedTarget != "native" {
+		result.RequestedTarget != "native" ||
+		result.IdentityStrength != mutationIdentityExact ||
+		result.RequestFingerprint == "" {
 		t.Fatalf("reconciled result = %+v", result)
+	}
+	replayStdout, replayRC := captureStdout(t, func() int {
+		return cmdMutation([]string{"reconcile", "route-offline", "--json"})
+	})
+	if replayRC != 0 {
+		t.Fatalf("terminal reconcile rc = %d: %s", replayRC, replayStdout)
+	}
+	replay := decodeMutationResult(t, replayStdout)
+	if !replay.OK || replay.Operation != result.Operation || replay.Client != result.Client ||
+		replay.Key != "" || replay.RequestedTarget != "" ||
+		replay.RequestFingerprint != result.RequestFingerprint || replay.IdentityStrength != mutationIdentityExact {
+		t.Fatalf("terminal reconcile replay = %+v", replay)
 	}
 }
 
@@ -711,6 +725,7 @@ func TestJournaledMutationCASPreservesConcurrentExternalEdit(t *testing.T) {
 	opts := mutationOptions{JSON: true, OperationID: "external-race", hasOperationID: true}
 	rc := runJournaledMutationLocked(path, prior, mode, opts, &out, journaledMutationSpec{
 		Operation:       "set_claude_route",
+		Surface:         mutationSurfaceClaude,
 		RequestedTarget: "native",
 		Client:          "claude-code",
 		Key:             "opus",
@@ -737,6 +752,52 @@ func TestJournaledMutationCASPreservesConcurrentExternalEdit(t *testing.T) {
 	}
 	if _, err := os.Stat(mutationJournalPath(path, "external-race")); !os.IsNotExist(err) {
 		t.Fatalf("CAS refusal left a journal: %v", err)
+	}
+}
+
+func TestRejectedMutationReceiptPreservesCleanupPending(t *testing.T) {
+	installRoutingMutationSeams(t)
+	installTerminalPublicationSeams(t)
+	path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+	prior, mode, err := readExactConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	external := append(append([]byte(nil), prior...), []byte("# external edit\n")...)
+	realRemove := mutationTerminalRemove
+	mutationTerminalRemove = func(target string) error {
+		if target == mutationJournalPath(path, "rejected-cleanup") {
+			return errors.New("injected active journal cleanup failure")
+		}
+		return realRemove(target)
+	}
+	lock, err := acquireConfigMutationLock(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lock.close()
+	var out strings.Builder
+	opts := mutationOptions{JSON: true, OperationID: "rejected-cleanup", hasOperationID: true}
+	rc := runJournaledMutationLocked(path, prior, mode, opts, &out, journaledMutationSpec{
+		Operation: "set_claude_route", Surface: mutationSurfaceClaude, Client: "claude-code", Key: "opus", RequestedTarget: "native",
+		Apply: func(previewPath string) error {
+			if err := config.SetClientMapEntries(previewPath, "claude-code", "model_routes", map[string]string{"opus": "native"}); err != nil {
+				return err
+			}
+			return os.WriteFile(path, external, mode)
+		},
+	})
+	result := decodeMutationResult(t, out.String())
+	if rc != 1 || result.Error == nil || result.Error.Code != "stale_config_hash" ||
+		result.Outcome != mutationOutcomeRejected || !result.CleanupPending {
+		t.Fatalf("rejected result rc=%d result=%+v", rc, result)
+	}
+	if _, err := os.Stat(mutationJournalPath(path, opts.OperationID)); err != nil {
+		t.Fatalf("cleanup-pending journal missing: %v", err)
+	}
+	record, err := readMutationTerminal(path, opts.OperationID)
+	if err != nil || record.Outcome != mutationOutcomeRejected {
+		t.Fatalf("rejected terminal=%+v err=%v", record, err)
 	}
 }
 

--- a/gateway/cmd/baseten-switch/switchverbs.go
+++ b/gateway/cmd/baseten-switch/switchverbs.go
@@ -48,6 +48,13 @@ func runSwitch(verb string, args []string, out io.Writer) int {
 			fmt.Fprintln(os.Stderr, notice)
 		}
 	}
+	if replayed, rc := preflightTerminalReplay(path, opts, journaledMutationSpec{
+		Operation: "set_global_routing",
+		Surface:   mutationSurfaceSwitch,
+		Requested: requested,
+	}, out); replayed {
+		return rc
+	}
 	if _, err := config.Load(path); err != nil {
 		message := config.MalformedConfigMessage(path, err)
 		if errors.Is(err, os.ErrNotExist) {

--- a/gateway/cmd/baseten-switch/switchverbs_test.go
+++ b/gateway/cmd/baseten-switch/switchverbs_test.go
@@ -113,7 +113,7 @@ func TestRunSwitchRequiresGlobalRoutingEnabled(t *testing.T) {
 			t.Fatalf("code = %d, output:\n%s", code, out.String())
 		}
 	})
-	if !strings.Contains(stderr, "global.routing_enabled") {
+	if !strings.Contains(stderr, "routing config could not be safely prepared") {
 		t.Fatalf("stdout:\n%s\nstderr:\n%s", out.String(), stderr)
 	}
 }

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/BasetenSwitchState.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/BasetenSwitchState.swift
@@ -7,6 +7,22 @@ enum MutationPhase: String, Equatable, Sendable {
     case reconciling
 }
 
+enum MutationRecoveryState: Equatable, Sendable {
+    case disabled
+    case awaitingSnapshot
+    case checking
+    case waitingToRetry(seconds: TimeInterval)
+    case ready
+    case legacyFallback
+    case blocked(errorCode: String)
+}
+
+private struct MutationRecoveryKey: Equatable, Sendable {
+    let configIdentity: String
+    let routerBootID: String
+    let runtimeIdentity: String?
+}
+
 struct PendingGlobalRouting: Equatable, Sendable {
     let operationID: String
     let requested: Bool
@@ -38,6 +54,14 @@ private struct PolicyMutationAttempt {
     let result: CLIExecutionResult
     let receipt: GlobalMutationReceipt?
     let primaryTimedOut: Bool
+    let verifiedTerminalReplay: Bool
+}
+
+private struct PolicyMutationRequestIdentity {
+    let operation: String
+    let client: String
+    let key: String
+    let requestedTarget: String
 }
 
 @MainActor
@@ -78,6 +102,7 @@ final class BasetenSwitchState: ObservableObject {
     @Published private(set) var pendingSubagents: [String: PendingControlMutation] = [:]
     @Published private(set) var pendingReasoning: PendingReasoningMutation?
     @Published private(set) var reasoningWarnings: [String: String] = [:]
+    @Published private(set) var mutationRecoveryState: MutationRecoveryState
 
     private let reader: any AdminStatusReading
     private let modelCatalogReader: any ModelCatalogReading
@@ -88,11 +113,15 @@ final class BasetenSwitchState: ObservableObject {
     private let previewRuntimeValidator: (RuntimeProfile) -> String?
     private let pollCoordinator: PollCoordinator?
     private let mutationCoordinator: MutationCoordinator?
+    private let automaticMutationRecoveryEnabled: Bool
     private var reconcileTimers: [String: Task<Void, Never>] = [:]
     private var interactiveRefreshTask: Task<Void, Never>?
     private var interactiveStatsRequested = false
     private var modelCatalogTask: Task<Void, Never>?
     private var modelCatalogGeneration: UInt64 = 0
+    private var mutationRecoveryTask: Task<Void, Never>?
+    private var mutationRecoveryKey: MutationRecoveryKey?
+    private var unsupportedRecoveryRuntime: String?
     private(set) var menuVisible = false
     let variant: AppVariant
 
@@ -129,7 +158,8 @@ final class BasetenSwitchState: ObservableObject {
          previewRuntimeValidator: @escaping (RuntimeProfile) -> String? = {
              previewRuntimeFilesystemError(runtime: $0)
          },
-         startPolling: Bool = true) {
+         startPolling: Bool = true,
+         automaticMutationRecoveryEnabled: Bool? = nil) {
         self.variant = variant
         let apiClient = GatewayAPIClient(runtime: variant.runtime)
         self.reader = reader ?? apiClient
@@ -139,6 +169,11 @@ final class BasetenSwitchState: ObservableObject {
         self.clock = clock
         self.loginItemService = loginItemService ?? SystemLoginItemService()
         self.previewRuntimeValidator = previewRuntimeValidator
+        self.automaticMutationRecoveryEnabled =
+            automaticMutationRecoveryEnabled ?? startPolling
+        mutationRecoveryState = self.automaticMutationRecoveryEnabled
+            ? .awaitingSnapshot
+            : .disabled
         if let identityError = variant.identityError {
             runtimeTrust = .identityMismatch(reason: identityError)
             lastError = identityError
@@ -188,6 +223,8 @@ final class BasetenSwitchState: ObservableObject {
         previewRuntimeValidator = {
             previewRuntimeFilesystemError(runtime: $0)
         }
+        automaticMutationRecoveryEnabled = false
+        mutationRecoveryState = .disabled
         pollCoordinator = nil
         mutationCoordinator = nil
         if let identityError = variant.identityError {
@@ -224,6 +261,8 @@ final class BasetenSwitchState: ObservableObject {
         interactiveRefreshTask = nil
         interactiveStatsRequested = false
         invalidateModelCatalog()
+        mutationRecoveryTask?.cancel()
+        mutationRecoveryTask = nil
         Task { await pollCoordinator?.stop() }
     }
 
@@ -253,6 +292,7 @@ final class BasetenSwitchState: ObservableObject {
                     loginItemStatus = updatedStatus
                 }
             }
+            beginAutomaticMutationRecoveryIfNeeded(snapshot)
         case .unavailable:
             if !snapshotIsStale {
                 snapshotIsStale = true
@@ -265,6 +305,219 @@ final class BasetenSwitchState: ObservableObject {
         case .ignoredStaleToken:
             break
         }
+    }
+
+    private var mutationRecoveryAllowsRouting: Bool {
+        switch mutationRecoveryState {
+        case .disabled, .ready, .legacyFallback:
+            return true
+        case .awaitingSnapshot, .checking, .waitingToRetry, .blocked:
+            return false
+        }
+    }
+
+    private var mutationRecoveryDisabledReason: String? {
+        switch mutationRecoveryState {
+        case .awaitingSnapshot, .checking:
+            return "Checking for an unfinished routing change."
+        case .waitingToRetry:
+            return "Waiting to retry routing cleanup."
+        case .blocked:
+            return "Routing cleanup must finish before settings can be changed."
+        case .disabled, .ready, .legacyFallback:
+            return nil
+        }
+    }
+
+    var mutationRecoveryMessage: String? {
+        switch mutationRecoveryState {
+        case .checking:
+            return "Checking for an unfinished routing change."
+        case .waitingToRetry(let seconds):
+            return "Routing cleanup will retry in \(Int(seconds)) seconds."
+        case .blocked(let errorCode):
+            return reviewedMutationErrorMessage(
+                errorCode: errorCode,
+                fallback: "Routing cleanup could not be completed safely.")
+        case .disabled, .awaitingSnapshot, .ready, .legacyFallback:
+            return nil
+        }
+    }
+
+    var canRetryMutationCleanup: Bool {
+        if case .blocked = mutationRecoveryState {
+            return mutationRecoveryKey != nil
+        }
+        return false
+    }
+
+    func retryMutationCleanup() {
+        guard canRetryMutationCleanup,
+              let key = mutationRecoveryKey else { return }
+        mutationRecoveryTask?.cancel()
+        mutationRecoveryState = .checking
+        mutationRecoveryTask = Task { [weak self] in
+            await self?.runCleanupRecovery(for: key)
+        }
+    }
+
+    func waitForMutationRecovery() async {
+        await mutationRecoveryTask?.value
+    }
+
+    private func beginAutomaticMutationRecoveryIfNeeded(
+        _ snapshot: RoutingSnapshot
+    ) {
+        guard automaticMutationRecoveryEnabled,
+              snapshot.token.isAuthoritative,
+              !snapshot.configPath.isEmpty else { return }
+        let runtime = recoveryRuntimeIdentifier
+        let key = MutationRecoveryKey(
+            configIdentity: URL(fileURLWithPath: snapshot.configPath)
+                .standardizedFileURL.path,
+            routerBootID: snapshot.token.routerBootID,
+            runtimeIdentity: runtime)
+        guard key != mutationRecoveryKey else { return }
+
+        mutationRecoveryTask?.cancel()
+        mutationRecoveryKey = key
+        if let runtime,
+           unsupportedRecoveryRuntime == runtime {
+            mutationRecoveryState = .legacyFallback
+            return
+        }
+
+        mutationRecoveryState = .checking
+        mutationRecoveryTask = Task { [weak self] in
+            await self?.probeAndRecoverMutation(for: key, runtime: runtime)
+        }
+    }
+
+    private var recoveryRuntimeIdentifier: String? {
+        guard let binary = Self.locateBasetenSwitchBinary(variant: variant)?
+            .standardizedFileURL else { return nil }
+        let attributes = try? FileManager.default.attributesOfItem(
+            atPath: binary.path)
+        let modified = (attributes?[.modificationDate] as? Date)?
+            .timeIntervalSince1970 ?? 0
+        let size = attributes?[.size] as? NSNumber
+        let inode = attributes?[.systemFileNumber] as? NSNumber
+        return "\(binary.path):\(inode?.uint64Value ?? 0):\(modified):\(size?.int64Value ?? 0)"
+    }
+
+    private func probeAndRecoverMutation(
+        for key: MutationRecoveryKey,
+        runtime: String?
+    ) async {
+        let status = await executeCLI(
+            ["--json", "mutation", "status"],
+            timeout: 10)
+        guard recoveryKeyIsCurrent(key), !Task.isCancelled else { return }
+        let receipt = MutationRecoveryReceipt(json: status.standardOutput)
+        if mutationStatusIsUnsupported(status, receipt: receipt) {
+            unsupportedRecoveryRuntime = runtime
+            await finishMutationRecovery(for: key, state: .legacyFallback)
+            return
+        }
+        if !status.succeeded,
+           !status.timedOut,
+           receipt?.errorRetryable != true,
+           !isTransientRecoveryError(receipt?.errorCode ?? "") {
+            await finishMutationRecovery(
+                for: key,
+                state: .blocked(
+                    errorCode: receipt?.errorCode ?? "status_unavailable"))
+            return
+        }
+        await runCleanupRecovery(for: key)
+    }
+
+    private func runCleanupRecovery(for key: MutationRecoveryKey) async {
+        let retryDelays: [TimeInterval] = [1, 2, 4, 8, 16]
+        var finalErrorCode = "cleanup_failed"
+        for attempt in 0...retryDelays.count {
+            guard recoveryKeyIsCurrent(key), !Task.isCancelled else { return }
+            if attempt > 0 {
+                let delay = retryDelays[attempt - 1]
+                mutationRecoveryState = .waitingToRetry(seconds: delay)
+                do {
+                    try await clock.sleep(seconds: delay)
+                } catch {
+                    return
+                }
+                guard recoveryKeyIsCurrent(key), !Task.isCancelled else { return }
+                mutationRecoveryState = .checking
+            }
+
+            let result = await executeCLI(
+                ["--json", "mutation", "recover"],
+                timeout: 10)
+            guard recoveryKeyIsCurrent(key), !Task.isCancelled else { return }
+            let receipt = MutationRecoveryReceipt(json: result.standardOutput)
+            if result.succeeded, receipt?.ok == true {
+                if receipt?.cleanupPending == true {
+                    finalErrorCode = "cleanup_pending"
+                    guard attempt < retryDelays.count else {
+                        await finishMutationRecovery(
+                            for: key,
+                            state: .blocked(errorCode: finalErrorCode))
+                        return
+                    }
+                    continue
+                } else {
+                    await finishMutationRecovery(for: key, state: .ready)
+                    return
+                }
+            }
+
+            if result.timedOut && (receipt?.errorCode.isEmpty != false) {
+                finalErrorCode = "cleanup_timed_out"
+            } else {
+                finalErrorCode = receipt?.errorCode ?? "cleanup_failed"
+            }
+            let shouldRetry = (result.timedOut
+                && (receipt?.errorCode.isEmpty != false))
+                || receipt?.errorRetryable == true
+                || isTransientRecoveryError(finalErrorCode)
+            guard shouldRetry,
+                  attempt < retryDelays.count else {
+                await finishMutationRecovery(
+                    for: key,
+                    state: .blocked(errorCode: finalErrorCode))
+                return
+            }
+        }
+    }
+
+    private func finishMutationRecovery(
+        for key: MutationRecoveryKey,
+        state: MutationRecoveryState
+    ) async {
+        await refresh()
+        guard recoveryKeyIsCurrent(key), !Task.isCancelled else { return }
+        mutationRecoveryState = state
+    }
+
+    private func recoveryKeyIsCurrent(_ key: MutationRecoveryKey) -> Bool {
+        key == mutationRecoveryKey
+    }
+
+    private func mutationStatusIsUnsupported(
+        _ result: CLIExecutionResult,
+        receipt: MutationRecoveryReceipt?
+    ) -> Bool {
+        let unsupportedCodes = [
+            "usage", "unknown_command", "unknown_subcommand",
+            "unsupported_command",
+        ]
+        return unsupportedCodes.contains(receipt?.errorCode ?? "")
+            || (result.status == 2 && !result.timedOut)
+    }
+
+    private func isTransientRecoveryError(_ errorCode: String) -> Bool {
+        errorCode == "mutation_locked"
+            || errorCode == "router_unavailable"
+            || errorCode == "cleanup_pending"
     }
 
     func menuDidShow() {
@@ -418,6 +671,7 @@ final class BasetenSwitchState: ObservableObject {
     var canMutateRouting: Bool {
         guard gatewayUp,
               canMutate,
+              mutationRecoveryAllowsRouting,
               let snapshot = routingSnapshot else { return false }
         return snapshot.supportsGlobalRouting
             && snapshot.token.isAuthoritative
@@ -431,6 +685,9 @@ final class BasetenSwitchState: ObservableObject {
         }
         guard gatewayUp else { return "The local gateway is unavailable." }
         guard canMutate else { return runtimeTrustError }
+        if let recoveryReason = mutationRecoveryDisabledReason {
+            return recoveryReason
+        }
         guard let snapshot = routingSnapshot,
               snapshot.supportsGlobalRouting else {
             return "Update the local gateway to configure global routing."
@@ -497,10 +754,10 @@ final class BasetenSwitchState: ObservableObject {
             lastError = nil
         } else if attempt.primaryTimedOut {
             lastError = "The routing change timed out and could not be confirmed."
-        } else if let message = receipt?.errorMessage, !message.isEmpty {
-            lastError = menuErrorLabel(redactDiagnosticText(message), limit: 180)
         } else {
-            lastError = "The routing change failed and the last confirmed setting was restored."
+            lastError = mutationFailureMessage(
+                receipt,
+                fallback: "The routing change failed and the last confirmed setting was restored.")
         }
         clearPending(key: "global", operationID: pending.operationID)
         pendingGlobalRouting = nil
@@ -516,6 +773,22 @@ final class BasetenSwitchState: ObservableObject {
             && current.activeConfigHash == expected
             && current.desiredConfigHash == expected
             && receipt.activeToken == current.token.cliValue
+    }
+
+    private func receiptRequestIdentityConfirms(
+        _ receipt: GlobalMutationReceipt?,
+        key: String,
+        requestedTarget: String,
+        verifiedTerminalReplay: Bool
+    ) -> Bool {
+        guard let receipt else { return false }
+        if receipt.key == key
+            && receipt.requestedTarget == requestedTarget {
+            return true
+        }
+        return verifiedTerminalReplay
+            && receipt.identityStrength == "exact"
+            && !receipt.requestFingerprint.isEmpty
     }
 
     // MARK: - Client model routing
@@ -573,7 +846,12 @@ final class BasetenSwitchState: ObservableObject {
             command: codexRouteDispatchArgs(model: model))
         let attempt = await executePolicyMutation(
             arguments,
-            operationID: pending.operationID)
+            operationID: pending.operationID,
+            requestIdentity: PolicyMutationRequestIdentity(
+                operation: "set_codex_route",
+                client: client.name,
+                key: "default_model",
+                requestedTarget: model.slug))
         await refresh()
         let receipt = attempt.receipt
         let confirmed = !snapshotIsStale
@@ -582,8 +860,11 @@ final class BasetenSwitchState: ObservableObject {
             && receipt?.operationID == pending.operationID
             && receipt?.operation == "set_codex_route"
             && receipt?.client == client.name
-            && receipt?.key == "default_model"
-            && receipt?.requestedTarget == model.slug
+            && receiptRequestIdentityConfirms(
+                receipt,
+                key: "default_model",
+                requestedTarget: model.slug,
+                verifiedTerminalReplay: attempt.verifiedTerminalReplay)
             && receipt?.applied == true
             && hashesConfirm(receipt)
             && codexRouteMutationConfirmed(
@@ -665,7 +946,12 @@ final class BasetenSwitchState: ObservableObject {
                 choice: choice))
         let attempt = await executePolicyMutation(
             arguments,
-            operationID: pending.operationID)
+            operationID: pending.operationID,
+            requestIdentity: PolicyMutationRequestIdentity(
+                operation: "set_claude_route",
+                client: client.name,
+                key: family,
+                requestedTarget: requestedTarget))
         await refresh()
         let receipt = attempt.receipt
         let confirmed = !snapshotIsStale
@@ -674,8 +960,11 @@ final class BasetenSwitchState: ObservableObject {
             && receipt?.operationID == pending.operationID
             && receipt?.operation == "set_claude_route"
             && receipt?.client == client.name
-            && receipt?.key == family
-            && receipt?.requestedTarget == requestedTarget
+            && receiptRequestIdentityConfirms(
+                receipt,
+                key: family,
+                requestedTarget: requestedTarget,
+                verifiedTerminalReplay: attempt.verifiedTerminalReplay)
             && receipt?.applied == true
             && hashesConfirm(receipt)
             && familyMutationConfirmed(
@@ -741,7 +1030,12 @@ final class BasetenSwitchState: ObservableObject {
             command: subagentDispatchArgs(client: client.name, choice: choice))
         let attempt = await executePolicyMutation(
             arguments,
-            operationID: pending.operationID)
+            operationID: pending.operationID,
+            requestIdentity: PolicyMutationRequestIdentity(
+                operation: "set_claude_subagents",
+                client: client.name,
+                key: "subagents",
+                requestedTarget: requestedTarget))
         await refresh()
         let receipt = attempt.receipt
         let confirmed = !snapshotIsStale
@@ -750,8 +1044,11 @@ final class BasetenSwitchState: ObservableObject {
             && receipt?.operationID == pending.operationID
             && receipt?.operation == "set_claude_subagents"
             && receipt?.client == client.name
-            && receipt?.key == "subagents"
-            && receipt?.requestedTarget == requestedTarget
+            && receiptRequestIdentityConfirms(
+                receipt,
+                key: "subagents",
+                requestedTarget: requestedTarget,
+                verifiedTerminalReplay: attempt.verifiedTerminalReplay)
             && receipt?.applied == true
             && hashesConfirm(receipt)
             && subagentMutationConfirmed(
@@ -786,6 +1083,7 @@ final class BasetenSwitchState: ObservableObject {
     var canMutateReasoning: Bool {
         guard gatewayUp,
               canMutate,
+              mutationRecoveryAllowsRouting,
               let snapshot = routingSnapshot else { return false }
         return snapshot.token.isAuthoritative
             && snapshot.token.activeGeneration > 0
@@ -932,6 +1230,9 @@ final class BasetenSwitchState: ObservableObject {
         let requestedTarget = reasoningRequestedTarget(policy)
         let command = reasoningDispatchArgs(
             client: client,
+            protocolShape: snapshot.clients
+                .first(where: { $0.name == client })?
+                .protocolShape,
             provider: provider,
             model: model,
             policy: policy)
@@ -941,7 +1242,12 @@ final class BasetenSwitchState: ObservableObject {
             command: command)
         let attempt = await executePolicyMutation(
             arguments,
-            operationID: operationID)
+            operationID: operationID,
+            requestIdentity: PolicyMutationRequestIdentity(
+                operation: "set_model_reasoning",
+                client: client,
+                key: model,
+                requestedTarget: requestedTarget))
         await refresh()
         let receipt = attempt.receipt
         let confirmed = !snapshotIsStale
@@ -950,8 +1256,11 @@ final class BasetenSwitchState: ObservableObject {
             && receipt?.operationID == operationID
             && receipt?.operation == "set_model_reasoning"
             && receipt?.client == client
-            && receipt?.key == model
-            && receipt?.requestedTarget == requestedTarget
+            && receiptRequestIdentityConfirms(
+                receipt,
+                key: model,
+                requestedTarget: requestedTarget,
+                verifiedTerminalReplay: attempt.verifiedTerminalReplay)
             && receipt?.applied == true
             && hashesConfirm(receipt)
             && reasoningMutationConfirmed(
@@ -1059,29 +1368,66 @@ final class BasetenSwitchState: ObservableObject {
         ] + command
     }
 
-    /// Every policy mutation receives one reconciliation attempt before its
-    /// pending UI is cleared. Reconciliation is mandatory for a timeout,
-    /// malformed receipt, failed command, or an otherwise-successful receipt
-    /// whose journal cleanup remains indeterminate.
+    private func receiptMatchesDispatchedRequest(
+        _ receipt: GlobalMutationReceipt?,
+        identity: PolicyMutationRequestIdentity?
+    ) -> Bool {
+        guard let receipt, let identity else { return false }
+        return receipt.operation == identity.operation
+            && receipt.client == identity.client
+            && receipt.key == identity.key
+            && receipt.requestedTarget == identity.requestedTarget
+    }
+
+    /// Policy mutations reconcile only when their result is missing or
+    /// explicitly indeterminate. A valid deterministic failure is primary
+    /// evidence and must not be replaced by a failed secondary lookup.
     private func executePolicyMutation(
         _ arguments: [String],
-        operationID: String
+        operationID: String,
+        requestIdentity: PolicyMutationRequestIdentity? = nil
     ) async -> PolicyMutationAttempt {
         let primary = await executeCLI(arguments, timeout: 30)
         let primaryReceipt = GlobalMutationReceipt(
             json: primary.standardOutput)
+        let primaryReceiptMatches = primaryReceipt?.operationID == operationID
+        let primaryRequiresRecovery = receiptRequiresMutationRecovery(
+            primaryReceipt)
+        if primaryRequiresRecovery {
+            mutationRecoveryState = .checking
+        }
+        let primaryTypedError = primaryReceiptMatches
+            && primaryReceipt?.errorCode.isEmpty == false
+        if primaryReceiptMatches,
+           primaryReceipt?.errorCode == "unfinished_mutation",
+           primaryReceipt?.blockingOperationID.isEmpty == false {
+            retainMutationRecoveryGateIfNeeded(primaryReceipt)
+            return PolicyMutationAttempt(
+                result: primary,
+                receipt: primaryReceipt,
+                primaryTimedOut: false,
+                verifiedTerminalReplay: false)
+        }
+        if primaryReceiptMatches,
+           primaryReceipt?.reconciliationRequired == false,
+           !primary.timedOut || primaryTypedError {
+            retainMutationRecoveryGateIfNeeded(primaryReceipt)
+            return PolicyMutationAttempt(
+                result: primary,
+                receipt: primaryReceipt,
+                primaryTimedOut: primary.timedOut && !primaryTypedError,
+                verifiedTerminalReplay: false)
+        }
+
         let needsReconciliation = primary.timedOut
-            || !primary.succeeded
-            || primaryReceipt == nil
-            || primaryReceipt?.ok != true
-            || primaryReceipt?.applied != true
-            || primaryReceipt?.operationID != operationID
+            || !primaryReceiptMatches
             || primaryReceipt?.reconciliationRequired == true
         guard needsReconciliation else {
             return PolicyMutationAttempt(
                 result: primary,
                 receipt: primaryReceipt,
-                primaryTimedOut: false)
+                primaryTimedOut: primary.timedOut && !primaryTypedError,
+                verifiedTerminalReplay: false)
         }
 
         markReconciling(operationID: operationID)
@@ -1090,20 +1436,73 @@ final class BasetenSwitchState: ObservableObject {
             timeout: 10)
         let reconciledReceipt = GlobalMutationReceipt(
             json: reconciled.standardOutput)
-        let shouldUseReconciliation = reconciledReceipt?.operationID == operationID
-            && (reconciledReceipt?.ok == true
-                || primaryReceipt == nil
-                || primaryReceipt?.reconciliationRequired == true)
+        let shouldUseReconciliation = reconciled.succeeded
+            && reconciledReceipt?.operationID == operationID
+            && reconciledReceipt?.ok == true
+            && reconciledReceipt?.reconciliationRequired == false
+            && reconciledReceipt?.cleanupPending == false
+        let verifiedTerminalReplay = shouldUseReconciliation
+            && receiptMatchesDispatchedRequest(
+                primaryReceipt,
+                identity: requestIdentity)
+            && primaryReceipt?.identityStrength == "exact"
+            && reconciledReceipt?.identityStrength == "exact"
+            && isValidMutationRequestFingerprint(
+                primaryReceipt?.requestFingerprint ?? "")
+            && primaryReceipt?.requestFingerprint
+                == reconciledReceipt?.requestFingerprint
         if shouldUseReconciliation {
+            if primaryRequiresRecovery {
+                mutationRecoveryState = .ready
+            }
             return PolicyMutationAttempt(
                 result: reconciled,
                 receipt: reconciledReceipt,
-                primaryTimedOut: primary.timedOut)
+                primaryTimedOut: false,
+                verifiedTerminalReplay: verifiedTerminalReplay)
         }
+        let unresolvedReceipt: GlobalMutationReceipt?
+        if receiptRequiresMutationRecovery(reconciledReceipt) {
+            unresolvedReceipt = reconciledReceipt
+        } else if primaryRequiresRecovery {
+            unresolvedReceipt = primaryReceipt
+        } else {
+            unresolvedReceipt = reconciledReceipt ?? primaryReceipt
+        }
+        retainMutationRecoveryGate(unresolvedReceipt)
         return PolicyMutationAttempt(
             result: primary,
             receipt: primaryReceipt,
-            primaryTimedOut: primary.timedOut)
+            primaryTimedOut: primary.timedOut && !primaryTypedError,
+            verifiedTerminalReplay: false)
+    }
+
+    private func receiptRequiresMutationRecovery(
+        _ receipt: GlobalMutationReceipt?
+    ) -> Bool {
+        receipt?.cleanupPending == true
+            || receipt?.reconciliationRequired == true
+    }
+
+    private func retainMutationRecoveryGateIfNeeded(
+        _ receipt: GlobalMutationReceipt?
+    ) {
+        guard receiptRequiresMutationRecovery(receipt) else { return }
+        retainMutationRecoveryGate(receipt)
+    }
+
+    private func retainMutationRecoveryGate(
+        _ receipt: GlobalMutationReceipt?
+    ) {
+        let errorCode: String
+        if receipt?.cleanupPending == true {
+            errorCode = "cleanup_pending"
+        } else if receipt?.errorCode.isEmpty == false {
+            errorCode = receipt?.errorCode ?? "reconciliation_required"
+        } else {
+            errorCode = "reconciliation_required"
+        }
+        mutationRecoveryState = .blocked(errorCode: errorCode)
     }
 
     private func markReconciling(operationID: String) {
@@ -1130,10 +1529,49 @@ final class BasetenSwitchState: ObservableObject {
         _ receipt: GlobalMutationReceipt?,
         fallback: String
     ) -> String {
-        guard let message = receipt?.errorMessage, !message.isEmpty else {
+        reviewedMutationErrorMessage(
+            errorCode: receipt?.errorCode ?? "",
+            fallback: fallback)
+    }
+
+    private func reviewedMutationErrorMessage(
+        errorCode: String,
+        fallback: String
+    ) -> String {
+        switch errorCode {
+        case "mutation_locked":
+            return "Another routing change is still in progress. Try again shortly."
+        case "unfinished_mutation":
+            return "A previous routing change still needs cleanup."
+        case "router_unavailable":
+            return "The local gateway is unavailable. Try again after it reconnects."
+        case "router_unsupported":
+            return "Update the local gateway before changing routing settings."
+        case "journal_not_found":
+            return "The routing change outcome is no longer available. Refresh and try again."
+        case "journal_invalid", "journal_conflict", "terminal_conflict":
+            return "Saved routing recovery data needs manual attention."
+        case "commit_recovery_required":
+            return "A configuration update needs manual recovery before routing can change."
+        case "external_change":
+            return "The configuration changed outside Baseten Switch. Refresh before trying again."
+        case "stale_active_token", "stale_config_hash", "precondition_failed":
+            return "Routing settings changed before this request completed. Refresh and try again."
+        case "operation_id_conflict":
+            return "This routing request conflicts with an earlier request. Try again."
+        case "activation_failed_rolled_back", "mutation_not_applied":
+            return "The routing change was not applied. The last confirmed setting remains active."
+        case "terminal_write_failed", "activation_indeterminate":
+            return "The routing change could not be confirmed safely. Retry cleanup."
+        case "status_unavailable":
+            return "Routing cleanup status could not be checked."
+        case "cleanup_failed":
+            return "Routing cleanup could not be completed safely."
+        case "cleanup_pending":
+            return "Routing cleanup is still pending."
+        default:
             return fallback
         }
-        return menuErrorLabel(redactDiagnosticText(message), limit: 180)
     }
 
     private func executeCLI(
@@ -1293,11 +1731,20 @@ final class BasetenSwitchState: ObservableObject {
 
 func reasoningDispatchArgs(
     client: String,
+    protocolShape: String? = nil,
     provider: String,
     model: String,
     policy: ReasoningPolicyValue
 ) -> [String] {
-    let harness = client == "claude-code" ? "claude" : client
+    let harness: String
+    switch protocolShape {
+    case "anthropic":
+        harness = "claude"
+    case "openai":
+        harness = "codex"
+    default:
+        harness = client == "claude-code" ? "claude" : client
+    }
     var arguments = [harness, "reasoning", provider, model]
     switch policy.mode {
     case .off:

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/RouterWindow.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/RouterWindow.swift
@@ -709,6 +709,11 @@ private struct RoutingOverviewView: View {
                         symbol: "exclamationmark.triangle.fill",
                         color: .red)
                 }
+                if let message = state.mutationRecoveryMessage {
+                    mutationRecoveryWarningBanner(
+                        message,
+                        state: state)
+                }
             }
             .padding(28)
             .frame(maxWidth: 680, alignment: .leading)
@@ -1051,6 +1056,11 @@ private struct ClientRoutingView: View {
                 menuErrorLabel(error, limit: 160),
                 symbol: "exclamationmark.triangle.fill",
                 color: .red)
+        }
+        if let message = state.mutationRecoveryMessage {
+            mutationRecoveryWarningBanner(
+                message,
+                state: state)
         }
         if authNeedsReauth(auth: state.auth),
            state.displayedGlobalRoutingEnabled {
@@ -2119,4 +2129,30 @@ func warningBanner(_ text: String,
             in: RoundedRectangle(cornerRadius: 8))
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isStaticText)
+}
+
+@MainActor
+func mutationRecoveryWarningBanner(
+    _ text: String,
+    state: BasetenSwitchState
+) -> some View {
+    HStack(spacing: 10) {
+        Label(text, systemImage: "exclamationmark.triangle.fill")
+            .font(.callout)
+            .foregroundStyle(.orange)
+        Spacer()
+        if state.canRetryMutationCleanup {
+            Button("Retry cleanup") {
+                state.retryMutationCleanup()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+    }
+    .padding(10)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(
+        Color.orange.opacity(0.09),
+        in: RoundedRectangle(cornerRadius: 8))
+    .accessibilityIdentifier("mutation-recovery-warning")
 }

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/RuntimeCoordination.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/RuntimeCoordination.swift
@@ -303,27 +303,57 @@ struct SystemCLIRunner: CLIRunning {
 }
 
 actor MutationCoordinator {
+    private struct Waiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Bool, Never>
+    }
+
     private let runner: any CLIRunning
     private var busy = false
-    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var waiters: [Waiter] = []
 
     init(runner: any CLIRunning) {
         self.runner = runner
     }
 
     func perform(_ request: CLIExecutionRequest) async -> CLIExecutionResult {
-        await acquire()
+        guard await acquire() else {
+            return canceledCLIExecutionResult
+        }
+        guard !Task.isCancelled else {
+            release()
+            return canceledCLIExecutionResult
+        }
         defer { release() }
         return await runner.run(request)
     }
 
-    private func acquire() async {
+    private func acquire() async -> Bool {
+        guard !Task.isCancelled else { return false }
         if !busy {
             busy = true
-            return
+            return true
         }
-        await withCheckedContinuation { continuation in
-            waiters.append(continuation)
+        let id = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if Task.isCancelled {
+                    continuation.resume(returning: false)
+                } else {
+                    waiters.append(Waiter(
+                        id: id,
+                        continuation: continuation))
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelWaiter(id) }
+        }
+    }
+
+    private func cancelWaiter(_ id: UUID) {
+        if let index = waiters.firstIndex(where: { $0.id == id }) {
+            let waiter = waiters.remove(at: index)
+            waiter.continuation.resume(returning: false)
         }
     }
 
@@ -331,8 +361,16 @@ actor MutationCoordinator {
         if waiters.isEmpty {
             busy = false
         } else {
-            waiters.removeFirst().resume()
+            waiters.removeFirst().continuation.resume(returning: true)
         }
+    }
+
+    private var canceledCLIExecutionResult: CLIExecutionResult {
+        CLIExecutionResult(
+            status: -1,
+            standardOutput: "",
+            standardError: "",
+            timedOut: false)
     }
 }
 
@@ -349,8 +387,14 @@ struct GlobalMutationReceipt: Equatable, Sendable {
     var activeConfigHash: String
     var applied: Bool
     var reconciliationRequired: Bool
+    var blockingOperationID: String
+    var outcome: String
+    var cleanupPending: Bool
+    var requestFingerprint: String
+    var identityStrength: String
     var errorCode: String
     var errorMessage: String
+    var errorRetryable: Bool
 
     init?(json: String) {
         guard let data = json.data(using: .utf8),
@@ -371,10 +415,51 @@ struct GlobalMutationReceipt: Equatable, Sendable {
         applied = dict["applied"] as? Bool ?? false
         reconciliationRequired =
             dict["reconciliation_required"] as? Bool ?? false
+        blockingOperationID = dict["blocking_operation_id"] as? String ?? ""
+        outcome = dict["outcome"] as? String ?? ""
+        cleanupPending = dict["cleanup_pending"] as? Bool ?? false
+        requestFingerprint = dict["request_fingerprint"] as? String ?? ""
+        identityStrength = dict["identity_strength"] as? String ?? ""
         let error = dict["error"] as? [String: Any]
         errorCode = error?["code"] as? String ?? ""
         errorMessage = error?["message"] as? String ?? ""
+        errorRetryable = error?["retryable"] as? Bool ?? false
     }
+}
+
+struct MutationRecoveryReceipt: Equatable, Sendable {
+    var ok: Bool
+    var classification: String
+    var operationID: String
+    var cleanupPending: Bool
+    var errorCode: String
+    var errorRetryable: Bool
+
+    init?(json: String) {
+        guard let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              let dict = object as? [String: Any] else {
+            return nil
+        }
+        ok = dict["ok"] as? Bool ?? false
+        classification = dict["classification"] as? String
+            ?? dict["status"] as? String
+            ?? ""
+        operationID = dict["operation_id"] as? String ?? ""
+        cleanupPending = dict["cleanup_pending"] as? Bool ?? false
+        let error = dict["error"] as? [String: Any]
+        errorCode = error?["code"] as? String ?? ""
+        errorRetryable = error?["retryable"] as? Bool ?? false
+    }
+}
+
+func isValidMutationRequestFingerprint(_ value: String) -> Bool {
+    guard value.hasPrefix("sha256:") else { return false }
+    let digest = value.dropFirst("sha256:".count)
+    return digest.count == 64
+        && digest.allSatisfy {
+            $0.isNumber || ("a"..."f").contains($0)
+        }
 }
 
 func allowlistedCLIEnvironment(

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/StatusItemController.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/StatusItemController.swift
@@ -249,6 +249,19 @@ final class StatusItemController: NSObject, NSMenuDelegate {
             added = true
         }
 
+        if let message = state.mutationRecoveryMessage {
+            let item = disabledItem("Routing Cleanup Required")
+            item.image = symbol("exclamationmark.triangle")
+            item.toolTip = menuErrorLabel(message)
+            menu.addItem(item)
+            if state.canRetryMutationCleanup {
+                menu.addItem(actionItem(
+                    "Retry cleanup",
+                    action: #selector(retryMutationCleanup(_:))))
+            }
+            added = true
+        }
+
         if added {
             menu.addItem(.separator())
         }
@@ -360,6 +373,10 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     @objc private func openConfigurationWindow(_ sender: NSMenuItem) {
         guard !isPreview else { return }
         openConfiguration(sender.representedObject as? String)
+    }
+
+    @objc private func retryMutationCleanup(_ sender: NSMenuItem) {
+        state.retryMutationCleanup()
     }
 
     @objc private func openNativeTraffic() {

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/ReasoningConfigurationTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/ReasoningConfigurationTests.swift
@@ -71,6 +71,7 @@ private actor ReasoningAdminReader: AdminStatusReading {
 private actor FixedReasoningPreflightReader: ReasoningPreflightReading {
     let snapshot: ReasoningPreflightSnapshot
     private(set) var calls = 0
+    private(set) var clients: [String] = []
 
     init(snapshot: ReasoningPreflightSnapshot) {
         self.snapshot = snapshot
@@ -83,6 +84,7 @@ private actor FixedReasoningPreflightReader: ReasoningPreflightReading {
         policy: ReasoningPolicyValue
     ) async throws -> ReasoningPreflightSnapshot {
         calls += 1
+        clients.append(client)
         return snapshot
     }
 }
@@ -96,6 +98,52 @@ private actor ReasoningRecordingRunner: CLIRunning {
             status: 1,
             standardOutput: "",
             standardError: "fixture failure",
+            timedOut: false)
+    }
+}
+
+private actor ReasoningTerminalReplayRunner: CLIRunning {
+    private(set) var arguments: [[String]] = []
+
+    func run(_ request: CLIExecutionRequest) async -> CLIExecutionResult {
+        arguments.append(request.arguments)
+        let reconciling = request.arguments.contains("reconcile")
+        let operationID: String
+        if let index = request.arguments.firstIndex(of: "--operation-id"),
+           request.arguments.indices.contains(index + 1) {
+            operationID = request.arguments[index + 1]
+        } else {
+            operationID = request.arguments.last ?? ""
+        }
+        var object: [String: Any] = [
+            "ok": reconciling,
+            "operation_id": operationID,
+            "operation": "set_model_reasoning",
+            "client": "claude-code",
+            "desired_config_hash": "sha256:active",
+            "active_config_hash": "sha256:active",
+            "active_token": "boot-a:4",
+            "applied": reconciling,
+            "reconciliation_required": !reconciling,
+            "request_fingerprint":
+                "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            "identity_strength": "exact",
+            "error": reconciling
+                ? NSNull()
+                : [
+                    "code": "activation_indeterminate",
+                    "message": "reconciliation required",
+                ],
+        ]
+        if !reconciling {
+            object["key"] = "zai-org/GLM-5.2"
+            object["requested_target"] = "default"
+        }
+        let data = try! JSONSerialization.data(withJSONObject: object)
+        return CLIExecutionResult(
+            status: reconciling ? 0 : 1,
+            standardOutput: String(decoding: data, as: UTF8.self),
+            standardError: "",
             timedOut: false)
     }
 }
@@ -639,6 +687,14 @@ final class ReasoningConfigurationTests: XCTestCase {
                 model: model,
                 policy: ReasoningPolicyValue(mode: .fixed, effort: "high")),
             ["codex", "reasoning", "baseten", model, "effort", "high"])
+        XCTAssertEqual(
+            reasoningDispatchArgs(
+                client: "anthropic-fallback",
+                protocolShape: "anthropic",
+                provider: "baseten",
+                model: model,
+                policy: ReasoningPolicyValue(mode: .off)),
+            ["claude", "reasoning", "baseten", model, "off"])
 
         let fixed = routingSnapshot(client: reasoningClient(
             configured: ["mode": "fixed", "effort": "high"],
@@ -708,6 +764,41 @@ final class ReasoningConfigurationTests: XCTestCase {
     }
 
     @MainActor
+    func testFallbackAnthropicReasoningUsesClaudeVerbAndSelectedIdentity()
+        async {
+        let preflight = FixedReasoningPreflightReader(
+            snapshot: preflightSnapshot())
+        let runner = ReasoningRecordingRunner()
+        let state = makeState(
+            preflight: preflight,
+            runner: runner,
+            clientName: "anthropic-fallback",
+            protocolShape: "anthropic")
+        await state.refresh()
+
+        XCTAssertTrue(state.requestReasoning(
+            client: "anthropic-fallback",
+            provider: "baseten",
+            model: model,
+            policy: ReasoningPolicyValue(mode: .followHarness)))
+        await waitUntil { state.pendingReasoning == nil }
+
+        let clients = await preflight.clients
+        XCTAssertEqual(clients, ["anthropic-fallback"])
+        let calls = await runner.arguments
+        XCTAssertEqual(
+            Array(calls[0].suffix(5)),
+            [
+                "claude",
+                "reasoning",
+                "baseten",
+                model,
+                "follow-harness",
+            ])
+        state.stop()
+    }
+
+    @MainActor
     func testDefaultResetSkipsPreflightAndUsesTypedCLIPath() async {
         let preflight = FixedReasoningPreflightReader(
             snapshot: preflightSnapshot())
@@ -731,6 +822,32 @@ final class ReasoningConfigurationTests: XCTestCase {
         XCTAssertEqual(
             Array(calls[0].suffix(5)),
             ["claude", "reasoning", "baseten", model, "default"])
+        XCTAssertEqual(
+            Array(calls[1].prefix(3)),
+            ["--json", "mutation", "reconcile"])
+        state.stop()
+    }
+
+    @MainActor
+    func testReasoningAcceptsVerifiedTargetlessTerminalReplay() async {
+        let preflight = FixedReasoningPreflightReader(
+            snapshot: preflightSnapshot())
+        let runner = ReasoningTerminalReplayRunner()
+        let state = makeState(
+            preflight: preflight,
+            runner: runner)
+        await state.refresh()
+
+        XCTAssertTrue(state.requestReasoning(
+            client: "claude-code",
+            provider: "baseten",
+            model: model,
+            policy: ReasoningPolicyValue(mode: .default)))
+        await waitUntil { state.pendingReasoning == nil }
+
+        XCTAssertNil(state.lastError)
+        let calls = await runner.arguments
+        XCTAssertEqual(calls.count, 2)
         XCTAssertEqual(
             Array(calls[1].prefix(3)),
             ["--json", "mutation", "reconcile"])
@@ -1004,7 +1121,9 @@ final class ReasoningConfigurationTests: XCTestCase {
     @MainActor
     private func makeState(
         preflight: FixedReasoningPreflightReader,
-        runner: ReasoningRecordingRunner
+        runner: any CLIRunning,
+        clientName: String = "claude-code",
+        protocolShape: String = "anthropic"
     ) -> BasetenSwitchState {
         let status = AdminStatusSnapshot(dict: [
             "router_boot_id": "boot-a",
@@ -1014,9 +1133,10 @@ final class ReasoningConfigurationTests: XCTestCase {
             "health": "ready",
             "global_routing_enabled": true,
             "clients": [[
-                "name": "claude-code",
+                "name": clientName,
                 "enabled": true,
                 "bind_addr": "127.0.0.1:8789",
+                "protocol_shape": protocolShape,
                 "model_options": [
                     "baseten": [
                         model: [

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/RuntimeCoordinationTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/RuntimeCoordinationTests.swift
@@ -68,6 +68,268 @@ private struct FixedClock: RuntimeClock {
     }
 }
 
+private final class RecordingClock: RuntimeClock, @unchecked Sendable {
+    let now: Date
+    private let queue = DispatchQueue(label: "mutation-recovery-test-clock")
+    private var values: [TimeInterval] = []
+
+    init(now: Date = Date(timeIntervalSince1970: 100)) {
+        self.now = now
+    }
+
+    func sleep(seconds: TimeInterval) async throws {
+        try Task.checkCancellation()
+        queue.sync {
+            values.append(seconds)
+        }
+    }
+
+    var sleeps: [TimeInterval] {
+        queue.sync { values }
+    }
+}
+
+private actor RecoveryScriptRunner: CLIRunning {
+    private(set) var arguments: [[String]] = []
+    private let statusResult: CLIExecutionResult
+    private var recoverResults: [CLIExecutionResult]
+
+    init(statusResult: CLIExecutionResult,
+         recoverResults: [CLIExecutionResult]) {
+        self.statusResult = statusResult
+        self.recoverResults = recoverResults
+    }
+
+    func run(_ request: CLIExecutionRequest) async -> CLIExecutionResult {
+        arguments.append(request.arguments)
+        if request.arguments.suffix(2) == ["mutation", "status"] {
+            return statusResult
+        }
+        if request.arguments.suffix(2) == ["mutation", "recover"] {
+            if !recoverResults.isEmpty {
+                return recoverResults.removeFirst()
+            }
+        }
+        return CLIExecutionResult(
+            status: 1,
+            standardOutput: "",
+            standardError: "",
+            timedOut: false)
+    }
+}
+
+private actor PrimaryFailureRunner: CLIRunning {
+    enum Mode: Equatable {
+        case blocker
+        case doubleTimeout
+        case failedReconciliation
+        case malformedSecondary
+        case mismatchedSecondary
+        case timedTypedError
+        case timedSuccess
+    }
+
+    private(set) var arguments: [[String]] = []
+    private let mode: Mode
+
+    init(mode: Mode) {
+        self.mode = mode
+    }
+
+    func run(_ request: CLIExecutionRequest) async -> CLIExecutionResult {
+        arguments.append(request.arguments)
+        let args = request.arguments
+        let operationID: String
+        if let flag = args.firstIndex(of: "--operation-id"),
+           args.indices.contains(flag + 1) {
+            operationID = args[flag + 1]
+        } else {
+            operationID = args.last ?? ""
+        }
+        let reconciling = args.suffix(3).dropLast().contains("mutation")
+            || (args.contains("mutation") && args.contains("reconcile"))
+        if mode == .doubleTimeout
+            || mode == .malformedSecondary
+            || mode == .mismatchedSecondary {
+            if !reconciling || mode == .doubleTimeout {
+                return CLIExecutionResult(
+                    status: -1,
+                    standardOutput: "",
+                    standardError: "",
+                    timedOut: true)
+            }
+            if mode == .malformedSecondary {
+                return CLIExecutionResult(
+                    status: 1,
+                    standardOutput: "{not-json",
+                    standardError: "",
+                    timedOut: false)
+            }
+            let object: [String: Any] = [
+                "ok": true,
+                "operation_id": "different-operation",
+                "operation": "set_global_routing",
+                "requested": true,
+                "desired_config_hash": "sha256:active",
+                "active_config_hash": "sha256:active",
+                "active_token": "boot-a:4",
+                "applied": true,
+                "reconciliation_required": false,
+                "error": NSNull(),
+            ]
+            let data = try! JSONSerialization.data(withJSONObject: object)
+            return CLIExecutionResult(
+                status: 0,
+                standardOutput: String(decoding: data, as: UTF8.self),
+                standardError: "",
+                timedOut: false)
+        }
+        if mode == .timedSuccess {
+            let object: [String: Any] = [
+                "ok": true,
+                "operation_id": operationID,
+                "operation": "set_global_routing",
+                "requested": true,
+                "desired_config_hash": "sha256:active",
+                "active_config_hash": "sha256:active",
+                "active_token": "boot-a:4",
+                "applied": true,
+                "reconciliation_required": false,
+                "error": NSNull(),
+            ]
+            let data = try! JSONSerialization.data(withJSONObject: object)
+            return CLIExecutionResult(
+                status: reconciling ? 0 : -1,
+                standardOutput: String(decoding: data, as: UTF8.self),
+                standardError: "",
+                timedOut: !reconciling)
+        }
+        let errorCode: String
+        let blockingID: String?
+        let reconciliationRequired: Bool
+        if mode == .blocker {
+            errorCode = "unfinished_mutation"
+            blockingID = "older-operation"
+            reconciliationRequired = false
+        } else if mode == .timedTypedError {
+            errorCode = "stale_config_hash"
+            blockingID = nil
+            reconciliationRequired = false
+        } else if reconciling {
+            errorCode = "journal_not_found"
+            blockingID = nil
+            reconciliationRequired = false
+        } else {
+            errorCode = "activation_indeterminate"
+            blockingID = nil
+            reconciliationRequired = true
+        }
+        var object: [String: Any] = [
+            "ok": false,
+            "operation_id": operationID,
+            "operation": "set_global_routing",
+            "applied": false,
+            "reconciliation_required": reconciliationRequired,
+            "error": [
+                "code": errorCode,
+                "message": "open /Users/example/private/model-id.json: no such file",
+                "retryable": false,
+            ],
+        ]
+        if let blockingID {
+            object["blocking_operation_id"] = blockingID
+        }
+        let data = try! JSONSerialization.data(withJSONObject: object)
+        return CLIExecutionResult(
+            status: mode == .timedTypedError ? -1 : 1,
+            standardOutput: String(decoding: data, as: UTF8.self),
+            standardError: "",
+            timedOut: mode == .timedTypedError)
+    }
+}
+
+private actor CleanupPendingMutationRunner: CLIRunning {
+    enum Mode: Equatable {
+        case rejected
+        case priorActive
+    }
+
+    private(set) var arguments: [[String]] = []
+    private let mode: Mode
+
+    init(mode: Mode) {
+        self.mode = mode
+    }
+
+    func run(_ request: CLIExecutionRequest) async -> CLIExecutionResult {
+        arguments.append(request.arguments)
+        let args = request.arguments
+        let operationID = argumentValue("--operation-id", in: args)
+            ?? args.last
+            ?? ""
+        let reconciling = args.contains("reconcile")
+        let rejected = mode == .rejected
+        let object: [String: Any]
+        if reconciling {
+            object = [
+                "ok": true,
+                "operation_id": operationID,
+                "operation": "set_global_routing",
+                "requested": true,
+                "desired_config_hash": "sha256:new",
+                "active_config_hash": "sha256:active",
+                "active_token": "boot-a:4",
+                "applied": false,
+                "reconciliation_required": false,
+                "cleanup_pending": true,
+                "outcome": "not_applied",
+                "identity_strength": "exact",
+                "request_fingerprint":
+                    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "error": NSNull(),
+            ]
+        } else {
+            object = [
+                "ok": false,
+                "operation_id": operationID,
+                "operation": "set_global_routing",
+                "requested": true,
+                "desired_config_hash": rejected
+                    ? "sha256:active"
+                    : "sha256:new",
+                "active_config_hash": "sha256:active",
+                "active_token": "boot-a:4",
+                "applied": false,
+                "reconciliation_required": !rejected,
+                "cleanup_pending": rejected,
+                "outcome": rejected ? "rejected" : "",
+                "error": [
+                    "code": rejected
+                        ? "stale_config_hash"
+                        : "activation_indeterminate",
+                    "message": "reviewed mutation error",
+                    "retryable": false,
+                ],
+            ]
+        }
+        let data = try! JSONSerialization.data(withJSONObject: object)
+        return CLIExecutionResult(
+            status: reconciling ? 0 : 1,
+            standardOutput: String(decoding: data, as: UTF8.self),
+            standardError: "",
+            timedOut: false)
+    }
+
+    private func argumentValue(
+        _ flag: String,
+        in arguments: [String]
+    ) -> String? {
+        guard let index = arguments.firstIndex(of: flag),
+              arguments.indices.contains(index + 1) else { return nil }
+        return arguments[index + 1]
+    }
+}
+
 private actor ConcurrencyRecordingRunner: CLIRunning {
     private(set) var active = 0
     private(set) var maximumActive = 0
@@ -87,12 +349,57 @@ private actor ConcurrencyRecordingRunner: CLIRunning {
     }
 }
 
+private actor BlockingFirstRunner: CLIRunning {
+    private(set) var arguments: [[String]] = []
+    private var firstContinuation: CheckedContinuation<Void, Never>?
+
+    func run(_ request: CLIExecutionRequest) async -> CLIExecutionResult {
+        arguments.append(request.arguments)
+        if arguments.count == 1 {
+            await withCheckedContinuation { continuation in
+                firstContinuation = continuation
+            }
+        }
+        return CLIExecutionResult(
+            status: 0,
+            standardOutput: "",
+            standardError: "",
+            timedOut: false)
+    }
+
+    func waitUntilFirstStarted() async {
+        while arguments.isEmpty {
+            await Task.yield()
+        }
+    }
+
+    func releaseFirst() {
+        firstContinuation?.resume()
+        firstContinuation = nil
+    }
+}
+
 private actor ReconciliationReceiptRunner: CLIRunning {
+    private static let requestFingerprint =
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     private(set) var arguments: [[String]] = []
     private var journalOperation = ""
     private var journalClient = ""
     private var journalKey = ""
     private var journalTarget = ""
+    private let reconciledFingerprint: String
+    private let primaryTargetOverride: String?
+    private let clientOverride: String?
+
+    init(
+        reconciledFingerprint: String = requestFingerprint,
+        primaryTargetOverride: String? = nil,
+        clientOverride: String? = nil
+    ) {
+        self.reconciledFingerprint = reconciledFingerprint
+        self.primaryTargetOverride = primaryTargetOverride
+        self.clientOverride = clientOverride
+    }
 
     func run(_ request: CLIExecutionRequest) async -> CLIExecutionResult {
         arguments.append(request.arguments)
@@ -135,24 +442,27 @@ private actor ReconciliationReceiptRunner: CLIRunning {
             key = journalKey
             target = journalTarget
         } else {
+            client = clientOverride ?? client
             journalOperation = operation
             journalClient = client
             journalKey = key
             journalTarget = target
         }
         let ok = reconciling
-        let object: [String: Any] = [
+        var object: [String: Any] = [
             "ok": ok,
             "operation_id": operationID,
             "operation": operation,
             "client": client,
-            "key": key,
-            "requested_target": target,
             "desired_config_hash": "sha256:new",
             "active_token": "boot-a:5",
             "active_config_hash": "sha256:new",
             "applied": ok,
             "reconciliation_required": !ok,
+            "request_fingerprint": reconciling
+                ? reconciledFingerprint
+                : Self.requestFingerprint,
+            "identity_strength": "exact",
             "error": ok
                 ? NSNull()
                 : [
@@ -160,6 +470,10 @@ private actor ReconciliationReceiptRunner: CLIRunning {
                     "message": "reconciliation required",
                 ],
         ]
+        if !reconciling {
+            object["key"] = key
+            object["requested_target"] = primaryTargetOverride ?? target
+        }
         let data = try! JSONSerialization.data(withJSONObject: object)
         return CLIExecutionResult(
             status: ok ? 0 : 1,
@@ -193,7 +507,9 @@ final class RuntimeCoordinationTests: XCTestCase {
     private let previewConfigPath =
         "/tmp/baseten-switch-home/.config/baseten-switch-preview/gateway.yaml"
 
-    private func previewVariant() -> AppVariant {
+    private func previewVariant(
+        binaryPath: String = "/usr/bin/true"
+    ) -> AppVariant {
         AppVariant.resolve(
             infoDictionary: [
                 "BasetenSwitchBuildChannel": "preview",
@@ -203,7 +519,7 @@ final class RuntimeCoordinationTests: XCTestCase {
             bundleIdentifier: "co.baseten.switch.preview",
             runningExecutableName: "BasetenSwitchPreview",
             homeDirectory: "/tmp/baseten-switch-home",
-            environment: ["BASETEN_SWITCH_GATEWAY_BIN": "/usr/bin/true"])
+            environment: ["BASETEN_SWITCH_GATEWAY_BIN": binaryPath])
     }
 
     private func isolatedPreviewVariant() throws -> AppVariant {
@@ -249,10 +565,12 @@ final class RuntimeCoordinationTests: XCTestCase {
         hash: String,
         familyTarget: String,
         subagentModel: String = "",
-        subagentRouting: String = "off"
+        subagentRouting: String = "off",
+        bootID: String = "boot-a",
+        clientName: String = "claude-code"
     ) -> AdminStatusSnapshot {
         AdminStatusSnapshot(dict: [
-            "router_boot_id": "boot-a",
+            "router_boot_id": bootID,
             "active_generation": generation,
             "active_config_hash": hash,
             "desired_config_hash": hash,
@@ -261,7 +579,7 @@ final class RuntimeCoordinationTests: XCTestCase {
             "config_path": previewConfigPath,
             "global_routing_enabled": false,
             "clients": [[
-                "name": "claude-code",
+                "name": clientName,
                 "enabled": true,
                 "bind_addr": "127.0.0.1:45372",
                 "protocol_shape": "anthropic",
@@ -432,6 +750,11 @@ final class RuntimeCoordinationTests: XCTestCase {
           "active_config_hash": "sha256:new",
           "applied": true,
           "reconciliation_required": true,
+          "blocking_operation_id": "op-older",
+          "outcome": "applied",
+          "cleanup_pending": true,
+          "request_fingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "identity_strength": "exact",
           "error": null
         }
         """)
@@ -447,6 +770,510 @@ final class RuntimeCoordinationTests: XCTestCase {
         XCTAssertEqual(receipt?.activeConfigHash, "sha256:new")
         XCTAssertEqual(receipt?.applied, true)
         XCTAssertEqual(receipt?.reconciliationRequired, true)
+        XCTAssertEqual(receipt?.blockingOperationID, "op-older")
+        XCTAssertEqual(receipt?.outcome, "applied")
+        XCTAssertEqual(receipt?.cleanupPending, true)
+        XCTAssertEqual(
+            receipt?.requestFingerprint,
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        XCTAssertEqual(receipt?.identityStrength, "exact")
+        XCTAssertTrue(isValidMutationRequestFingerprint(
+            receipt?.requestFingerprint ?? ""))
+        XCTAssertFalse(isValidMutationRequestFingerprint(
+            "sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"))
+    }
+
+    @MainActor
+    func testStartupRecoveryProbesOnceThenRunsCleanupOnly() async {
+        let runner = RecoveryScriptRunner(
+            statusResult: recoveryStatusResult(
+                classification: "none"),
+            recoverResults: [recoveryResult(
+                ok: true,
+                classification: "none")])
+        let state = BasetenSwitchState(
+            variant: previewVariant(),
+            reader: CountingAdminReader(status: previewStatus(
+                generation: 4,
+                hash: "sha256:active",
+                familyTarget: "native")),
+            cliRunner: runner,
+            clock: RecordingClock(),
+            loginItemService: FakeLoginItemService(),
+            previewRuntimeValidator: { _ in nil },
+            startPolling: false,
+            automaticMutationRecoveryEnabled: true)
+
+        XCTAssertFalse(state.canMutateRouting)
+        await state.refresh()
+        await state.waitForMutationRecovery()
+
+        XCTAssertEqual(state.mutationRecoveryState, .ready)
+        XCTAssertTrue(state.canMutateRouting)
+        let initialCalls = await runner.arguments
+        XCTAssertEqual(initialCalls, [
+            ["--json", "mutation", "status"],
+            ["--json", "mutation", "recover"],
+        ])
+
+        await state.refresh()
+        let repeatedCalls = await runner.arguments
+        XCTAssertEqual(repeatedCalls.count, 2)
+        state.stop()
+    }
+
+    @MainActor
+    func testStartupRecoveryUsesBoundedBackoffAndManualRetry() async {
+        let transient = recoveryResult(
+            ok: false,
+            errorCode: "mutation_locked",
+            status: 1)
+        let clock = RecordingClock()
+        let runner = RecoveryScriptRunner(
+            statusResult: recoveryStatusResult(
+                classification: "desired_active"),
+            recoverResults: Array(repeating: transient, count: 6) + [
+                recoveryResult(ok: true, classification: "none"),
+            ])
+        let state = BasetenSwitchState(
+            variant: previewVariant(),
+            reader: CountingAdminReader(status: previewStatus(
+                generation: 4,
+                hash: "sha256:active",
+                familyTarget: "native")),
+            cliRunner: runner,
+            clock: clock,
+            loginItemService: FakeLoginItemService(),
+            previewRuntimeValidator: { _ in nil },
+            startPolling: false,
+            automaticMutationRecoveryEnabled: true)
+
+        await state.refresh()
+        await state.waitForMutationRecovery()
+
+        XCTAssertEqual(
+            state.mutationRecoveryState,
+            .blocked(errorCode: "mutation_locked"))
+        XCTAssertEqual(clock.sleeps, [1, 2, 4, 8, 16])
+        XCTAssertTrue(state.canRetryMutationCleanup)
+        let automaticCalls = await runner.arguments
+        XCTAssertFalse(automaticCalls.joined().contains("reconcile"))
+
+        state.retryMutationCleanup()
+        await state.waitForMutationRecovery()
+        XCTAssertEqual(state.mutationRecoveryState, .ready)
+        XCTAssertEqual(clock.sleeps, [1, 2, 4, 8, 16])
+        state.stop()
+    }
+
+    @MainActor
+    func testCleanupPendingSuccessRemainsGatedAndRetries() async {
+        let pending = recoveryResult(
+            ok: true,
+            classification: "cleanup_pending",
+            cleanupPending: true)
+        let clock = RecordingClock()
+        let runner = RecoveryScriptRunner(
+            statusResult: recoveryStatusResult(
+                classification: "cleanup_pending"),
+            recoverResults: Array(repeating: pending, count: 6))
+        let state = BasetenSwitchState(
+            variant: previewVariant(),
+            reader: CountingAdminReader(status: previewStatus(
+                generation: 4,
+                hash: "sha256:active",
+                familyTarget: "native")),
+            cliRunner: runner,
+            clock: clock,
+            loginItemService: FakeLoginItemService(),
+            previewRuntimeValidator: { _ in nil },
+            startPolling: false,
+            automaticMutationRecoveryEnabled: true)
+
+        await state.refresh()
+        await state.waitForMutationRecovery()
+
+        XCTAssertEqual(
+            state.mutationRecoveryState,
+            .blocked(errorCode: "cleanup_pending"))
+        XCTAssertFalse(state.canMutateRouting)
+        XCTAssertTrue(state.canRetryMutationCleanup)
+        XCTAssertEqual(clock.sleeps, [1, 2, 4, 8, 16])
+        state.stop()
+    }
+
+    @MainActor
+    func testRetryableCleanupPredicateChangeRetriesThenRecovers() async {
+        let clock = RecordingClock()
+        let runner = RecoveryScriptRunner(
+            statusResult: recoveryStatusResult(
+                classification: "desired_active"),
+            recoverResults: [
+                recoveryResult(
+                    ok: false,
+                    errorCode: "cleanup_predicate_changed",
+                    status: 1,
+                    errorRetryable: true),
+                recoveryResult(ok: true, classification: "none"),
+            ])
+        let state = BasetenSwitchState(
+            variant: previewVariant(),
+            reader: CountingAdminReader(status: previewStatus(
+                generation: 4,
+                hash: "sha256:active",
+                familyTarget: "native")),
+            cliRunner: runner,
+            clock: clock,
+            loginItemService: FakeLoginItemService(),
+            previewRuntimeValidator: { _ in nil },
+            startPolling: false,
+            automaticMutationRecoveryEnabled: true)
+
+        await state.refresh()
+        await state.waitForMutationRecovery()
+
+        XCTAssertEqual(state.mutationRecoveryState, .ready)
+        XCTAssertEqual(clock.sleeps, [1])
+        state.stop()
+    }
+
+    @MainActor
+    func testTimedOutCleanupProcessRetriesThenRecovers() async {
+        let clock = RecordingClock()
+        let runner = RecoveryScriptRunner(
+            statusResult: recoveryStatusResult(
+                classification: "desired_active"),
+            recoverResults: [
+                recoveryResult(
+                    ok: false,
+                    status: -1,
+                    timedOut: true),
+                recoveryResult(ok: true, classification: "none"),
+            ])
+        let state = BasetenSwitchState(
+            variant: previewVariant(),
+            reader: CountingAdminReader(status: previewStatus(
+                generation: 4,
+                hash: "sha256:active",
+                familyTarget: "native")),
+            cliRunner: runner,
+            clock: clock,
+            loginItemService: FakeLoginItemService(),
+            previewRuntimeValidator: { _ in nil },
+            startPolling: false,
+            automaticMutationRecoveryEnabled: true)
+
+        await state.refresh()
+        await state.waitForMutationRecovery()
+
+        XCTAssertEqual(state.mutationRecoveryState, .ready)
+        XCTAssertEqual(clock.sleeps, [1])
+        state.stop()
+    }
+
+    @MainActor
+    func testTimedOutStatusProbeStillRunsCleanupRecovery() async {
+        let runner = RecoveryScriptRunner(
+            statusResult: recoveryResult(
+                ok: false,
+                status: -1,
+                timedOut: true),
+            recoverResults: [
+                recoveryResult(ok: true, classification: "none"),
+            ])
+        let state = BasetenSwitchState(
+            variant: previewVariant(),
+            reader: CountingAdminReader(status: previewStatus(
+                generation: 4,
+                hash: "sha256:active",
+                familyTarget: "native")),
+            cliRunner: runner,
+            clock: RecordingClock(),
+            loginItemService: FakeLoginItemService(),
+            previewRuntimeValidator: { _ in nil },
+            startPolling: false,
+            automaticMutationRecoveryEnabled: true)
+
+        await state.refresh()
+        await state.waitForMutationRecovery()
+
+        XCTAssertEqual(state.mutationRecoveryState, .ready)
+        let calls = await runner.arguments
+        XCTAssertEqual(calls, [
+            ["--json", "mutation", "status"],
+            ["--json", "mutation", "recover"],
+        ])
+        state.stop()
+    }
+
+    @MainActor
+    func testUnsupportedStatusFallsBackWithoutRepeatedProbe() async {
+        let runner = RecoveryScriptRunner(
+            statusResult: recoveryResult(
+                ok: false,
+                errorCode: "usage",
+                status: 2),
+            recoverResults: [])
+        let state = BasetenSwitchState(
+            variant: previewVariant(),
+            reader: SequencedAdminReader(statuses: [
+                previewStatus(
+                    generation: 4,
+                    hash: "sha256:active",
+                    familyTarget: "native"),
+                previewStatus(
+                    generation: 4,
+                    hash: "sha256:active",
+                    familyTarget: "native"),
+                previewStatus(
+                    generation: 1,
+                    hash: "sha256:active",
+                    familyTarget: "native",
+                    bootID: "boot-b"),
+            ]),
+            cliRunner: runner,
+            clock: RecordingClock(),
+            loginItemService: FakeLoginItemService(),
+            previewRuntimeValidator: { _ in nil },
+            startPolling: false,
+            automaticMutationRecoveryEnabled: true)
+
+        await state.refresh()
+        await state.waitForMutationRecovery()
+        XCTAssertEqual(state.mutationRecoveryState, .legacyFallback)
+        XCTAssertTrue(state.canMutateRouting)
+        let initialCalls = await runner.arguments
+        XCTAssertEqual(initialCalls.count, 1)
+
+        await state.refresh()
+        let repeatedCalls = await runner.arguments
+        XCTAssertEqual(repeatedCalls.count, 1)
+        state.stop()
+    }
+
+    @MainActor
+    func testInPlaceCLIUpgradeInvalidatesLegacyFallback() async throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let binary = root.appendingPathComponent("baseten-switch")
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true)
+        try Data("#!/bin/sh\nexit 0\n".utf8).write(to: binary)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o755)],
+            ofItemAtPath: binary.path)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        let runner = RecoveryScriptRunner(
+            statusResult: recoveryResult(
+                ok: false,
+                errorCode: "usage",
+                status: 2),
+            recoverResults: [])
+        let state = BasetenSwitchState(
+            variant: previewVariant(binaryPath: binary.path),
+            reader: CountingAdminReader(status: previewStatus(
+                generation: 4,
+                hash: "sha256:active",
+                familyTarget: "native")),
+            cliRunner: runner,
+            loginItemService: FakeLoginItemService(),
+            previewRuntimeValidator: { _ in nil },
+            startPolling: false,
+            automaticMutationRecoveryEnabled: true)
+
+        await state.refresh()
+        await state.waitForMutationRecovery()
+        let initialCalls = await runner.arguments
+        XCTAssertEqual(initialCalls.count, 1)
+
+        try Data("#!/bin/sh\nexit 0\n# upgraded\n".utf8)
+            .write(to: binary, options: .atomic)
+        try FileManager.default.setAttributes(
+            [
+                .posixPermissions: NSNumber(value: 0o755),
+                .modificationDate: Date(timeIntervalSinceNow: 5),
+            ],
+            ofItemAtPath: binary.path)
+
+        await state.refresh()
+        await state.waitForMutationRecovery()
+        let calls = await runner.arguments
+        XCTAssertEqual(calls.count, 2)
+        XCTAssertEqual(calls.last, ["--json", "mutation", "status"])
+        state.stop()
+    }
+
+    @MainActor
+    func testReasoningControlsStayDisabledDuringStartupRecovery() async {
+        let runner = BlockingFirstRunner()
+        let state = BasetenSwitchState(
+            variant: previewVariant(),
+            reader: CountingAdminReader(status: previewStatus(
+                generation: 4,
+                hash: "sha256:active",
+                familyTarget: "native")),
+            cliRunner: runner,
+            loginItemService: FakeLoginItemService(),
+            previewRuntimeValidator: { _ in nil },
+            startPolling: false,
+            automaticMutationRecoveryEnabled: true)
+
+        await state.refresh()
+        await runner.waitUntilFirstStarted()
+        XCTAssertFalse(state.canMutateReasoning)
+
+        state.stop()
+        await runner.releaseFirst()
+    }
+
+    @MainActor
+    func testBlockingOperationPreservesPrimaryAndNeverReconcilesNewID() async {
+        let runner = PrimaryFailureRunner(mode: .blocker)
+        let state = mutationTestState(runner: runner)
+        await state.refresh()
+
+        await state.setAllRoutesThroughBaseten(true)
+
+        let calls = await runner.arguments
+        XCTAssertEqual(calls.count, 1)
+        XCTAssertEqual(
+            state.lastError,
+            "A previous routing change still needs cleanup.")
+        XCTAssertFalse(state.lastError?.contains("/Users/") == true)
+        XCTAssertFalse(state.lastError?.contains("model-id") == true)
+        state.stop()
+    }
+
+    @MainActor
+    func testFailedSecondaryReconciliationCannotMaskPrimaryFailure() async {
+        let runner = PrimaryFailureRunner(mode: .failedReconciliation)
+        let state = mutationTestState(runner: runner)
+        await state.refresh()
+
+        await state.setAllRoutesThroughBaseten(true)
+
+        let calls = await runner.arguments
+        XCTAssertEqual(calls.count, 2)
+        XCTAssertEqual(Array(calls[1].prefix(3)), [
+            "--json", "mutation", "reconcile",
+        ])
+        XCTAssertEqual(
+            state.lastError,
+            "The routing change could not be confirmed safely. Retry cleanup.")
+        XCTAssertFalse(state.lastError?.contains("/Users/") == true)
+        state.stop()
+    }
+
+    @MainActor
+    func testDoubleTimeoutRetainsRecoveryGate() async {
+        let runner = PrimaryFailureRunner(mode: .doubleTimeout)
+        let state = mutationTestState(runner: runner)
+        await state.refresh()
+
+        await state.setAllRoutesThroughBaseten(true)
+
+        let calls = await runner.arguments
+        XCTAssertEqual(calls.count, 2)
+        XCTAssertEqual(
+            state.mutationRecoveryState,
+            .blocked(errorCode: "reconciliation_required"))
+        XCTAssertFalse(state.canMutateRouting)
+        state.stop()
+    }
+
+    @MainActor
+    func testUnusableSecondaryReceiptRetainsRecoveryGate() async {
+        for mode in [
+            PrimaryFailureRunner.Mode.malformedSecondary,
+            .mismatchedSecondary,
+        ] {
+            let runner = PrimaryFailureRunner(mode: mode)
+            let state = mutationTestState(runner: runner)
+            await state.refresh()
+
+            await state.setAllRoutesThroughBaseten(true)
+
+            let calls = await runner.arguments
+            XCTAssertEqual(calls.count, 2)
+            XCTAssertEqual(
+                state.mutationRecoveryState,
+                .blocked(errorCode: "reconciliation_required"))
+            XCTAssertFalse(state.canMutateRouting)
+            state.stop()
+        }
+    }
+
+    @MainActor
+    func testMatchingTypedPrimaryErrorOutranksProcessTimeout() async {
+        let runner = PrimaryFailureRunner(mode: .timedTypedError)
+        let state = mutationTestState(runner: runner)
+        await state.refresh()
+
+        await state.setAllRoutesThroughBaseten(true)
+
+        let calls = await runner.arguments
+        XCTAssertEqual(calls.count, 1)
+        XCTAssertEqual(
+            state.lastError,
+            "Routing settings changed before this request completed. Refresh and try again.")
+        XCTAssertFalse(state.lastError?.contains("timed out") == true)
+        state.stop()
+    }
+
+    @MainActor
+    func testTimedOutSuccessReceiptStillReconciles() async {
+        let runner = PrimaryFailureRunner(mode: .timedSuccess)
+        let state = mutationTestState(runner: runner)
+        await state.refresh()
+
+        await state.setAllRoutesThroughBaseten(true)
+
+        let calls = await runner.arguments
+        XCTAssertEqual(calls.count, 2)
+        XCTAssertEqual(
+            Array(calls[1].prefix(3)),
+            ["--json", "mutation", "reconcile"])
+        XCTAssertFalse(state.lastError?.contains("timed out") == true)
+        state.stop()
+    }
+
+    @MainActor
+    func testRejectedReceiptWithCleanupPendingRetainsRecoveryGate() async {
+        let runner = CleanupPendingMutationRunner(mode: .rejected)
+        let state = mutationTestState(runner: runner)
+        await state.refresh()
+
+        await state.setAllRoutesThroughBaseten(true)
+
+        let calls = await runner.arguments
+        XCTAssertEqual(calls.count, 1)
+        XCTAssertEqual(
+            state.mutationRecoveryState,
+            .blocked(errorCode: "cleanup_pending"))
+        XCTAssertFalse(state.canMutateRouting)
+        state.stop()
+    }
+
+    @MainActor
+    func testPriorActiveReconcileWithCleanupPendingIsNotResolved() async {
+        let runner = CleanupPendingMutationRunner(mode: .priorActive)
+        let state = mutationTestState(runner: runner)
+        await state.refresh()
+
+        await state.setAllRoutesThroughBaseten(true)
+
+        let calls = await runner.arguments
+        XCTAssertEqual(calls.count, 2)
+        XCTAssertTrue(calls[1].contains("reconcile"))
+        XCTAssertEqual(
+            state.mutationRecoveryState,
+            .blocked(errorCode: "cleanup_pending"))
+        XCTAssertFalse(state.canMutateRouting)
+        state.stop()
     }
 
     func testMutationCoordinatorSerializesChildProcesses() async {
@@ -466,6 +1293,34 @@ final class RuntimeCoordinationTests: XCTestCase {
         let arguments = await runner.arguments
         XCTAssertEqual(maximumActive, 1)
         XCTAssertEqual(arguments, [["on"], ["on"]])
+    }
+
+    func testMutationCoordinatorDropsCanceledQueuedRequest() async {
+        let runner = BlockingFirstRunner()
+        let coordinator = MutationCoordinator(runner: runner)
+        let firstRequest = CLIExecutionRequest(
+            binary: URL(fileURLWithPath: "/usr/bin/true"),
+            arguments: ["first"],
+            environment: [:],
+            timeout: 1)
+        let secondRequest = CLIExecutionRequest(
+            binary: URL(fileURLWithPath: "/usr/bin/true"),
+            arguments: ["stale"],
+            environment: [:],
+            timeout: 1)
+
+        let first = Task { await coordinator.perform(firstRequest) }
+        await runner.waitUntilFirstStarted()
+        let stale = Task { await coordinator.perform(secondRequest) }
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        stale.cancel()
+        let staleResult = await stale.value
+        await runner.releaseFirst()
+        _ = await first.value
+
+        XCTAssertEqual(staleResult.status, -1)
+        let calls = await runner.arguments
+        XCTAssertEqual(calls, [["first"]])
     }
 
     func testSuccessfulCLIWithUnchangedFamilyStateIsNotConfirmed() {
@@ -732,6 +1587,103 @@ final class RuntimeCoordinationTests: XCTestCase {
     }
 
     @MainActor
+    func testTargetlessReplayUsesSelectedFallbackAdapterClient() async {
+        let reader = SequencedAdminReader(statuses: [
+            previewStatus(
+                generation: 4,
+                hash: "sha256:old",
+                familyTarget: "zai-org/GLM-5.2",
+                clientName: "anthropic"),
+            previewStatus(
+                generation: 5,
+                hash: "sha256:new",
+                familyTarget: "native",
+                clientName: "anthropic"),
+        ])
+        let runner = ReconciliationReceiptRunner(
+            clientOverride: "anthropic")
+        let state = BasetenSwitchState(
+            variant: previewVariant(),
+            reader: reader,
+            cliRunner: runner,
+            loginItemService: FakeLoginItemService(),
+            previewRuntimeValidator: { _ in nil },
+            startPolling: false)
+        await state.refresh()
+        let client = try! XCTUnwrap(state.clients.first)
+
+        await state.routeFamily(client, family: "opus", choice: .native)
+
+        XCTAssertNil(state.lastError)
+        state.stop()
+    }
+
+    @MainActor
+    func testTargetlessTerminalReplayRequiresMatchingExactFingerprint() async {
+        let reader = SequencedAdminReader(statuses: [
+            previewStatus(
+                generation: 4,
+                hash: "sha256:old",
+                familyTarget: "zai-org/GLM-5.2"),
+            previewStatus(
+                generation: 5,
+                hash: "sha256:new",
+                familyTarget: "native"),
+        ])
+        let runner = ReconciliationReceiptRunner(
+            reconciledFingerprint:
+                "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+        let state = BasetenSwitchState(
+            variant: previewVariant(),
+            reader: reader,
+            cliRunner: runner,
+            loginItemService: FakeLoginItemService(),
+            previewRuntimeValidator: { _ in nil },
+            startPolling: false)
+        await state.refresh()
+        let client = try! XCTUnwrap(state.clients.first)
+
+        await state.routeFamily(client, family: "opus", choice: .native)
+
+        XCTAssertEqual(
+            state.lastError,
+            "Opus mapping was not present in the active router state.")
+        state.stop()
+    }
+
+    @MainActor
+    func testTerminalFingerprintMustBindTheDispatchedRequest() async {
+        let reader = SequencedAdminReader(statuses: [
+            previewStatus(
+                generation: 4,
+                hash: "sha256:old",
+                familyTarget: "zai-org/GLM-5.2"),
+            previewStatus(
+                generation: 5,
+                hash: "sha256:new",
+                familyTarget: "native"),
+        ])
+        let runner = ReconciliationReceiptRunner(
+            primaryTargetOverride: "different-target")
+        let state = BasetenSwitchState(
+            variant: previewVariant(),
+            reader: reader,
+            cliRunner: runner,
+            loginItemService: FakeLoginItemService(),
+            previewRuntimeValidator: { _ in nil },
+            startPolling: false)
+        await state.refresh()
+        let client = try! XCTUnwrap(state.clients.first)
+
+        await state.routeFamily(client, family: "opus", choice: .native)
+
+        XCTAssertEqual(
+            state.lastError,
+            "Opus mapping was not present in the active router state.")
+        state.stop()
+    }
+
+    @MainActor
     func testSubagentMutationUsesCASAndReconcilesBeforeClearingPending() async {
         let reader = SequencedAdminReader(statuses: [
             previewStatus(
@@ -817,6 +1769,77 @@ final class RuntimeCoordinationTests: XCTestCase {
         }
         XCTAssertFalse(state.canMutateRouting)
         state.stop()
+    }
+
+    private func recoveryResult(
+        ok: Bool,
+        classification: String = "",
+        errorCode: String = "",
+        status: Int32 = 0,
+        cleanupPending: Bool = false,
+        errorRetryable: Bool? = nil,
+        timedOut: Bool = false
+    ) -> CLIExecutionResult {
+        var object: [String: Any] = [
+            "ok": ok,
+            "classification": classification,
+            "cleanup_pending": cleanupPending,
+            "error": NSNull(),
+        ]
+        if !errorCode.isEmpty {
+            object["error"] = [
+                "code": errorCode,
+                "message": "private backend detail must not be displayed",
+                "retryable": errorRetryable
+                    ?? (errorCode == "mutation_locked"
+                        || errorCode == "router_unavailable"),
+            ]
+        }
+        let data = try! JSONSerialization.data(withJSONObject: object)
+        return CLIExecutionResult(
+            status: status,
+            standardOutput: String(decoding: data, as: UTF8.self),
+            standardError: "",
+            timedOut: timedOut)
+    }
+
+    private func recoveryStatusResult(
+        classification: String,
+        errorCode: String = "",
+        status: Int32 = 0
+    ) -> CLIExecutionResult {
+        var object: [String: Any] = [
+            "classification": classification,
+        ]
+        if !errorCode.isEmpty {
+            object["error"] = [
+                "code": errorCode,
+                "message": "reviewed status text",
+                "retryable": errorCode == "mutation_locked",
+            ]
+        }
+        let data = try! JSONSerialization.data(withJSONObject: object)
+        return CLIExecutionResult(
+            status: status,
+            standardOutput: String(decoding: data, as: UTF8.self),
+            standardError: "",
+            timedOut: false)
+    }
+
+    @MainActor
+    private func mutationTestState(
+        runner: any CLIRunning
+    ) -> BasetenSwitchState {
+        BasetenSwitchState(
+            variant: previewVariant(),
+            reader: CountingAdminReader(status: previewStatus(
+                generation: 4,
+                hash: "sha256:active",
+                familyTarget: "native")),
+            cliRunner: runner,
+            loginItemService: FakeLoginItemService(),
+            previewRuntimeValidator: { _ in nil },
+            startPolling: false)
     }
 
     private func argumentValue(_ flag: String,


### PR DESCRIPTION
## What

- Persist durable routing-mutation receipts and surface-bound request fingerprints so exact retries can replay completed results safely.
- Add read-only mutation status and cleanup-only recovery commands, with fail-closed handling for malformed, conflicting, or incomplete recovery state.
- Integrate recovery with doctor and the macOS app so unresolved mutations gate new routing changes and automatic startup.
- Preserve compatibility with existing version 1 active journals.

## Why

An interrupted mutation or lost command receipt can leave a valid recovery journal after routing has already reached a definitive state. That journal blocks later routing changes, while deleting it without verifying config and router state would be unsafe. This change makes definitive outcomes replayable and automates only cleanup that can be proven safe.

## Testing

- `scripts/check.sh`
- `cd gateway && go test ./... -count=1`
- `cd mac/BasetenSwitch && swift test`

The full repository gate passed with 24 Go packages, 234 Swift tests, the candidate source secret scan, builds, and scratch lifecycle smokes.

## Security and privacy

Recovery remains local and adds no external dependency, telemetry, or network destination. Terminal records omit config bytes, config paths, requested target plaintext, and raw backend errors; files and directories are permission-checked and size-bounded. Automatic recovery only removes state whose outcome is confirmed by authoritative config and router state. Ambiguous state remains preserved for explicit reconciliation.
