### PR TITLE
menubar: resize status icon and pulse during requests

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -53,6 +53,20 @@ request coalescing, and navigation. Nothing drives live AppKit behavior
 Release validation also covers the packaged app, accessibility, and
 performance.
 
+To inspect the status-item icon without a gateway or model request, run one of
+the debug fixtures below and stop it with Ctrl-C:
+
+```sh
+scripts/preview-menubar-icon.sh idle
+scripts/preview-menubar-icon.sh active
+scripts/preview-menubar-icon.sh degraded
+scripts/preview-menubar-icon.sh activity
+```
+
+`activity` forces the same pulsing green presentation used while an inference
+request is in flight. These fixtures use the side-effect-free Swift preview
+state: they do not poll localhost, read credentials, or send network traffic.
+
 ## Layer 2: the `check.sh` gate
 
 ```sh

--- a/gateway/cmd/gateway/admin.go
+++ b/gateway/cmd/gateway/admin.go
@@ -566,6 +566,7 @@ func (g *Gateway) adminStatus(w http.ResponseWriter, r *http.Request) {
 			"error": reloadErr,
 		},
 		"global_routing_enabled": globalEnabled,
+		"active_requests":        g.activeRequests.Load(),
 		"uptime_seconds":         g.uptimeSeconds(),
 		"version":                version.Version,
 		// Mutation clients must target the exact file this process has

--- a/gateway/cmd/gateway/gateway.go
+++ b/gateway/cmd/gateway/gateway.go
@@ -585,6 +585,9 @@ type Gateway struct {
 	activeConfigHash string
 	activeConfigFile *config.File
 	reloadError      string
+	// activeRequests is intentionally aggregate-only: the menubar needs a
+	// transient activity signal, not request contents or client identity.
+	activeRequests atomic.Int64
 
 	wg  sync.WaitGroup
 	ctx context.Context
@@ -1275,6 +1278,10 @@ func (lg *listenerGroup) resolveClient(r *http.Request) *clientListener {
 func (g *Gateway) handleClient(cl *clientListener, w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Path
 	shape := cl.cfg.ProtocolShape
+	if isInferenceRequest(shape, r.Method, path) {
+		g.activeRequests.Add(1)
+		defer g.activeRequests.Add(-1)
+	}
 	switch r.Method {
 	case http.MethodGet:
 		switch path {
@@ -1341,6 +1348,23 @@ func (g *Gateway) handleClient(cl *clientListener, w http.ResponseWriter, r *htt
 		proxy.DrainBody(r)
 		g.reject(w, 405, "method not allowed: "+r.Method)
 		return
+	}
+}
+
+// isInferenceRequest excludes health and model-discovery traffic so the
+// menubar pulse represents a harness exchanging model data, not background
+// probes. The counter spans the full handler lifetime, including streaming.
+func isInferenceRequest(shape, method, path string) bool {
+	if method != http.MethodPost {
+		return false
+	}
+	switch shape {
+	case "anthropic":
+		return path == "/v1/messages" || path == "/v1/messages/count_tokens"
+	case "openai":
+		return path == "/v1/chat/completions" || path == "/v1/responses"
+	default:
+		return false
 	}
 }
 

--- a/gateway/cmd/gateway/gateway_test.go
+++ b/gateway/cmd/gateway/gateway_test.go
@@ -425,6 +425,104 @@ func TestCountTokensSynthetic(t *testing.T) {
 	}
 }
 
+func TestIsInferenceRequest(t *testing.T) {
+	tests := []struct {
+		shape  string
+		method string
+		path   string
+		want   bool
+	}{
+		{"anthropic", http.MethodPost, "/v1/messages", true},
+		{"anthropic", http.MethodPost, "/v1/messages/count_tokens", true},
+		{"openai", http.MethodPost, "/v1/chat/completions", true},
+		{"openai", http.MethodPost, "/v1/responses", true},
+		{"anthropic", http.MethodGet, "/v1/models", false},
+		{"anthropic", http.MethodGet, "/healthz", false},
+		{"openai", http.MethodPost, "/v1/messages", false},
+	}
+	for _, test := range tests {
+		if got := isInferenceRequest(test.shape, test.method, test.path); got != test.want {
+			t.Errorf("isInferenceRequest(%q, %q, %q) = %t, want %t",
+				test.shape, test.method, test.path, got, test.want)
+		}
+	}
+}
+
+func TestAdminStatusReportsActiveInferenceRequests(t *testing.T) {
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseRequest := func() { releaseOnce.Do(func() { close(release) }) }
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		started <- struct{}{}
+		<-release
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"zai-org/GLM-5.2","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	t.Cleanup(func() {
+		releaseRequest()
+		srv.Close()
+	})
+
+	cfg := testConfig(t, srv.URL, srv.URL)
+	g, adminL, _ := newGateway(t, cfg, resolvedAnthropicBaseten(t))
+	defer adminL.Close()
+	stop := start(t, g)
+	defer stop()
+	defer releaseRequest()
+
+	completed := make(chan int, 1)
+	go func() {
+		body := strings.NewReader(`{"model":"claude-opus-4-8","stream":false,"messages":[{"role":"user","content":"ping"}]}`)
+		req, _ := http.NewRequest(http.MethodPost,
+			clientURL(g, "claude-code", "/v1/messages"), body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer tok")
+		req.Header.Set("Anthropic-Version", "2023-06-01")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			completed <- 0
+			return
+		}
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		completed <- resp.StatusCode
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("inference request did not reach upstream")
+	}
+
+	resp, err := http.Get(adminURL(g, "/v1/admin/status"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var status map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		resp.Body.Close()
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if got := status["active_requests"]; got != float64(1) {
+		t.Fatalf("active_requests = %v, want 1", got)
+	}
+
+	releaseRequest()
+	select {
+	case code := <-completed:
+		if code != http.StatusOK {
+			t.Fatalf("inference response status = %d, want 200", code)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("inference request did not complete")
+	}
+	if got := g.activeRequests.Load(); got != 0 {
+		t.Fatalf("activeRequests after completion = %d, want 0", got)
+	}
+}
+
 func TestPostMessagesBasetenForwardsRewrittenModel(t *testing.T) {
 	gotModel := make(chan string, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/BasetenSwitchApp.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/BasetenSwitchApp.swift
@@ -10,6 +10,13 @@ enum AppColors {
         alpha: 1.0)
 }
 
+enum MenubarIconMetrics {
+    static let canvas = NSSize(width: 18, height: 18)
+    static let glyph = NSSize(width: 11.5, height: 11.5)
+    static let borderWidth: CGFloat = 1
+    static let cornerRadius: CGFloat = 3.75
+}
+
 /// Native menu-bar shell: AppKit owns the NSStatusItem and NSMenu via
 /// StatusItemController. The SwiftUI App struct only hosts the delegate
 /// adaptor and the single-instance guard.
@@ -47,23 +54,21 @@ struct BasetenSwitchApp: App {
         Settings { EmptyView() }
     }
 
-    /// The Baseten logo as a native template image. AppKit derives the
-    /// glyph from the SVG's alpha so it adapts to light/dark and menu
-    /// highlight states. The packaged app loads it from Resources; the
-    /// source-tree candidate keeps bare Swift builds useful in development.
-    static let menubarIcon: NSImage = {
+    /// The Baseten logo loaded from the packaged resource or source tree.
+    private static let menubarLogo: NSImage = {
         guard let url = menubarIconResourceURL(),
               let img = NSImage(contentsOf: url) else {
             return NSImage(systemSymbolName: "circle.lefthalf.filled",
                            accessibilityDescription: "Baseten Switch") ?? NSImage()
         }
-        img.isTemplate = true
-        // Match the previous 22pt PNG canvas, whose logo occupied 27 of
-        // its 36 pixels. The SVG has no equivalent outer padding, so its
-        // image size is the old logo's effective 16.5pt footprint.
-        img.size = NSSize(width: 16.5, height: 16.5)
         return img
     }()
+
+    /// An 18pt rounded-square template mark. The 11.5pt Baseten glyph leaves
+    /// enough negative space that it matches neighboring system extras
+    /// optically; the thin frame gives it a bounded silhouette similar to
+    /// Notion's status item without relying on a literal light/dark color.
+    static let menubarIcon = framedMenubarIcon(menubarLogo)
 
     static func menubarIconResourceURL() -> URL? {
         if let bundled = Bundle.main.url(forResource: "baseten-logo-white",
@@ -80,6 +85,33 @@ struct BasetenSwitchApp: App {
         return FileManager.default.fileExists(atPath: sourceAsset.path)
             ? sourceAsset
             : nil
+    }
+
+    static func framedMenubarIcon(_ logo: NSImage) -> NSImage {
+        let image = NSImage(size: MenubarIconMetrics.canvas)
+        image.lockFocus()
+        NSGraphicsContext.current?.imageInterpolation = .high
+
+        let canvas = NSRect(origin: .zero, size: MenubarIconMetrics.canvas)
+        let borderRect = canvas.insetBy(dx: 0.75, dy: 0.75)
+        let border = NSBezierPath(
+            roundedRect: borderRect,
+            xRadius: MenubarIconMetrics.cornerRadius,
+            yRadius: MenubarIconMetrics.cornerRadius)
+        border.lineWidth = MenubarIconMetrics.borderWidth
+        NSColor.black.setStroke()
+        border.stroke()
+
+        let glyphOrigin = NSPoint(
+            x: (canvas.width - MenubarIconMetrics.glyph.width) / 2,
+            y: (canvas.height - MenubarIconMetrics.glyph.height) / 2)
+        logo.draw(in: NSRect(
+            origin: glyphOrigin,
+            size: MenubarIconMetrics.glyph))
+
+        image.unlockFocus()
+        image.isTemplate = true
+        return image
     }
 
     /// Baseten brand green (#16D766). The active icon is a pre-tinted
@@ -113,7 +145,7 @@ struct BasetenSwitchApp: App {
             blue: 0x23 / 255.0,
             alpha: 1.0))
 
-    /// Production Preview keeps the same 16.5pt optical footprint as Stable,
+    /// Production Preview keeps the same 18pt optical footprint as Stable,
     /// but adds a small lower-right dot so both status items remain
     /// distinguishable when they run side by side.
     static func menubarIcon(for variant: AppVariant,
@@ -138,8 +170,8 @@ struct BasetenSwitchApp: App {
         let rect = NSRect(origin: .zero, size: base.size)
         base.draw(in: rect)
         NSColor.black.setFill()
-        NSBezierPath(ovalIn: NSRect(x: 12.0, y: 0.5,
-                                    width: 4.0, height: 4.0)).fill()
+        NSBezierPath(ovalIn: NSRect(x: 13.75, y: 0.25,
+                                    width: 3.75, height: 3.75)).fill()
         image.unlockFocus()
         image.isTemplate = true
         return image
@@ -242,8 +274,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         let variant = AppVariant.current()
         let state = BasetenSwitchState(preview: fixture, variant: variant)
+        let forceActivity =
+            ProcessInfo.processInfo.environment["BASETEN_SWITCH_MENUBAR_ACTIVITY"] == "1"
         let controller = StatusItemController(
-            state: state, variant: variant, isPreview: true)
+            state: state,
+            variant: variant,
+            isPreview: true,
+            forceActivity: forceActivity)
         self.state = state
         previewController = controller
         let hasHostWindow =
@@ -263,9 +300,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             host.makeKeyAndOrderFront(nil)
             previewHostWindow = host
         }
-        let menuDelay = hasHostWindow ? 2.0 : 0.35
-        DispatchQueue.main.asyncAfter(deadline: .now() + menuDelay) {
-            controller.openForPreview()
+        if ProcessInfo.processInfo.environment["BASETEN_SWITCH_POPUP_AUTO_OPEN"] != "0" {
+            let menuDelay = hasHostWindow ? 2.0 : 0.35
+            DispatchQueue.main.asyncAfter(deadline: .now() + menuDelay) {
+                controller.openForPreview()
+            }
         }
     }
 

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/BasetenSwitchApp.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/BasetenSwitchApp.swift
@@ -11,10 +11,7 @@ enum AppColors {
 }
 
 enum MenubarIconMetrics {
-    static let canvas = NSSize(width: 18, height: 18)
-    static let glyph = NSSize(width: 11.5, height: 11.5)
-    static let borderWidth: CGFloat = 1
-    static let cornerRadius: CGFloat = 3.75
+    static let size = NSSize(width: 20, height: 20)
 }
 
 /// Native menu-bar shell: AppKit owns the NSStatusItem and NSMenu via
@@ -54,21 +51,19 @@ struct BasetenSwitchApp: App {
         Settings { EmptyView() }
     }
 
-    /// The Baseten logo loaded from the packaged resource or source tree.
-    private static let menubarLogo: NSImage = {
+    /// The Baseten logo as a 20pt native template image. The SVG's own
+    /// view-box padding leaves a roughly 16pt visible glyph, matching the
+    /// optical height of neighboring standalone menu-bar symbols.
+    static let menubarIcon: NSImage = {
         guard let url = menubarIconResourceURL(),
               let img = NSImage(contentsOf: url) else {
             return NSImage(systemSymbolName: "circle.lefthalf.filled",
                            accessibilityDescription: "Baseten Switch") ?? NSImage()
         }
+        img.size = MenubarIconMetrics.size
+        img.isTemplate = true
         return img
     }()
-
-    /// An 18pt rounded-square template mark. The 11.5pt Baseten glyph leaves
-    /// enough negative space that it matches neighboring system extras
-    /// optically; the thin frame gives it a bounded silhouette similar to
-    /// Notion's status item without relying on a literal light/dark color.
-    static let menubarIcon = framedMenubarIcon(menubarLogo)
 
     static func menubarIconResourceURL() -> URL? {
         if let bundled = Bundle.main.url(forResource: "baseten-logo-white",
@@ -85,33 +80,6 @@ struct BasetenSwitchApp: App {
         return FileManager.default.fileExists(atPath: sourceAsset.path)
             ? sourceAsset
             : nil
-    }
-
-    static func framedMenubarIcon(_ logo: NSImage) -> NSImage {
-        let image = NSImage(size: MenubarIconMetrics.canvas)
-        image.lockFocus()
-        NSGraphicsContext.current?.imageInterpolation = .high
-
-        let canvas = NSRect(origin: .zero, size: MenubarIconMetrics.canvas)
-        let borderRect = canvas.insetBy(dx: 0.75, dy: 0.75)
-        let border = NSBezierPath(
-            roundedRect: borderRect,
-            xRadius: MenubarIconMetrics.cornerRadius,
-            yRadius: MenubarIconMetrics.cornerRadius)
-        border.lineWidth = MenubarIconMetrics.borderWidth
-        NSColor.black.setStroke()
-        border.stroke()
-
-        let glyphOrigin = NSPoint(
-            x: (canvas.width - MenubarIconMetrics.glyph.width) / 2,
-            y: (canvas.height - MenubarIconMetrics.glyph.height) / 2)
-        logo.draw(in: NSRect(
-            origin: glyphOrigin,
-            size: MenubarIconMetrics.glyph))
-
-        image.unlockFocus()
-        image.isTemplate = true
-        return image
     }
 
     /// Baseten brand green (#16D766). The active icon is a pre-tinted
@@ -145,7 +113,7 @@ struct BasetenSwitchApp: App {
             blue: 0x23 / 255.0,
             alpha: 1.0))
 
-    /// Production Preview keeps the same 18pt optical footprint as Stable,
+    /// Production Preview keeps the same 20pt optical footprint as Stable,
     /// but adds a small lower-right dot so both status items remain
     /// distinguishable when they run side by side.
     static func menubarIcon(for variant: AppVariant,
@@ -170,7 +138,7 @@ struct BasetenSwitchApp: App {
         let rect = NSRect(origin: .zero, size: base.size)
         base.draw(in: rect)
         NSColor.black.setFill()
-        NSBezierPath(ovalIn: NSRect(x: 13.75, y: 0.25,
+        NSBezierPath(ovalIn: NSRect(x: 15.75, y: 0.25,
                                     width: 3.75, height: 3.75)).fill()
         image.unlockFocus()
         image.isTemplate = true

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/BasetenSwitchState.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/BasetenSwitchState.swift
@@ -132,6 +132,7 @@ final class BasetenSwitchState: ObservableObject {
     var uptimeSeconds: Int64 {
         projectedUptimeSeconds(snapshot: routingSnapshot, now: Date())
     }
+    var activeRequests: Int { routingSnapshot?.activeRequests ?? 0 }
     var routerVersion: String { routingSnapshot?.version ?? "" }
     var auth: AuthStatus? { routingSnapshot?.auth }
     var activeConfigPath: String { routingSnapshot?.configPath ?? "" }
@@ -184,7 +185,10 @@ final class BasetenSwitchState: ObservableObject {
         let poll = PollCoordinator(
             reader: self.reader,
             clock: clock,
-            interval: 5)
+            // Model calls are usually long-lived streams. A one-second local
+            // status read makes their activity visible without a new event
+            // channel or high-frequency polling.
+            interval: 1)
         pollCoordinator = poll
         mutationCoordinator = MutationCoordinator(runner: cliRunner)
 
@@ -1802,6 +1806,7 @@ func routingPresentationEqual(_ lhs: RoutingSnapshot,
         && lhs.gateway == rhs.gateway
         && lhs.health == rhs.health
         && lhs.version == rhs.version
+        && lhs.activeRequests == rhs.activeRequests
         && lhs.configPath == rhs.configPath
         && lhs.capabilities == rhs.capabilities
         && lhs.globalRoutingEnabled == rhs.globalRoutingEnabled

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/Display.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/Display.swift
@@ -23,6 +23,13 @@ enum MenubarIconState: Equatable {
     case degraded
 }
 
+/// In-flight model traffic temporarily takes over the status color. Once the
+/// request completes, the persistent routing/degraded projection returns.
+func menubarIconState(_ persistent: MenubarIconState,
+                      hasActivity: Bool) -> MenubarIconState {
+    hasActivity ? .active : persistent
+}
+
 /// auth defaults to nil (unknown), so an unavailable admin auth block does not
 /// claim that reauthentication is required.
 func menubarIconState(gatewayUp: Bool, clients: [ClientStatus],

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/GatewayClient.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/GatewayClient.swift
@@ -34,6 +34,7 @@ struct RoutingSnapshot: Equatable, Sendable {
     let health: String
     let version: String
     let uptimeSeconds: Int64
+    let activeRequests: Int
     let configPath: String
     let capabilities: Set<String>
     let globalRoutingEnabled: Bool
@@ -60,6 +61,7 @@ struct RoutingSnapshot: Equatable, Sendable {
         health = status.health
         version = status.version
         uptimeSeconds = status.uptimeSeconds
+        activeRequests = status.activeRequests
         configPath = status.configPath
         capabilities = Set(status.capabilities)
         globalRoutingEnabled = status.globalRoutingEnabled
@@ -71,6 +73,7 @@ struct RoutingSnapshot: Equatable, Sendable {
     init(observedAt: Date,
          version: String,
          uptimeSeconds: Int64,
+         activeRequests: Int = 0,
          globalRoutingEnabled: Bool,
          auth: AuthStatus?,
          clients: [ClientStatus]) {
@@ -82,6 +85,7 @@ struct RoutingSnapshot: Equatable, Sendable {
         health = "ready"
         self.version = version
         self.uptimeSeconds = uptimeSeconds
+        self.activeRequests = activeRequests
         configPath = ""
         capabilities = []
         self.globalRoutingEnabled = globalRoutingEnabled
@@ -617,6 +621,7 @@ struct AdminStatusSnapshot: Equatable, Sendable {
     var health: String
     var version: String
     var uptimeSeconds: Int64
+    var activeRequests: Int
     var configPath: String
     var reload: ReloadStatus
     var globalRoutingEnabled: Bool
@@ -634,6 +639,7 @@ struct AdminStatusSnapshot: Equatable, Sendable {
         health = dict["health"] as? String ?? "ready"
         version = dict["version"] as? String ?? ""
         uptimeSeconds = (dict["uptime_seconds"] as? NSNumber)?.int64Value ?? 0
+        activeRequests = (dict["active_requests"] as? NSNumber)?.intValue ?? 0
         configPath = dict["config_path"] as? String ?? ""
         reload = (dict["reload"] as? [String: Any])
             .map(ReloadStatus.init)

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/RuntimeCoordination.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/RuntimeCoordination.swift
@@ -68,7 +68,7 @@ actor PollCoordinator {
          interval: TimeInterval = 5) {
         self.reader = reader
         self.clock = clock
-        self.interval = max(interval, 5)
+        self.interval = max(interval, 0.5)
     }
 
     func start(handler: @escaping Handler) {

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/StatusItemController.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/StatusItemController.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Combine
+import QuartzCore
 
 /// AppKit owns the status item, menu tracking, keyboard behavior, and the
 /// native global switch. The menu is rebuilt only immediately before a
@@ -10,6 +11,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     private let state: BasetenSwitchState
     private let variant: AppVariant
     private let isPreview: Bool
+    private let forceActivity: Bool
     private let openConfiguration: (String?) -> Void
     private let openTraffic: () -> Void
     private let statusItem: NSStatusItem
@@ -18,16 +20,19 @@ final class StatusItemController: NSObject, NSMenuDelegate {
     private var menuIsOpen = false
     private var menuNeedsRebuild = true
     private var displayedIconState: MenubarIconState?
+    private var displayedActivity: Bool?
     private weak var headerView: StatusMenuHeaderView?
 
     init(state: BasetenSwitchState,
          variant: AppVariant = .current(),
          isPreview: Bool = false,
+         forceActivity: Bool = false,
          openConfiguration: @escaping (String?) -> Void = { _ in },
          openTraffic: @escaping () -> Void = {}) {
         self.state = state
         self.variant = variant
         self.isPreview = isPreview
+        self.forceActivity = forceActivity
         self.openConfiguration = openConfiguration
         self.openTraffic = openTraffic
         statusItem = NSStatusBar.system.statusItem(
@@ -405,11 +410,42 @@ final class StatusItemController: NSObject, NSMenuDelegate {
             globalRoutingEnabled: state.confirmedGlobalRoutingEnabled,
             clients: state.clients,
             auth: state.auth)
-        guard projected != displayedIconState else { return }
+        let hasActivity = forceActivity || state.activeRequests > 0
+        guard projected != displayedIconState
+                || hasActivity != displayedActivity else { return }
         displayedIconState = projected
+        displayedActivity = hasActivity
         statusItem.button?.image = BasetenSwitchApp.menubarIcon(
             for: variant,
-            state: projected)
+            state: menubarIconState(projected, hasActivity: hasActivity))
+        updateActivityPulse(hasActivity)
+    }
+
+    private func updateActivityPulse(_ active: Bool) {
+        guard let button = statusItem.button else { return }
+        let animationKey = "baseten-switch.activityPulse"
+        button.layer?.removeAnimation(forKey: animationKey)
+        button.alphaValue = 1
+        button.toolTip = active
+            ? "\(variant.displayName) is sending or receiving data"
+            : variant.displayName
+        button.setAccessibilityLabel(active
+            ? "\(variant.displayName), sending or receiving data"
+            : variant.displayName)
+
+        guard active,
+              !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion else {
+            return
+        }
+        button.wantsLayer = true
+        let animation = CABasicAnimation(keyPath: "opacity")
+        animation.fromValue = 1.0
+        animation.toValue = 0.35
+        animation.duration = 0.7
+        animation.autoreverses = true
+        animation.repeatCount = .infinity
+        animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        button.layer?.add(animation, forKey: animationKey)
     }
 }
 

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/DisplayTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/DisplayTests.swift
@@ -201,7 +201,8 @@ final class DisplayTests: XCTestCase {
         XCTAssertEqual(resourceURL?.lastPathComponent, "baseten-logo-white.svg")
         XCTAssertTrue(BasetenSwitchApp.menubarIcon.isTemplate)
         XCTAssertEqual(BasetenSwitchApp.menubarIcon.size,
-                       NSSize(width: 16.5, height: 16.5))
+                       NSSize(width: 18, height: 18))
+        XCTAssertNotNil(BasetenSwitchApp.menubarIcon.tiffRepresentation)
     }
 
     func testClientBrandMarksUseOfficialMonochromeIdentities() throws {
@@ -554,7 +555,9 @@ final class DisplayTests: XCTestCase {
     }
 
     func testPresentationEqualityIgnoresMonotonicUptimePolls() {
-        func snapshot(uptime: Int64, observedAt: TimeInterval)
+        func snapshot(uptime: Int64,
+                      observedAt: TimeInterval,
+                      activeRequests: Int = 0)
             -> RoutingSnapshot {
             RoutingSnapshot(
                 status: AdminStatusSnapshot(dict: [
@@ -565,6 +568,7 @@ final class DisplayTests: XCTestCase {
                     "health": "ready",
                     "version": "v1",
                     "uptime_seconds": NSNumber(value: uptime),
+                    "active_requests": NSNumber(value: activeRequests),
                                         "capabilities": ["global_routing"],
                     "global_routing_enabled": true,
                     "clients": [],
@@ -575,6 +579,9 @@ final class DisplayTests: XCTestCase {
         XCTAssertTrue(routingPresentationEqual(
             snapshot(uptime: 100, observedAt: 1_000),
             snapshot(uptime: 105, observedAt: 1_005)))
+        XCTAssertFalse(routingPresentationEqual(
+            snapshot(uptime: 100, observedAt: 1_000),
+            snapshot(uptime: 101, observedAt: 1_001, activeRequests: 1)))
         XCTAssertEqual(
             projectedUptimeSeconds(
                 snapshot: snapshot(uptime: 100, observedAt: 1_000),
@@ -875,7 +882,7 @@ final class DisplayTests: XCTestCase {
             environment: [:])
         let image = BasetenSwitchApp.menubarIcon(for: preview)
 
-        XCTAssertEqual(image.size, NSSize(width: 16.5, height: 16.5))
+        XCTAssertEqual(image.size, NSSize(width: 18, height: 18))
         XCTAssertTrue(image.isTemplate)
     }
 
@@ -960,6 +967,12 @@ final class DisplayTests: XCTestCase {
                                         clients: [client("claude-code", route: "anthropic")]),
                        .off)
         XCTAssertEqual(menubarIconState(gatewayUp: true, clients: []), .off)
+    }
+
+    func testMenubarActivityTemporarilyUsesActiveColor() {
+        XCTAssertEqual(menubarIconState(.off, hasActivity: true), .active)
+        XCTAssertEqual(menubarIconState(.degraded, hasActivity: true), .active)
+        XCTAssertEqual(menubarIconState(.degraded, hasActivity: false), .degraded)
     }
 
     private func authWithHealth(_ health: String) -> AuthStatus {

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/DisplayTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/DisplayTests.swift
@@ -201,7 +201,7 @@ final class DisplayTests: XCTestCase {
         XCTAssertEqual(resourceURL?.lastPathComponent, "baseten-logo-white.svg")
         XCTAssertTrue(BasetenSwitchApp.menubarIcon.isTemplate)
         XCTAssertEqual(BasetenSwitchApp.menubarIcon.size,
-                       NSSize(width: 18, height: 18))
+                       NSSize(width: 20, height: 20))
         XCTAssertNotNil(BasetenSwitchApp.menubarIcon.tiffRepresentation)
     }
 
@@ -882,7 +882,7 @@ final class DisplayTests: XCTestCase {
             environment: [:])
         let image = BasetenSwitchApp.menubarIcon(for: preview)
 
-        XCTAssertEqual(image.size, NSSize(width: 18, height: 18))
+        XCTAssertEqual(image.size, NSSize(width: 20, height: 20))
         XCTAssertTrue(image.isTemplate)
     }
 

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/StatsTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/StatsTests.swift
@@ -110,7 +110,8 @@ final class StatsTests: XCTestCase {
     func testAdminStatusSnapshotDecodes() {
         let snap = AdminStatusSnapshot(dict: decode("""
         {
-          "uptime_seconds": 12, "version": "v0.2.1",
+          "uptime_seconds": 12, "active_requests": 2,
+          "version": "v0.2.1",
           "config_path": "/tmp/live/gateway.yaml",
           "global_routing_enabled": true,
           "auth": {"signed_in": true, "auth_type": "api_key", "profile": "example-profile",
@@ -121,6 +122,7 @@ final class StatsTests: XCTestCase {
         }
         """))
         XCTAssertEqual(snap.version, "v0.2.1")
+        XCTAssertEqual(snap.activeRequests, 2)
         XCTAssertEqual(snap.configPath, "/tmp/live/gateway.yaml")
         XCTAssertTrue(snap.globalRoutingEnabled)
         XCTAssertEqual(snap.auth?.signedIn, true)
@@ -137,6 +139,7 @@ final class StatsTests: XCTestCase {
     func testAdminStatusSnapshotAbsentKeys() {
         let snap = AdminStatusSnapshot(dict: decode("{}"))
         XCTAssertEqual(snap.version, "")
+        XCTAssertEqual(snap.activeRequests, 0)
         XCTAssertEqual(snap.configPath, "")
         XCTAssertNil(snap.auth)
         XCTAssertTrue(snap.clients.isEmpty)

--- a/scripts/preview-menubar-icon.sh
+++ b/scripts/preview-menubar-icon.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Render a side-effect-free debug status item without starting the gateway or
+# sending model traffic. Stop it with Ctrl-C.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+PACKAGE_DIR="$(dirname "$SCRIPT_DIR")/mac/BasetenSwitch"
+STATE="${1:-activity}"
+FIXTURE="native-off"
+FORCE_ACTIVITY=0
+
+case "$STATE" in
+    idle) ;;
+    active) FIXTURE="healthy" ;;
+    degraded) FIXTURE="fallback" ;;
+    activity) FORCE_ACTIVITY=1 ;;
+    *)
+        printf 'Usage: %s [idle|active|degraded|activity]\n' "$0" >&2
+        exit 2
+        ;;
+esac
+
+cd "$PACKAGE_DIR"
+exec env \
+    BASETEN_SWITCH_POPUP_PREVIEW="$FIXTURE" \
+    BASETEN_SWITCH_POPUP_AUTO_OPEN=0 \
+    BASETEN_SWITCH_MENUBAR_ACTIVITY="$FORCE_ACTIVITY" \
+    swift run BasetenSwitch


### PR DESCRIPTION
## What

- Sizes the borderless Baseten SVG at 20 pt. Its built-in view-box padding leaves a roughly 16 pt visible “B,” matching the optical height of neighboring macOS menu bar icons.
- Pulses the icon green while one or more model API requests are in flight.
- Adds side-effect-free fixtures for inspecting every icon state without credentials, a gateway, or model traffic.

## How it works

The gateway keeps an aggregate in-flight request count and publishes it as `active_requests` in `/v1/admin/status`. Only inference POSTs are counted (`/v1/messages`, `/v1/messages/count_tokens`, `/v1/chat/completions`, and `/v1/responses`); health checks and model discovery are excluded. The counter covers the full handler lifetime, including streaming responses, and does not retain prompts, responses, model names, or client identity.

The menu bar app reads the local admin status once per second. While `active_requests > 0`, activity temporarily takes precedence and the icon pulses from full to 35% opacity over 0.7 seconds, then reverses. Reduce Motion keeps the activity icon steady green. When the count returns to zero, the persistent routing state is restored.

- **Idle:** monochrome; the gateway is down or global Baseten routing is off.
- **Active:** steady green; global Baseten routing is on.
- **Degraded:** steady amber; an enabled client is using fallback or the stored Baseten credential needs reauthentication.
- **Activity:** pulsing green; at least one model request is in flight. The peak and trough below show the animation endpoints.

The leftmost borderless icon in each capture is this branch's isolated `BasetenSwitch` debug fixture. The older yellow icon farther right is the installed build and provides a direct size comparison.

## Screenshots

### Idle

![Idle menu bar icon](https://gist.githubusercontent.com/bleikamp/8c983eda2392ffea0a47866a0ca1d313/raw/aefbbee76195097175b7a5b12a8573b836c182e9/menubar-idle.svg)

### Active

![Active menu bar icon](https://gist.githubusercontent.com/bleikamp/8c983eda2392ffea0a47866a0ca1d313/raw/27e34608c58e7d3bd1924b2f0a79ab30e5e6af2c/menubar-active.svg)

### Degraded

![Degraded menu bar icon](https://gist.githubusercontent.com/bleikamp/8c983eda2392ffea0a47866a0ca1d313/raw/aa3430066aeee125d8a9696ec84091b5301d32ed/menubar-degraded.svg)

### Activity pulse

Peak:

![Activity pulse at full opacity](https://gist.githubusercontent.com/bleikamp/8c983eda2392ffea0a47866a0ca1d313/raw/0f87df4bc832d0a46c7c250bd9bf2c7c4c0b8c78/menubar-activity-peak.svg)

Trough:

![Activity pulse at reduced opacity](https://gist.githubusercontent.com/bleikamp/8c983eda2392ffea0a47866a0ca1d313/raw/ff123397cd25b867583dd00cdd600dd49866e1fe/menubar-activity-trough.svg)

## Testing without model traffic

```sh
scripts/preview-menubar-icon.sh idle
scripts/preview-menubar-icon.sh active
scripts/preview-menubar-icon.sh degraded
scripts/preview-menubar-icon.sh activity
```

Each command launches the same production icon rendering through a debug-only fixture, disables the popup, and skips localhost polling, credential reads, and network traffic. Stop it with Ctrl-C.

## Validation

- `scripts/check.sh --offline` — 24 Go packages, 235 Swift tests, binary build, and scratch gateway/door/lifecycle smokes passed for the feature branch.
- After the borderless sizing follow-up: `swift test` passed all 235 tests and `swift build -c release` passed.
- Manually rendered and inspected all four borderless fixtures, including both ends of the activity pulse.
- Each screenshot SVG returns HTTP 200, is valid XML, and contains one non-empty embedded PNG capture.

## Release requirements

- Pre-release: None.
- Post-release: None. The status field is backward compatible: older apps ignore it, and newer apps decode a missing field as zero.
- External communication: None.
