### PR TITLE
Show primary route for fallback requests

### DIFF
--- a/gateway/cmd/gateway/admin_requests.go
+++ b/gateway/cmd/gateway/admin_requests.go
@@ -38,6 +38,7 @@ type adminRequestRow struct {
 	TTFTMS               *int64                      `json:"ttft_ms"`
 	Subagent             bool                        `json:"subagent"`
 	Fallback             telemetry.FallbackV1        `json:"fallback"`
+	Primary              *telemetry.PrimaryV1        `json:"primary,omitempty"`
 }
 
 type adminRequestsCoverage struct {
@@ -182,6 +183,7 @@ func projectAdminRequest(event telemetry.EventV1) adminRequestRow {
 		TTFTMS:               event.TTFTMS,
 		Subagent:             event.Subagent,
 		Fallback:             event.Fallback,
+		Primary:              clonePrimaryV1(event.Primary),
 	}
 }
 

--- a/gateway/cmd/gateway/admin_requests_test.go
+++ b/gateway/cmd/gateway/admin_requests_test.go
@@ -147,6 +147,14 @@ func TestAdminRequestsProjectsFallbackAndNullableFields(t *testing.T) {
 		Count:     1,
 		Trigger:   &trigger,
 	}
+	primaryStatus := http.StatusBadRequest
+	event.Primary = &telemetry.PrimaryV1{
+		Provider:  "baseten",
+		Model:     "zai-org/GLM-5.2",
+		Attempted: true,
+		Outcome:   telemetry.PrimaryOutcomeImageInputUnsupported,
+		Status:    &primaryStatus,
+	}
 	writeAdminRequestEvents(t, dir, event)
 
 	recorder, response := requestAdminRequests(
@@ -178,7 +186,13 @@ func TestAdminRequestsProjectsFallbackAndNullableFields(t *testing.T) {
 		!row.Fallback.Attempted ||
 		row.Fallback.Count != 1 ||
 		row.Fallback.Trigger == nil ||
-		*row.Fallback.Trigger != trigger {
+		*row.Fallback.Trigger != trigger ||
+		row.Primary == nil ||
+		row.Primary.Provider != "baseten" ||
+		row.Primary.Model != "zai-org/GLM-5.2" ||
+		!row.Primary.Attempted ||
+		row.Primary.Outcome != telemetry.PrimaryOutcomeImageInputUnsupported ||
+		row.Primary.Status == nil || *row.Primary.Status != http.StatusBadRequest {
 		t.Fatalf("row = %+v", row)
 	}
 	body := recorder.Body.String()

--- a/gateway/cmd/gateway/gateway.go
+++ b/gateway/cmd/gateway/gateway.go
@@ -1975,6 +1975,9 @@ type upstreamAttempt struct {
 	// an earlier attempt failure, an active cooldown, or unavailable primary
 	// credentials. It flows into telemetry as fallback_trigger.
 	fallbackTrigger string
+	// primary retains the bounded primary-route outcome on the fallback that
+	// ultimately serves. It is nil for requests that never select fallback.
+	primary *telemetry.PrimaryV1
 	// origRequestedModel is the model the harness originally sent, before
 	// the subagent rewrite replaced it. Empty unless the subagent gate
 	// fired. When set, telemetry requested_model uses this instead of
@@ -2039,6 +2042,7 @@ const (
 	fallbackTriggerCooldown         = "cooldown"
 	fallbackTriggerAuthUnavailable  = "auth_unavailable"
 	fallbackTriggerImageUnsupported = "image_input_unsupported"
+	fallbackTriggerRequestBuild     = "request_build_error"
 )
 
 func allowsImageTranslationFallback(err error) bool {
@@ -2680,17 +2684,21 @@ func (g *Gateway) resolveAttemptsLadderWithSnapshot(
 			if perr == nil && g.fallbackActive(cl.cfg.Name) {
 				fba.fallbackCount = 1
 				fba.fallbackTrigger = fallbackTriggerCooldown
+				fba.primary = primarySummary(primary, false, telemetry.PrimaryOutcomeCooldown, nil)
 				attempts = []upstreamAttempt{fba}
 			} else {
 				if errors.Is(perr, errNeedsLogin) {
 					fba.fallbackCount = 1
 					fba.fallbackTrigger = fallbackTriggerAuthUnavailable
+					fba.primary = primarySummary(primary, false, telemetry.PrimaryOutcomeAuthUnavailable, nil)
 				} else if allowsImageTranslationFallback(perr) {
 					fba.fallbackCount = 1
 					fba.fallbackTrigger = fallbackTriggerImageUnsupported
+					fba.primary = primarySummary(primary, false, telemetry.PrimaryOutcomeImageInputUnsupported, nil)
 				} else if reasoning.AllowsFallback(perr) {
 					fba.fallbackCount = 1
 					fba.fallbackTrigger = "reasoning_policy_error"
+					fba.primary = primarySummary(primary, false, telemetry.PrimaryOutcomeReasoningPolicyError, nil)
 				}
 				attempts = append(attempts, fba)
 			}
@@ -2875,8 +2883,17 @@ func (g *Gateway) resolveModelRoutePrimaryWithSnapshot(
 		requested,
 		catalogFamily,
 	)
+	planned := upstreamAttempt{route: decision.route}
+	if decision.route == pricing.ProviderBaseten {
+		planned.modelForCost = decision.model
+		if !decision.forced {
+			rc := cl.cfg
+			rc.Route = pricing.ProviderBaseten
+			planned.modelForCost = g.upstreamModelFor(rc)
+		}
+	}
 	if decision.forced {
-		return g.buildAttemptTargetWithSnapshot(
+		at, err := g.buildAttemptTargetWithSnapshot(
 			snapshot,
 			requestedReasoning,
 			requestedObserved,
@@ -2888,8 +2905,12 @@ func (g *Gateway) resolveModelRoutePrimaryWithSnapshot(
 			decision.model,
 			true,
 		)
+		if err != nil && planned.modelForCost != "" {
+			return planned, err
+		}
+		return at, err
 	}
-	return g.buildAttemptWithSnapshot(
+	at, err := g.buildAttemptWithSnapshot(
 		snapshot,
 		requestedReasoning,
 		requestedObserved,
@@ -2899,6 +2920,28 @@ func (g *Gateway) resolveModelRoutePrimaryWithSnapshot(
 		decision.route,
 		kind,
 	)
+	if err != nil && planned.modelForCost != "" {
+		return planned, err
+	}
+	return at, err
+}
+
+func primarySummary(
+	primary upstreamAttempt,
+	attempted bool,
+	outcome string,
+	status *int,
+) *telemetry.PrimaryV1 {
+	if primary.route == "" || primary.modelForCost == "" {
+		return nil
+	}
+	return &telemetry.PrimaryV1{
+		Provider:  primary.route,
+		Model:     primary.modelForCost,
+		Attempted: attempted,
+		Outcome:   outcome,
+		Status:    cloneIntPointer(status),
+	}
 }
 
 // routeEffective returns the value for the telemetry route_effective
@@ -3049,18 +3092,21 @@ attemptLoop:
 		}
 
 		ttftExpired := false
+		attemptDispatched := false
 		var err error
 		for {
 			var classifierBody []byte
 			classifierReadAttempted := false
 			classifierBodyComplete := false
 			var watch upstreamTTFTWatch
-			resp, err, ttftExpired, watch = startUpstreamSubAttempt(
+			var dispatched bool
+			resp, err, ttftExpired, dispatched, watch = startUpstreamSubAttempt(
 				reqCtx,
 				at,
 				res.NewBody,
 				ttftDeadline,
 			)
+			attemptDispatched = attemptDispatched || dispatched
 			if ttftExpired || err != nil {
 				watch.stop()
 				watch.cancel()
@@ -3086,6 +3132,12 @@ attemptLoop:
 				}
 				attempts[i+1].fallbackTrigger =
 					fmt.Sprintf("http_%d", resp.StatusCode)
+				attempts[i+1].primary = primarySummary(
+					at,
+					true,
+					telemetry.PrimaryOutcomeHTTPError,
+					&resp.StatusCode,
+				)
 				continue attemptLoop
 			}
 
@@ -3163,6 +3215,12 @@ attemptLoop:
 					}
 					attempts[i+1].fallbackTrigger =
 						fallbackTriggerImageUnsupported
+					attempts[i+1].primary = primarySummary(
+						at,
+						true,
+						telemetry.PrimaryOutcomeImageInputUnsupported,
+						&resp.StatusCode,
+					)
 					continue attemptLoop
 				}
 			}
@@ -3196,7 +3254,19 @@ attemptLoop:
 					attempts[i+1].responsesCompatibility =
 						at.responsesCompatibility
 				}
-				attempts[i+1].fallbackTrigger = "transport_error"
+				fallbackTrigger := "transport_error"
+				primaryOutcome := telemetry.PrimaryOutcomeTransportError
+				if !attemptDispatched {
+					fallbackTrigger = fallbackTriggerRequestBuild
+					primaryOutcome = telemetry.PrimaryOutcomeRequestBuildError
+				}
+				attempts[i+1].fallbackTrigger = fallbackTrigger
+				attempts[i+1].primary = primarySummary(
+					at,
+					attemptDispatched,
+					primaryOutcome,
+					nil,
+				)
 				continue
 			}
 			g.reject(w, code, "upstream unreachable: "+err.Error())
@@ -3219,6 +3289,12 @@ attemptLoop:
 						at.responsesCompatibility
 				}
 				attempts[i+1].fallbackTrigger = fallbackTriggerTTFT
+				attempts[i+1].primary = primarySummary(
+					at,
+					attemptDispatched,
+					telemetry.PrimaryOutcomeTTFTTimeout,
+					nil,
+				)
 				continue
 			}
 			fmt.Fprintf(os.Stderr,

--- a/gateway/cmd/gateway/model_routes_test.go
+++ b/gateway/cmd/gateway/model_routes_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
 	"github.com/basetenlabs/baseten-switch/gateway/internal/pricing"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/telemetry"
 )
 
 // modelRoutesClient returns an anthropic-shape resolved client with
@@ -457,6 +458,14 @@ func TestModelRouteFallbackOriginalID(t *testing.T) {
 	// from the configured baseten route).
 	if rows[0].EffectiveProvider != "anthropic" {
 		t.Errorf("route_effective = %q, want anthropic (fallback served)", rows[0].EffectiveProvider)
+	}
+	if primary := rows[0].Primary; primary == nil ||
+		primary.Provider != "baseten" ||
+		primary.Model != "zai-org/GLM-5.2" ||
+		!primary.Attempted ||
+		primary.Outcome != telemetry.PrimaryOutcomeHTTPError ||
+		primary.Status == nil || *primary.Status != http.StatusServiceUnavailable {
+		t.Errorf("primary = %+v, want attempted baseten zai-org/GLM-5.2 HTTP 503", primary)
 	}
 }
 

--- a/gateway/cmd/gateway/multimodal_fallback_test.go
+++ b/gateway/cmd/gateway/multimodal_fallback_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/basetenlabs/baseten-switch/gateway/internal/telemetry"
 	"github.com/basetenlabs/baseten-switch/gateway/internal/upstreamerror"
 )
 
@@ -134,6 +135,14 @@ func TestImageTranslationErrorUsesNativeFallback(t *testing.T) {
 			got,
 			fallbackTriggerImageUnsupported,
 		)
+	}
+	if primary := rows[0].Primary; primary == nil ||
+		primary.Provider != "baseten" ||
+		primary.Model != reasoningNeutralBasetenModel ||
+		primary.Attempted ||
+		primary.Outcome != telemetry.PrimaryOutcomeImageInputUnsupported ||
+		primary.Status != nil {
+		t.Fatalf("preflight image primary = %+v", primary)
 	}
 }
 
@@ -297,6 +306,14 @@ func TestReactiveImage400FallbackMessages(t *testing.T) {
 			rows[0].Fallback.Trigger,
 			fallbackTriggerImageUnsupported,
 		)
+	}
+	if primary := rows[0].Primary; primary == nil ||
+		primary.Provider != "baseten" ||
+		primary.Model != reasoningNeutralBasetenModel ||
+		!primary.Attempted ||
+		primary.Outcome != telemetry.PrimaryOutcomeImageInputUnsupported ||
+		primary.Status == nil || *primary.Status != http.StatusBadRequest {
+		t.Fatalf("reactive image primary = %+v", primary)
 	}
 
 	textBody := []byte(`{

--- a/gateway/cmd/gateway/primary_telemetry_test.go
+++ b/gateway/cmd/gateway/primary_telemetry_test.go
@@ -1,0 +1,213 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/basetenlabs/baseten-switch/gateway/internal/telemetry"
+)
+
+func TestStartUpstreamSubAttemptDispatchSignal(t *testing.T) {
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	t.Run("expired TTFT budget", func(t *testing.T) {
+		at := upstreamAttempt{url: server.URL, client: http.DefaultClient}
+		resp, err, expired, dispatched, watch := startUpstreamSubAttempt(
+			context.Background(), at, nil, time.Now().Add(-time.Second),
+		)
+		watch.cancel()
+		if resp != nil || err != nil || !expired || dispatched {
+			t.Fatalf("resp=%v err=%v expired=%v dispatched=%v", resp, err, expired, dispatched)
+		}
+		if hits.Load() != 0 {
+			t.Fatalf("upstream hits = %d, want 0", hits.Load())
+		}
+	})
+
+	t.Run("request build failure", func(t *testing.T) {
+		at := upstreamAttempt{url: "://invalid", client: http.DefaultClient}
+		resp, err, expired, dispatched, watch := startUpstreamSubAttempt(
+			context.Background(), at, nil, time.Time{},
+		)
+		watch.cancel()
+		if resp != nil || err == nil || expired || dispatched {
+			t.Fatalf("resp=%v err=%v expired=%v dispatched=%v", resp, err, expired, dispatched)
+		}
+	})
+
+	t.Run("transport starts", func(t *testing.T) {
+		closed := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		url := closed.URL
+		closed.Close()
+		at := upstreamAttempt{url: url, client: http.DefaultClient}
+		resp, err, expired, dispatched, watch := startUpstreamSubAttempt(
+			context.Background(), at, nil, time.Time{},
+		)
+		watch.cancel()
+		if resp != nil || err == nil || expired || !dispatched {
+			t.Fatalf("resp=%v err=%v expired=%v dispatched=%v", resp, err, expired, dispatched)
+		}
+	})
+}
+
+func TestPrimaryTransportFallbackRecordsDispatch(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	primaryURL := primary.URL
+	primary.Close()
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"FALLBACK"}],"model":"claude-opus-4-8","usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	defer fallback.Close()
+
+	cfg := testConfig(t, primaryURL, fallback.URL)
+	rc := resolvedAnthropicBaseten(t)
+	rc.FallbackRoute = "anthropic"
+	g, adminListener, _ := newGateway(t, cfg, rc)
+	defer adminListener.Close()
+	stop := start(t, g)
+	defer stop()
+
+	resp, body := ttftPost(t, g, `{"model":"claude-opus-4-8","messages":[{"role":"user","content":"ping"}]}`)
+	if resp.StatusCode != http.StatusOK || !strings.Contains(body, "FALLBACK") {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	row := waitForRows(t, cfg.TelemetryDir, 1, 2*time.Second)[0]
+	if row.Primary == nil ||
+		row.Primary.Provider != "baseten" ||
+		row.Primary.Model != "zai-org/GLM-5.2" ||
+		!row.Primary.Attempted ||
+		row.Primary.Outcome != telemetry.PrimaryOutcomeTransportError ||
+		row.Primary.Status != nil {
+		t.Fatalf("primary = %+v, want dispatched Baseten transport error", row.Primary)
+	}
+}
+
+func TestPrimaryRequestBuildFallbackRecordsNoDispatch(t *testing.T) {
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"FALLBACK"}],"model":"claude-opus-4-8","usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	defer fallback.Close()
+
+	cfg := testConfig(t, "://invalid", fallback.URL)
+	rc := resolvedAnthropicBaseten(t)
+	rc.FallbackRoute = "anthropic"
+	g, adminListener, _ := newGateway(t, cfg, rc)
+	defer adminListener.Close()
+	stop := start(t, g)
+	defer stop()
+
+	resp, body := ttftPost(t, g, `{"model":"claude-opus-4-8","messages":[{"role":"user","content":"ping"}]}`)
+	if resp.StatusCode != http.StatusOK || !strings.Contains(body, "FALLBACK") {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	row := waitForRows(t, cfg.TelemetryDir, 1, 2*time.Second)[0]
+	if row.Primary == nil ||
+		row.Primary.Provider != "baseten" ||
+		row.Primary.Model != "zai-org/GLM-5.2" ||
+		row.Primary.Attempted ||
+		row.Primary.Outcome != telemetry.PrimaryOutcomeRequestBuildError ||
+		row.Primary.Status != nil {
+		t.Fatalf("primary = %+v, want unattempted Baseten request build error", row.Primary)
+	}
+	if valueOrZero(row.Fallback.Trigger) != fallbackTriggerRequestBuild {
+		t.Fatalf("fallback trigger = %q, want %q", valueOrZero(row.Fallback.Trigger), fallbackTriggerRequestBuild)
+	}
+}
+
+func TestOpenAIHTTPFallbackRecordsPrimary(t *testing.T) {
+	baseten := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer baseten.Close()
+	openai := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp_native","object":"response","status":"completed","model":"gpt-5","output":[]}`)
+	}))
+	defer openai.Close()
+
+	cfg := testConfig(t, baseten.URL, baseten.URL)
+	cfg.OpenAIURL = openai.URL
+	rc := resolvedOpenAIBaseten(t, "codex", "baseten")
+	rc.DefaultModel = "moonshotai/Kimi-K2.7-Code"
+	rc.FallbackRoute = "openai"
+	g, adminListener, _ := newGateway(t, cfg, rc)
+	defer adminListener.Close()
+	stop := start(t, g)
+	defer stop()
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		clientURL(g, "codex", "/v1/responses"),
+		bytes.NewBufferString(`{"model":"gpt-5","input":"ping"}`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	row := waitForRows(t, cfg.TelemetryDir, 1, 2*time.Second)[0]
+	if row.Primary == nil ||
+		row.Primary.Provider != "baseten" ||
+		row.Primary.Model != rc.DefaultModel ||
+		!row.Primary.Attempted ||
+		row.Primary.Outcome != telemetry.PrimaryOutcomeHTTPError ||
+		row.Primary.Status == nil || *row.Primary.Status != http.StatusTooManyRequests {
+		t.Fatalf("primary = %+v, want Baseten %s HTTP 429", row.Primary, rc.DefaultModel)
+	}
+}
+
+func TestNonstandardServerErrorFallbackRetainsPrimaryTelemetry(t *testing.T) {
+	baseten := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(600)
+	}))
+	defer baseten.Close()
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"FALLBACK"}],"model":"claude-opus-4-8","usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	defer fallback.Close()
+
+	cfg := testConfig(t, baseten.URL, fallback.URL)
+	rc := resolvedAnthropicBaseten(t)
+	rc.FallbackRoute = "anthropic"
+	g, adminListener, _ := newGateway(t, cfg, rc)
+	defer adminListener.Close()
+	stop := start(t, g)
+	defer stop()
+
+	resp, body := ttftPost(t, g, `{"model":"claude-opus-4-8","messages":[{"role":"user","content":"ping"}]}`)
+	if resp.StatusCode != http.StatusOK || !strings.Contains(body, "FALLBACK") {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	row := waitForRows(t, cfg.TelemetryDir, 1, 2*time.Second)[0]
+	if row.Primary == nil ||
+		row.Primary.Provider != "baseten" ||
+		row.Primary.Model != "zai-org/GLM-5.2" ||
+		!row.Primary.Attempted ||
+		row.Primary.Outcome != telemetry.PrimaryOutcomeHTTPError ||
+		row.Primary.Status == nil || *row.Primary.Status != 600 {
+		t.Fatalf("primary = %+v, want Baseten zai-org/GLM-5.2 HTTP 600", row.Primary)
+	}
+}

--- a/gateway/cmd/gateway/reasoning_policy_test.go
+++ b/gateway/cmd/gateway/reasoning_policy_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
 	"github.com/basetenlabs/baseten-switch/gateway/internal/pricing"
 	"github.com/basetenlabs/baseten-switch/gateway/internal/reasoning"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/telemetry"
 )
 
 func reasoningTestGateway(t *testing.T) *Gateway {
@@ -899,6 +900,14 @@ func TestReasoningPolicyConfiguredOffOpenAIShapesPreflightFallbackHTTP(
 					"fallback trigger = %v, want reasoning_policy_error",
 					rows[0].Fallback.Trigger,
 				)
+			}
+			if primary := rows[0].Primary; primary == nil ||
+				primary.Provider != "baseten" ||
+				primary.Model != "zai-org/GLM-5.2" ||
+				primary.Attempted ||
+				primary.Outcome != telemetry.PrimaryOutcomeReasoningPolicyError ||
+				primary.Status != nil {
+				t.Fatalf("reasoning preflight primary = %+v", primary)
 			}
 		})
 	}

--- a/gateway/cmd/gateway/responses_compatibility.go
+++ b/gateway/cmd/gateway/responses_compatibility.go
@@ -30,13 +30,15 @@ func (watch upstreamTTFTWatch) stop() {
 
 // startUpstreamSubAttempt waits for response headers under the remaining
 // absolute TTFT budget. The returned watch stays armed for the first body byte
-// and owns the sub-attempt context.
+// and owns the sub-attempt context. dispatched is true only after client.Do
+// has been started; request construction and an already-expired budget return
+// false without contacting the upstream.
 func startUpstreamSubAttempt(
 	ctx context.Context,
 	at upstreamAttempt,
 	body []byte,
 	ttftDeadline time.Time,
-) (*http.Response, error, bool, upstreamTTFTWatch) {
+) (*http.Response, error, bool, bool, upstreamTTFTWatch) {
 	attemptCtx, attemptCancel := context.WithCancel(ctx)
 	watch := upstreamTTFTWatch{cancel: attemptCancel}
 	upReq, err := http.NewRequestWithContext(
@@ -47,7 +49,7 @@ func startUpstreamSubAttempt(
 	)
 	if err != nil {
 		attemptCancel()
-		return nil, err, false, watch
+		return nil, err, false, false, watch
 	}
 	upReq.Header = at.headers
 
@@ -55,7 +57,7 @@ func startUpstreamSubAttempt(
 		remaining := time.Until(ttftDeadline)
 		if remaining <= 0 {
 			attemptCancel()
-			return nil, nil, true, watch
+			return nil, nil, true, false, watch
 		}
 		watch.timer = time.NewTimer(remaining)
 		watch.c = watch.timer.C
@@ -72,14 +74,14 @@ func startUpstreamSubAttempt(
 	}()
 	select {
 	case result := <-doCh:
-		return result.resp, result.err, false, watch
+		return result.resp, result.err, false, true, watch
 	case <-watch.c:
 		attemptCancel()
 		result := <-doCh
 		if result.resp != nil {
 			result.resp.Body.Close()
 		}
-		return result.resp, result.err, true, watch
+		return result.resp, result.err, true, true, watch
 	}
 }
 

--- a/gateway/cmd/gateway/subagent_test.go
+++ b/gateway/cmd/gateway/subagent_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/telemetry"
 )
 
 // subagentAgentIDHeader mirrors the gateway const so tests stay
@@ -431,6 +432,14 @@ func TestSubagentNativeTargetFallbackWaterfall(t *testing.T) {
 	}
 	if row.RequestedModel != "claude-opus-4-8" {
 		t.Errorf("requested_model = %q, want original claude-opus-4-8", row.RequestedModel)
+	}
+	if primary := row.Primary; primary == nil ||
+		primary.Provider != "baseten" ||
+		primary.Model != "zai-org/GLM-5.2" ||
+		!primary.Attempted ||
+		primary.Outcome != telemetry.PrimaryOutcomeHTTPError ||
+		primary.Status == nil || *primary.Status != http.StatusServiceUnavailable {
+		t.Errorf("subagent primary = %+v, want attempted Baseten default target HTTP 503", primary)
 	}
 }
 

--- a/gateway/cmd/gateway/telemetry_v1_capture.go
+++ b/gateway/cmd/gateway/telemetry_v1_capture.go
@@ -75,6 +75,7 @@ type telemetryCompletionV1 struct {
 	providerStopReason       *string
 	fallbackCount            int
 	fallbackTrigger          *string
+	primary                  *telemetry.PrimaryV1
 	subagent                 bool
 	subagentModel            *string
 	sanitized                bool
@@ -317,6 +318,7 @@ func (request telemetryRequestCaptureV1) event(
 			Count:     completion.fallbackCount,
 			Trigger:   cloneStringPointer(completion.fallbackTrigger),
 		},
+		Primary:           clonePrimaryV1(completion.primary),
 		Subagent:          completion.subagent,
 		SubagentModel:     cloneStringPointer(completion.subagentModel),
 		Sanitized:         completion.sanitized,
@@ -335,6 +337,15 @@ func (request telemetryRequestCaptureV1) event(
 		return telemetry.EventV1{}, err
 	}
 	return event, nil
+}
+
+func clonePrimaryV1(in *telemetry.PrimaryV1) *telemetry.PrimaryV1 {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	out.Status = cloneIntPointer(in.Status)
+	return &out
 }
 
 func cloneResponsesCompatibilityV1(
@@ -797,6 +808,9 @@ func (g *Gateway) recordTelemetryV1(
 	completion.fallbackCount = at.fallbackCount
 	if completion.fallbackTrigger == nil && at.fallbackTrigger != "" {
 		completion.fallbackTrigger = stringPointer(at.fallbackTrigger)
+	}
+	if completion.primary == nil {
+		completion.primary = at.primary
 	}
 	completion.subagent = at.subagent
 	if at.subagentModel != "" {

--- a/gateway/cmd/gateway/ttft_test.go
+++ b/gateway/cmd/gateway/ttft_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/telemetry"
 )
 
 func ttftPost(t *testing.T, g *Gateway, body string) (*http.Response, string) {
@@ -131,12 +132,28 @@ func TestTTFTFiresFallbackBeforeFirstByteWithCooldown(t *testing.T) {
 	if rows[0].EffectiveProvider != "anthropic" || valueOrZero(rows[0].Fallback.Trigger) != "ttft_timeout" {
 		t.Fatalf("row 0 route_effective/fallback_trigger = %q/%q, want anthropic/ttft_timeout", rows[0].EffectiveProvider, valueOrZero(rows[0].Fallback.Trigger))
 	}
+	if primary := rows[0].Primary; primary == nil ||
+		primary.Provider != "baseten" ||
+		primary.Model != "zai-org/GLM-5.2" ||
+		!primary.Attempted ||
+		primary.Outcome != telemetry.PrimaryOutcomeTTFTTimeout ||
+		primary.Status != nil {
+		t.Errorf("TTFT primary = %+v, want attempted baseten zai-org/GLM-5.2", primary)
+	}
 	if rows[1].EffectiveProvider != "anthropic" ||
 		!rows[1].Fallback.Attempted ||
 		rows[1].Fallback.Count != 1 ||
 		valueOrZero(rows[1].Fallback.Trigger) != fallbackTriggerCooldown {
 		t.Fatalf("row 1 fallback telemetry = provider %q, %+v; want anthropic cooldown bypass",
 			rows[1].EffectiveProvider, rows[1].Fallback)
+	}
+	if primary := rows[1].Primary; primary == nil ||
+		primary.Provider != "baseten" ||
+		primary.Model != "zai-org/GLM-5.2" ||
+		primary.Attempted ||
+		primary.Outcome != telemetry.PrimaryOutcomeCooldown ||
+		primary.Status != nil {
+		t.Errorf("cooldown primary = %+v, want unattempted baseten zai-org/GLM-5.2", primary)
 	}
 }
 
@@ -175,6 +192,14 @@ func TestAuthUnavailableBypassRecordsFallback(t *testing.T) {
 		valueOrZero(row.Fallback.Trigger) != fallbackTriggerAuthUnavailable {
 		t.Fatalf("fallback telemetry = provider %q, %+v; want anthropic auth-unavailable bypass",
 			row.EffectiveProvider, row.Fallback)
+	}
+	if primary := row.Primary; primary == nil ||
+		primary.Provider != "baseten" ||
+		primary.Model != "zai-org/GLM-5.2" ||
+		primary.Attempted ||
+		primary.Outcome != telemetry.PrimaryOutcomeAuthUnavailable ||
+		primary.Status != nil {
+		t.Errorf("auth-unavailable primary = %+v, want unattempted baseten zai-org/GLM-5.2", primary)
 	}
 }
 

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -2,6 +2,8 @@ module github.com/basetenlabs/baseten-switch/gateway
 
 go 1.26
 
+toolchain go1.26.6
+
 require (
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/oauth2 v0.36.0

--- a/gateway/internal/telemetry/event_v1.go
+++ b/gateway/internal/telemetry/event_v1.go
@@ -71,6 +71,7 @@ type EventV1 struct {
 	ActualCost                    CostSnapshotV1            `json:"actual_cost"`
 	NativeCounterfactualCost      *CostSnapshotV1           `json:"native_counterfactual_cost"`
 	Fallback                      FallbackV1                `json:"fallback"`
+	Primary                       *PrimaryV1                `json:"primary,omitempty"`
 	Subagent                      bool                      `json:"subagent"`
 	SubagentModel                 *string                   `json:"subagent_model"`
 	Sanitized                     bool                      `json:"sanitized"`
@@ -224,6 +225,28 @@ type FallbackV1 struct {
 	Trigger   *string `json:"trigger"`
 }
 
+// PrimaryV1 preserves the bounded outcome of the planned primary route when
+// another provider ultimately serves the logical request. It is intentionally
+// not a general attempt trace: request and response content never belong here.
+type PrimaryV1 struct {
+	Provider  string `json:"provider"`
+	Model     string `json:"model"`
+	Attempted bool   `json:"attempted"`
+	Outcome   string `json:"outcome"`
+	Status    *int   `json:"status"`
+}
+
+const (
+	PrimaryOutcomeHTTPError             = "http_error"
+	PrimaryOutcomeTransportError        = "transport_error"
+	PrimaryOutcomeRequestBuildError     = "request_build_error"
+	PrimaryOutcomeTTFTTimeout           = "ttft_timeout"
+	PrimaryOutcomeImageInputUnsupported = "image_input_unsupported"
+	PrimaryOutcomeCooldown              = "cooldown"
+	PrimaryOutcomeAuthUnavailable       = "auth_unavailable"
+	PrimaryOutcomeReasoningPolicyError  = "reasoning_policy_error"
+)
+
 func NewEventID() (string, error) {
 	var value [16]byte
 	if _, err := rand.Read(value[:]); err != nil {
@@ -278,10 +301,15 @@ func (e EventV1) Validate() error {
 		return errors.New("telemetry fallback count must be nonnegative")
 	case !e.Fallback.Attempted && e.Fallback.Count != 0:
 		return errors.New("telemetry fallback count requires attempted=true")
+	case e.Primary != nil && !e.Fallback.Attempted:
+		return errors.New("telemetry primary summary requires fallback attempted=true")
 	case e.ToolCalls < 0:
 		return errors.New("telemetry tool_calls must be nonnegative")
 	case e.RequestBytes < 0:
 		return errors.New("telemetry request_bytes must be nonnegative")
+	}
+	if err := e.Primary.validate(); err != nil {
+		return err
 	}
 	if err := e.ResponsesCompatibility.validate(); err != nil {
 		return err
@@ -301,6 +329,67 @@ func (e EventV1) Validate() error {
 		}
 	}
 	return nil
+}
+
+func (p *PrimaryV1) validate() error {
+	if p == nil {
+		return nil
+	}
+	switch {
+	case p.Provider == "":
+		return errors.New("telemetry primary provider is required")
+	case p.Model == "":
+		return errors.New("telemetry primary model is required")
+	case !validPrimaryOutcome(p.Outcome):
+		return fmt.Errorf("telemetry primary outcome = %q is invalid", p.Outcome)
+	case p.Status != nil && (*p.Status < 100 || *p.Status > 999):
+		return errors.New("telemetry primary status must be a three-digit status code or null")
+	case !p.Attempted && p.Status != nil:
+		return errors.New("telemetry unattempted primary status must be null")
+	}
+	switch p.Outcome {
+	case PrimaryOutcomeHTTPError:
+		if !p.Attempted || p.Status == nil ||
+			(*p.Status != 429 && *p.Status < 500) {
+			return errors.New("telemetry primary HTTP error requires attempted=true and fallback-eligible 429 or 5xx status")
+		}
+	case PrimaryOutcomeImageInputUnsupported:
+		if p.Attempted && (p.Status == nil || *p.Status != 400) {
+			return errors.New("telemetry attempted primary image rejection requires status 400")
+		}
+	case PrimaryOutcomeTransportError:
+		if !p.Attempted || p.Status != nil {
+			return errors.New("telemetry primary transport error requires attempted=true and null status")
+		}
+	case PrimaryOutcomeTTFTTimeout:
+		if p.Status != nil {
+			return errors.New("telemetry primary TTFT timeout requires null status")
+		}
+	case PrimaryOutcomeRequestBuildError,
+		PrimaryOutcomeCooldown,
+		PrimaryOutcomeAuthUnavailable,
+		PrimaryOutcomeReasoningPolicyError:
+		if p.Attempted || p.Status != nil {
+			return fmt.Errorf("telemetry primary outcome %q requires attempted=false and null status", p.Outcome)
+		}
+	}
+	return nil
+}
+
+func validPrimaryOutcome(outcome string) bool {
+	switch outcome {
+	case PrimaryOutcomeHTTPError,
+		PrimaryOutcomeTransportError,
+		PrimaryOutcomeRequestBuildError,
+		PrimaryOutcomeTTFTTimeout,
+		PrimaryOutcomeImageInputUnsupported,
+		PrimaryOutcomeCooldown,
+		PrimaryOutcomeAuthUnavailable,
+		PrimaryOutcomeReasoningPolicyError:
+		return true
+	default:
+		return false
+	}
 }
 
 func (c *ResponsesCompatibilityV1) validate() error {

--- a/gateway/internal/telemetry/event_v1_test.go
+++ b/gateway/internal/telemetry/event_v1_test.go
@@ -64,6 +64,144 @@ func TestEventV1NullAndZeroSemantics(t *testing.T) {
 		strings.Contains(value, `"cache_write_input"`) {
 		t.Fatalf("encoded event retained generic cache-write fields: %s", value)
 	}
+	if strings.Contains(value, `"primary"`) {
+		t.Fatalf("event without fallback unexpectedly emitted primary: %s", value)
+	}
+}
+
+func TestEventV1PrimarySummaryRoundTrip(t *testing.T) {
+	now := time.Date(2026, time.August, 13, 12, 0, 0, 0, time.UTC)
+	event := validEventV1(now)
+	event.EffectiveProvider = "anthropic"
+	event.Fallback = FallbackV1{Attempted: true, Count: 1}
+	status := 503
+	event.Primary = &PrimaryV1{
+		Provider:  "baseten",
+		Model:     "zai-org/GLM-5.2",
+		Attempted: true,
+		Outcome:   PrimaryOutcomeHTTPError,
+		Status:    &status,
+	}
+	if err := event.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded EventV1
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Primary == nil ||
+		decoded.Primary.Provider != "baseten" ||
+		decoded.Primary.Model != "zai-org/GLM-5.2" ||
+		!decoded.Primary.Attempted ||
+		decoded.Primary.Outcome != PrimaryOutcomeHTTPError ||
+		decoded.Primary.Status == nil || *decoded.Primary.Status != 503 {
+		t.Fatalf("primary round trip = %+v", decoded.Primary)
+	}
+}
+
+func TestPrimaryV1Validation(t *testing.T) {
+	status := func(value int) *int { return &value }
+	tests := []struct {
+		name    string
+		primary PrimaryV1
+		wantErr bool
+	}{
+		{
+			name: "HTTP fallback",
+			primary: PrimaryV1{Provider: "baseten", Model: "model", Attempted: true,
+				Outcome: PrimaryOutcomeHTTPError, Status: status(503)},
+		},
+		{
+			name: "HTTP fallback accepts rate limit",
+			primary: PrimaryV1{Provider: "baseten", Model: "model", Attempted: true,
+				Outcome: PrimaryOutcomeHTTPError, Status: status(429)},
+		},
+		{
+			name: "HTTP fallback rejects ineligible client error",
+			primary: PrimaryV1{Provider: "baseten", Model: "model", Attempted: true,
+				Outcome: PrimaryOutcomeHTTPError, Status: status(400)},
+			wantErr: true,
+		},
+		{
+			name: "HTTP fallback rejects success status",
+			primary: PrimaryV1{Provider: "baseten", Model: "model", Attempted: true,
+				Outcome: PrimaryOutcomeHTTPError, Status: status(200)},
+			wantErr: true,
+		},
+		{
+			name: "HTTP fallback requires status",
+			primary: PrimaryV1{Provider: "baseten", Model: "model", Attempted: true,
+				Outcome: PrimaryOutcomeHTTPError},
+			wantErr: true,
+		},
+		{
+			name: "reactive image requires exact rejection status",
+			primary: PrimaryV1{Provider: "baseten", Model: "model", Attempted: true,
+				Outcome: PrimaryOutcomeImageInputUnsupported, Status: status(400)},
+		},
+		{
+			name: "reactive image rejects success status",
+			primary: PrimaryV1{Provider: "baseten", Model: "model", Attempted: true,
+				Outcome: PrimaryOutcomeImageInputUnsupported, Status: status(200)},
+			wantErr: true,
+		},
+		{
+			name: "attempted image requires status",
+			primary: PrimaryV1{Provider: "baseten", Model: "model", Attempted: true,
+				Outcome: PrimaryOutcomeImageInputUnsupported},
+			wantErr: true,
+		},
+		{
+			name: "preflight image has no status",
+			primary: PrimaryV1{Provider: "baseten", Model: "model",
+				Outcome: PrimaryOutcomeImageInputUnsupported},
+		},
+		{
+			name: "unattempted status rejected",
+			primary: PrimaryV1{Provider: "baseten", Model: "model",
+				Outcome: PrimaryOutcomeCooldown, Status: status(503)},
+			wantErr: true,
+		},
+		{
+			name: "nonstandard three-digit server error accepted",
+			primary: PrimaryV1{Provider: "baseten", Model: "model", Attempted: true,
+				Outcome: PrimaryOutcomeHTTPError, Status: status(600)},
+		},
+		{
+			name: "status above three-digit range rejected",
+			primary: PrimaryV1{Provider: "baseten", Model: "model", Attempted: true,
+				Outcome: PrimaryOutcomeHTTPError, Status: status(1000)},
+			wantErr: true,
+		},
+		{
+			name: "transport requires dispatch",
+			primary: PrimaryV1{Provider: "baseten", Model: "model",
+				Outcome: PrimaryOutcomeTransportError},
+			wantErr: true,
+		},
+		{
+			name: "request build is pre-dispatch",
+			primary: PrimaryV1{Provider: "baseten", Model: "model",
+				Outcome: PrimaryOutcomeRequestBuildError},
+		},
+		{
+			name: "expired TTFT budget is pre-dispatch",
+			primary: PrimaryV1{Provider: "baseten", Model: "model",
+				Outcome: PrimaryOutcomeTTFTTimeout},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.primary.validate()
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validate() = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
 }
 
 func TestEventV1CacheWriteBucketsPreserveMissingVersusZero(t *testing.T) {

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/RequestsModels.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/RequestsModels.swift
@@ -64,6 +64,45 @@ struct RequestFallback: Decodable, Equatable, Sendable {
     }
 }
 
+struct RequestPrimaryAttempt: Decodable, Equatable, Sendable {
+    var provider: String
+    var model: String
+    var attempted: Bool
+    var outcome: String
+    var status: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case provider
+        case model
+        case attempted
+        case outcome
+        case status
+    }
+
+    init(
+        provider: String,
+        model: String,
+        attempted: Bool,
+        outcome: String,
+        status: Int? = nil
+    ) {
+        self.provider = provider
+        self.model = model
+        self.attempted = attempted
+        self.outcome = outcome
+        self.status = status
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        provider = try values.decode(String.self, forKey: .provider)
+        model = try values.decode(String.self, forKey: .model)
+        attempted = try values.decode(Bool.self, forKey: .attempted)
+        outcome = try values.decode(String.self, forKey: .outcome)
+        status = try values.decodeIfPresent(Int.self, forKey: .status)
+    }
+}
+
 struct RequestItem: Decodable, Equatable, Identifiable, Sendable {
     var eventID: String
     var completedAt: Date
@@ -77,6 +116,7 @@ struct RequestItem: Decodable, Equatable, Identifiable, Sendable {
     var terminationReason: String?
     var subagent: Bool
     var fallback: RequestFallback?
+    var primary: RequestPrimaryAttempt?
 
     var id: String { eventID }
 
@@ -110,6 +150,7 @@ struct RequestItem: Decodable, Equatable, Identifiable, Sendable {
         case terminationReason = "termination_reason"
         case subagent
         case fallback
+        case primary
     }
 
     init(
@@ -124,7 +165,8 @@ struct RequestItem: Decodable, Equatable, Identifiable, Sendable {
         durationMs: Int64?,
         terminationReason: String?,
         subagent: Bool,
-        fallback: RequestFallback?
+        fallback: RequestFallback?,
+        primary: RequestPrimaryAttempt? = nil
     ) {
         self.eventID = eventID
         self.completedAt = completedAt
@@ -138,6 +180,7 @@ struct RequestItem: Decodable, Equatable, Identifiable, Sendable {
         self.terminationReason = terminationReason
         self.subagent = subagent
         self.fallback = fallback
+        self.primary = primary
     }
 
     init(from decoder: Decoder) throws {
@@ -168,6 +211,9 @@ struct RequestItem: Decodable, Equatable, Identifiable, Sendable {
         fallback = try values.decodeIfPresent(
             RequestFallback.self,
             forKey: .fallback)
+        primary = try values.decodeIfPresent(
+            RequestPrimaryAttempt.self,
+            forKey: .primary)
     }
 }
 
@@ -207,6 +253,8 @@ func requestFallbackLabel(_ trigger: String?) -> String {
         return "Authentication unavailable"
     case "reasoning_policy_error":
         return "Reasoning policy error"
+    case "request_build_error":
+        return "Request setup failed"
     case "transport_error":
         return "Transport error"
     case "cooldown":

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/RequestsView.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/RequestsView.swift
@@ -203,11 +203,11 @@ private enum RequestTableMetrics {
     static let time: CGFloat = 128
     static let harness: CGFloat = 132
     static let requested: CGFloat = 190
-    static let served: CGFloat = 250
+    static let routing: CGFloat = 330
     static let result: CGFloat = 120
     static let duration: CGFloat = 86
-    static let fallback: CGFloat = 350
-    static let totalWidth = time + harness + requested + served
+    static let fallback: CGFloat = 270
+    static let totalWidth = time + harness + requested + routing
         + result + duration + fallback
 }
 
@@ -217,9 +217,7 @@ private struct RequestTableHeader: View {
             headerCell("Time", width: RequestTableMetrics.time)
             headerCell("Harness", width: RequestTableMetrics.harness)
             headerCell("Requested", width: RequestTableMetrics.requested)
-            headerCell(
-                "Served / Provider",
-                width: RequestTableMetrics.served)
+            headerCell("Routing", width: RequestTableMetrics.routing)
             headerCell("Result", width: RequestTableMetrics.result)
             headerCell("Duration", width: RequestTableMetrics.duration)
             headerCell("Fallback", width: RequestTableMetrics.fallback)
@@ -277,11 +275,8 @@ private struct RequestTableRow: View {
                 .help(item.requestedModel)
                 .requestTableCell(width: RequestTableMetrics.requested)
 
-            Text(requestServedProviderLabel(item))
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .help(requestServedProviderLabel(item))
-                .requestTableCell(width: RequestTableMetrics.served)
+            RequestRoutingCell(item: item)
+                .requestTableCell(width: RequestTableMetrics.routing)
 
             RequestResultBadge(item: item)
                 .requestTableCell(width: RequestTableMetrics.result)
@@ -322,6 +317,35 @@ private struct RequestTableRow: View {
         .overlay(alignment: .bottom) {
             Divider()
         }
+    }
+}
+
+private struct RequestRoutingCell: View {
+    let item: RequestItem
+
+    var body: some View {
+        Group {
+            if let primary = item.primary {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(requestPrimaryRoutingLabel(primary))
+                        .font(.caption)
+                        .foregroundStyle(
+                            primary.attempted ? Color.orange : Color.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Text("→ \(requestServedProviderLabel(item))")
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            } else {
+                Text(requestServedProviderLabel(item))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+        }
+        .help(requestRoutingAccessibilityLabel(item))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(requestRoutingAccessibilityLabel(item))
     }
 }
 
@@ -367,6 +391,42 @@ func requestServedProviderLabel(_ item: RequestItem) -> String {
     }
 }
 
+func requestPrimaryProviderLabel(_ primary: RequestPrimaryAttempt) -> String {
+    let model = primary.model
+    let provider = primary.provider.capitalized
+    switch (model.isEmpty, provider.isEmpty) {
+    case (false, false):
+        return "\(model) · \(provider)"
+    case (false, true):
+        return model
+    case (true, false):
+        return provider
+    case (true, true):
+        return "Unknown primary"
+    }
+}
+
+func requestPrimaryStateLabel(_ primary: RequestPrimaryAttempt) -> String {
+    guard primary.attempted else { return "Not attempted" }
+    if primary.outcome == "http_error" {
+        return primary.status.map { "HTTP \($0)" } ?? "HTTP error"
+    }
+    let label = requestFallbackLabel(primary.outcome)
+    return label == "Fallback" ? "Attempted" : label
+}
+
+func requestPrimaryRoutingLabel(_ primary: RequestPrimaryAttempt) -> String {
+    let route = requestPrimaryProviderLabel(primary)
+    return primary.attempted ? route : "\(route) · Not attempted"
+}
+
+func requestRoutingAccessibilityLabel(_ item: RequestItem) -> String {
+    let served = requestServedProviderLabel(item)
+    guard let primary = item.primary else { return served }
+    return "Primary \(requestPrimaryProviderLabel(primary)), "
+        + "\(requestPrimaryStateLabel(primary)). Served by \(served)"
+}
+
 func requestResultLabel(_ item: RequestItem) -> String {
     if let status = item.status {
         return "HTTP \(status)"
@@ -390,33 +450,7 @@ func requestIsError(_ item: RequestItem) -> Bool {
 
 func requestFallbackReason(_ fallback: RequestFallback?) -> String? {
     guard fallback?.attempted == true else { return nil }
-    let trigger = fallback?.trigger ?? ""
-    switch trigger {
-    case "image_input_unsupported":
-        return "Baseten could not accept the image, native provider used"
-    case "ttft_timeout":
-        return "Baseten timed out before the first token, native provider used"
-    case "cooldown":
-        return "Baseten health cooldown was active, native provider used"
-    case "auth_unavailable":
-        return "Baseten credentials were unavailable, native provider used"
-    case "transport_error":
-        return "Baseten connection failed, native provider used"
-    case "reasoning_policy_error":
-        return "Reasoning policy could not be applied, native provider used"
-    case "":
-        return "Fallback provider used"
-    default:
-        if trigger.hasPrefix("http_"),
-           let status = Int(trigger.dropFirst("http_".count)) {
-            if status == 429 {
-                return "Baseten rate limited the request, native provider used"
-            }
-            return "Baseten returned HTTP \(status), native provider used"
-        }
-        let readable = trigger.replacingOccurrences(of: "_", with: " ")
-        return "Fallback provider used (\(readable))"
-    }
+    return requestFallbackLabel(fallback?.trigger)
 }
 
 func requestModelLabel(_ item: RequestItem) -> String {

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/RequestPresentationTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/RequestPresentationTests.swift
@@ -24,11 +24,12 @@ final class RequestPresentationTests: XCTestCase {
 
         XCTAssertEqual(
             requestFallbackReason(fallback),
-            "Baseten could not accept the image, native provider used")
+            "Image input unsupported")
     }
 
-    func testRouteAndModelLabelsShowRequestedToServedPath() {
+    func testRouteAndModelLabelsShowRequestedToServedPath() throws {
         let item = requestItem()
+        let primary = try XCTUnwrap(item.primary)
 
         XCTAssertEqual(
             requestModelLabel(item),
@@ -39,7 +40,40 @@ final class RequestPresentationTests: XCTestCase {
         XCTAssertEqual(
             requestServedProviderLabel(item),
             "claude-opus-4-8-20260701 · Anthropic")
+        XCTAssertEqual(
+            requestPrimaryProviderLabel(primary),
+            "zai-org/GLM-5.2 · Baseten")
+        XCTAssertEqual(
+            requestPrimaryRoutingLabel(primary),
+            "zai-org/GLM-5.2 · Baseten")
+        XCTAssertEqual(
+            requestPrimaryStateLabel(primary),
+            "HTTP 503")
+        XCTAssertEqual(
+            requestRoutingAccessibilityLabel(item),
+            "Primary zai-org/GLM-5.2 · Baseten, HTTP 503. "
+                + "Served by claude-opus-4-8-20260701 · Anthropic")
         XCTAssertEqual(requestResultLabel(item), "HTTP 200")
+    }
+
+    func testBypassedPrimaryIsExplicitlyNotAttempted() throws {
+        var item = requestItem()
+        item.primary = RequestPrimaryAttempt(
+            provider: "baseten",
+            model: "zai-org/GLM-5.2",
+            attempted: false,
+            outcome: "cooldown")
+        let primary = try XCTUnwrap(item.primary)
+
+        XCTAssertEqual(
+            requestPrimaryStateLabel(primary),
+            "Not attempted")
+        XCTAssertEqual(
+            requestPrimaryRoutingLabel(primary),
+            "zai-org/GLM-5.2 · Baseten · Not attempted")
+        XCTAssertTrue(
+            requestRoutingAccessibilityLabel(item)
+                .contains("Not attempted"))
     }
 
     func testCoverageAndFilterSpecificEmptyStates() {
@@ -76,6 +110,12 @@ final class RequestPresentationTests: XCTestCase {
             fallback: RequestFallback(
                 attempted: true,
                 count: 1,
-                trigger: "image_input_unsupported"))
+                trigger: "http_503"),
+            primary: RequestPrimaryAttempt(
+                provider: "baseten",
+                model: "zai-org/GLM-5.2",
+                attempted: true,
+                outcome: "http_error",
+                status: 503))
     }
 }

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/RequestsTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/RequestsTests.swift
@@ -110,7 +110,14 @@ final class RequestsTests: XCTestCase {
         XCTAssertTrue(fallback.attempted)
         XCTAssertEqual(fallback.count, 1)
         XCTAssertEqual(fallback.trigger, "image_input_unsupported")
+        let primary = try XCTUnwrap(snapshot.items.first?.primary)
+        XCTAssertEqual(primary.provider, "baseten")
+        XCTAssertEqual(primary.model, "zai-org/GLM-5.2")
+        XCTAssertTrue(primary.attempted)
+        XCTAssertEqual(primary.outcome, "image_input_unsupported")
+        XCTAssertEqual(primary.status, 400)
         XCTAssertTrue(snapshot.items[0].isFallback)
+        XCTAssertNil(snapshot.items[1].primary)
         XCTAssertNil(snapshot.items[1].status)
         XCTAssertTrue(snapshot.items[1].isError)
     }
@@ -125,6 +132,9 @@ final class RequestsTests: XCTestCase {
         XCTAssertEqual(
             requestFallbackLabel("http_503"),
             "HTTP 503")
+        XCTAssertEqual(
+            requestFallbackLabel("request_build_error"),
+            "Request setup failed")
         XCTAssertEqual(
             requestFallbackLabel("future_reason"),
             "Future Reason")
@@ -186,6 +196,25 @@ final class RequestsTests: XCTestCase {
             unixItem.completedAt.timeIntervalSince1970,
             1_785_088_860.25,
             accuracy: 0.001)
+    }
+
+    func testDecodeRejectsPartialPrimarySummary() {
+        let data = Data(
+            """
+            {
+              "event_id": "partial-primary",
+              "completed_at": 1785088860.25,
+              "primary": {
+                "provider": "baseten",
+                "model": "zai-org/GLM-5.2",
+                "outcome": "cooldown",
+                "status": null
+              }
+            }
+            """.utf8)
+
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(RequestItem.self, from: data))
     }
 
     func testMergeSortsNewestFirstAndDeduplicatesByEventID() {

--- a/mac/BasetenSwitch/Tests/Fixtures/native-requests-mock.json
+++ b/mac/BasetenSwitch/Tests/Fixtures/native-requests-mock.json
@@ -16,6 +16,13 @@
         "attempted": true,
         "count": 1,
         "trigger": "image_input_unsupported"
+      },
+      "primary": {
+        "provider": "baseten",
+        "model": "zai-org/GLM-5.2",
+        "attempted": true,
+        "outcome": "image_input_unsupported",
+        "status": 400
       }
     },
     {


### PR DESCRIPTION
## Summary

- Record an optional, bounded summary of the planned primary route when another provider serves a request.
- Show the primary model/provider and whether it was attempted in the Requests routing column, while keeping normal requests compact.
- Preserve compatibility with existing telemetry rows and older clients by making the new field additive and optional.

## Testing

- `./scripts/check.sh`
- Manual dev-build QA with synthetic local upstreams covering HTTP fallback, cooldown and unavailable-credentials bypasses, direct primary success, Requests filters, horizontal scrolling, and accessibility labels.
<img width="1596" height="352" alt="CleanShot 2026-08-15 at 15 33 48" src="https://github.com/user-attachments/assets/c53734e5-1e25-4ad4-be7d-9a70c021a901" />
