### PR TITLE
Refresh Baseten auth and model routing coherently

### DIFF
--- a/gateway/cmd/gateway/admin.go
+++ b/gateway/cmd/gateway/admin.go
@@ -53,6 +53,7 @@ func (g *Gateway) registerAdmin(mux *http.ServeMux) {
 	mux.HandleFunc("/v1/admin/stats", g.adminStats)
 	mux.HandleFunc("/v1/admin/analytics", g.adminAnalytics)
 	mux.HandleFunc("/v1/admin/requests", g.adminRequests)
+	mux.HandleFunc("/v1/admin/auth/reload", g.handleAuthReload)
 	mux.HandleFunc("/v1/admin/auth/status", g.handleAuthStatus)
 }
 

--- a/gateway/cmd/gateway/auth_admin.go
+++ b/gateway/cmd/gateway/auth_admin.go
@@ -12,28 +12,88 @@ import (
 	"github.com/basetenlabs/baseten-switch/gateway/internal/auth"
 )
 
+const (
+	adminMutationHeader      = "X-Baseten-Switch-Admin"
+	adminMutationHeaderValue = "1"
+)
+
 func (g *Gateway) handleAuthStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
 		g.reject(w, 405, "method not allowed")
 		return
 	}
-	signedIn, authType, fallbackInUse := g.authState()
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, http.StatusOK, g.authStatusResponse())
+}
+
+func (g *Gateway) handleAuthReload(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		g.reject(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	// This non-simple request header forces browser callers through a CORS
+	// preflight, which the loopback admin server does not approve. Check it
+	// before body or credential-store work.
+	if r.Header.Get(adminMutationHeader) != adminMutationHeaderValue {
+		g.reject(w, http.StatusForbidden, "admin mutation header required")
+		return
+	}
+	var body []byte
+	if r.Body != nil {
+		var err error
+		body, err = io.ReadAll(io.LimitReader(r.Body, 1))
+		if err != nil {
+			g.reject(w, http.StatusBadRequest, "could not read request body")
+			return
+		}
+	}
+	if len(body) != 0 {
+		g.reject(w, http.StatusBadRequest, "request body must be empty")
+		return
+	}
+
+	// Serialize with config reloads so refreshAuth cannot read an old runtime
+	// profile and publish it after a concurrent SIGHUP has installed a new one.
+	g.reloadMu.Lock()
+	defer g.reloadMu.Unlock()
+	g.refreshAuthLocked()
+	// refreshAuthLocked preserves the existing nonblocking catalog-refresh
+	// kick. The reload receipt does not wait for that work and performs no
+	// synchronous upstream identity lookup.
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, http.StatusOK, g.localAuthStatusResponse())
+}
+
+// authStatusResponse preserves the existing read-only status projection. Its
+// local subset is shared with the explicit reload endpoint so that mutation
+// can respond without an upstream user lookup.
+func (g *Gateway) authStatusResponse() map[string]any {
+	response := g.localAuthStatusResponse()
 	email, expiresAt := g.authEmailAndExpiry()
 	ah := g.authHealth()
+	response["last_refresh_error"] = ah.LastError
+	response["last_refresh_error_at"] = rfc3339OrEmpty(ah.LastErrorAt)
+	response["last_refresh_ok_at"] = rfc3339OrEmpty(ah.LastOKAt)
+	response["email"] = email
+	response["expires_at"] = expiresAt
+	return response
+}
+
+// localAuthStatusResponse reads only in-memory state and configuration. It
+// performs no synchronous upstream request and includes no credential values,
+// fingerprints, refresh errors, or remote response bodies.
+func (g *Gateway) localAuthStatusResponse() map[string]any {
+	signedIn, authType, fallbackInUse := g.authState()
+	ah := g.authHealth()
 	cfg := g.runtimeConfig()
-	writeJSON(w, 200, map[string]any{
-		"signed_in":             signedIn,
-		"auth_type":             authType,
-		"health":                ah.Health,
-		"last_refresh_error":    ah.LastError,
-		"last_refresh_error_at": rfc3339OrEmpty(ah.LastErrorAt),
-		"last_refresh_ok_at":    rfc3339OrEmpty(ah.LastOKAt),
-		"profile":               cfg.OAuthProfile,
-		"fallback_enabled":      cfg.APIKeyFallback,
-		"fallback_in_use":       fallbackInUse,
-		"email":                 email,
-		"expires_at":            expiresAt,
-	})
+	return map[string]any{
+		"signed_in":        signedIn,
+		"auth_type":        authType,
+		"health":           ah.Health,
+		"profile":          cfg.OAuthProfile,
+		"fallback_enabled": cfg.APIKeyFallback,
+		"fallback_in_use":  fallbackInUse,
+	}
 }
 
 func (g *Gateway) authEmailAndExpiry() (string, string) {

--- a/gateway/cmd/gateway/auth_admin_reload_test.go
+++ b/gateway/cmd/gateway/auth_admin_reload_test.go
@@ -1,0 +1,424 @@
+package gateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basetenlabs/baseten-switch/gateway/internal/pricing"
+)
+
+func newAuthReloadTestGateway(t *testing.T, cfg Config) *Gateway {
+	t.Helper()
+	g := &Gateway{
+		cfg:     cfg,
+		client:  &http.Client{Transport: defaultTransport()},
+		pricing: pricing.New(),
+	}
+	// Match a running gateway that initialized before the CLI credential
+	// appeared.
+	g.refreshAuth()
+	mux := http.NewServeMux()
+	g.registerAdmin(mux)
+	g.adminServer = &http.Server{Handler: mux}
+	return g
+}
+
+func authReloadRequest(t *testing.T, g *Gateway, method string, body io.Reader) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, "/v1/admin/auth/reload", body)
+	req.Header.Set(adminMutationHeader, adminMutationHeaderValue)
+	recorder := httptest.NewRecorder()
+	g.adminServer.Handler.ServeHTTP(recorder, req)
+	return recorder
+}
+
+func authReloadRequestWithHeader(t *testing.T, g *Gateway, header string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/v1/admin/auth/reload", nil)
+	if header != "" {
+		req.Header.Set(adminMutationHeader, header)
+	}
+	recorder := httptest.NewRecorder()
+	g.adminServer.Handler.ServeHTTP(recorder, req)
+	return recorder
+}
+
+func writeOAuthProfileWithAccessToken(t *testing.T, remoteURL, accessToken, refreshToken string) {
+	t.Helper()
+	path := os.Getenv("BASETEN_SWITCH_AUTH_FILE")
+	if path == "" {
+		t.Fatal("BASETEN_SWITCH_AUTH_FILE not set (call testConfig first)")
+	}
+	blob := fmt.Sprintf(`{
+  "version": 1,
+  "current": "p",
+  "profiles": {
+    "p": {
+      "remote_url": %q,
+      "auth_type": "oauth",
+      "oauth_credential": {
+        "access_token": %q,
+        "refresh_token": %q,
+        "expiry": %q
+      }
+    }
+  }
+}`, remoteURL, accessToken, refreshToken, time.Now().Add(time.Hour).UTC().Format(time.RFC3339))
+	if err := os.WriteFile(path, []byte(blob), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func decodeAuthAdminResponse(t *testing.T, recorder *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var response map[string]any
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v\nbody: %s", err, recorder.Body.String())
+	}
+	return response
+}
+
+func assertResponseOmits(t *testing.T, recorder *httptest.ResponseRecorder, values ...string) {
+	t.Helper()
+	body := recorder.Body.String()
+	for _, value := range values {
+		if value != "" && strings.Contains(body, value) {
+			t.Fatalf("response contains protected value %q: %s", value, body)
+		}
+	}
+}
+
+func TestAdminAuthReloadLoadsOAuthFirstLogin(t *testing.T) {
+	const refreshToken = "synthetic-refresh-token-must-not-leak"
+	const accessToken = "expired-at"
+	var whoamiRequests int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		whoamiRequests++
+		if r.URL.Path != "/v1/users/me" {
+			t.Errorf("path = %q, want /v1/users/me", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer "+accessToken {
+			t.Errorf("Authorization = %q, want OAuth access token", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"email":"person@example.invalid"}`)
+	}))
+	defer upstream.Close()
+
+	cfg := testConfig(t, upstream.URL, upstream.URL)
+	cfg.OAuthProfile = "p"
+	cfg.OAuthHost = upstream.URL
+	cfg.APIKeyFallback = false
+	cfg.BasetenKey = ""
+	g := newAuthReloadTestGateway(t, cfg)
+
+	if signedIn, _, _ := g.authState(); signedIn {
+		t.Fatal("gateway started signed in before the CLI credential appeared")
+	}
+	writeOAuthProfileExpiry(t, upstream.URL, refreshToken, time.Now().Add(time.Hour))
+
+	recorder := authReloadRequest(t, g, http.MethodPost, nil)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", recorder.Code, recorder.Body.String())
+	}
+	if got := recorder.Header().Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control = %q, want no-store", got)
+	}
+	response := decodeAuthAdminResponse(t, recorder)
+	if response["signed_in"] != true || response["auth_type"] != "oauth" || response["health"] != "ok" {
+		t.Fatalf("auth reload response = %+v", response)
+	}
+	if response["profile"] != "p" || response["fallback_in_use"] != false {
+		t.Fatalf("auth reload projection = %+v", response)
+	}
+	if whoamiRequests != 0 {
+		t.Fatalf("reload made %d upstream requests, want 0", whoamiRequests)
+	}
+	assertResponseOmits(t, recorder, refreshToken, accessToken, "Authorization", "Bearer ")
+
+	statusReq := httptest.NewRequest(http.MethodGet, "/v1/admin/auth/status", nil)
+	statusRecorder := httptest.NewRecorder()
+	g.adminServer.Handler.ServeHTTP(statusRecorder, statusReq)
+	if statusRecorder.Code != http.StatusOK {
+		t.Fatalf("auth status = %d, want 200", statusRecorder.Code)
+	}
+	if got := statusRecorder.Header().Get("Cache-Control"); got != "no-store" {
+		t.Errorf("auth status Cache-Control = %q, want no-store", got)
+	}
+	statusResponse := decodeAuthAdminResponse(t, statusRecorder)
+	for key, want := range response {
+		if got := statusResponse[key]; !reflect.DeepEqual(got, want) {
+			t.Errorf("status[%q] = %v, want reload value %v", key, got, want)
+		}
+	}
+	if whoamiRequests != 1 {
+		t.Fatalf("status whoami requests = %d, want 1", whoamiRequests)
+	}
+
+	const upstreamBodySecret = "synthetic-upstream-body-secret-must-not-leak"
+	g.authMu.Lock()
+	g.authLastErr = `oauth2: cannot fetch token: 400 Bad Request\nResponse: {"error":"invalid_grant","refresh_token":"` + upstreamBodySecret + `"}`
+	g.authLastErrAt = time.Now()
+	g.authMu.Unlock()
+	sanitized := authReloadRequest(t, g, http.MethodPost, nil)
+	if sanitized.Code != http.StatusOK {
+		t.Fatalf("reload with prior refresh failure status = %d, want 200", sanitized.Code)
+	}
+	if _, present := decodeAuthAdminResponse(t, sanitized)["last_refresh_error"]; present {
+		t.Fatal("local reload receipt includes last_refresh_error")
+	}
+	assertResponseOmits(t, sanitized, refreshToken, accessToken, upstreamBodySecret, "Response:")
+}
+
+func TestAdminAuthReloadLoadsAndReplacesAPIKeyProfile(t *testing.T) {
+	const firstKey = "synthetic-profile-key-one-must-not-leak"
+	const replacementKey = "synthetic-profile-key-two-must-not-leak"
+	cfg := testConfig(t, "http://baseten.invalid", "http://anthropic.invalid")
+	cfg.OAuthProfile = "p"
+	cfg.APIKeyFallback = false
+	cfg.BasetenKey = ""
+	g := newAuthReloadTestGateway(t, cfg)
+
+	writeAPIKeyProfile(t, firstKey)
+	first := authReloadRequest(t, g, http.MethodPost, nil)
+	if first.Code != http.StatusOK {
+		t.Fatalf("first reload status = %d, want 200; body = %s", first.Code, first.Body.String())
+	}
+	firstResponse := decodeAuthAdminResponse(t, first)
+	if firstResponse["signed_in"] != true || firstResponse["auth_type"] != "api_key" || firstResponse["health"] != "ok" {
+		t.Fatalf("first reload response = %+v", firstResponse)
+	}
+	assertResponseOmits(t, first, firstKey, "Api-Key ")
+
+	writeAPIKeyProfile(t, replacementKey)
+	replacement := authReloadRequest(t, g, http.MethodPost, nil)
+	if replacement.Code != http.StatusOK {
+		t.Fatalf("replacement reload status = %d, want 200; body = %s", replacement.Code, replacement.Body.String())
+	}
+	selected, ok := g.basetenProfileAuth()
+	if !ok || selected.source != basetenAuthProfileAPIKey || selected.apiKey != replacementKey {
+		t.Fatalf("selected profile auth = source %q, key replaced %t", selected.source, selected.apiKey == replacementKey)
+	}
+	assertResponseOmits(t, replacement, firstKey, replacementKey, "Api-Key ")
+}
+
+func TestAdminAuthReloadRejectsMethodsAndBodiesBeforeMutation(t *testing.T) {
+	const profileKey = "synthetic-rejected-request-key-must-not-leak"
+	cfg := testConfig(t, "http://baseten.invalid", "http://anthropic.invalid")
+	cfg.OAuthProfile = "p"
+	cfg.APIKeyFallback = false
+	cfg.BasetenKey = ""
+	g := newAuthReloadTestGateway(t, cfg)
+	writeAPIKeyProfile(t, profileKey)
+
+	for name, header := range map[string]string{
+		"missing": "",
+		"wrong":   "0",
+	} {
+		t.Run("admin_header_"+name, func(t *testing.T) {
+			recorder := authReloadRequestWithHeader(t, g, header)
+			if recorder.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want 403; body = %s", recorder.Code, recorder.Body.String())
+			}
+			assertResponseOmits(t, recorder, profileKey)
+			if signedIn, _, _ := g.authState(); signedIn {
+				t.Fatal("rejected admin header reloaded authentication")
+			}
+		})
+	}
+
+	for _, method := range []string{
+		http.MethodGet,
+		http.MethodHead,
+		http.MethodPut,
+		http.MethodPatch,
+		http.MethodDelete,
+		http.MethodOptions,
+	} {
+		t.Run(method, func(t *testing.T) {
+			// Method rejection precedes the mutation-header check. In
+			// particular, browser preflight receives 405 with no CORS grant.
+			req := httptest.NewRequest(method, "/v1/admin/auth/reload", nil)
+			recorder := httptest.NewRecorder()
+			g.adminServer.Handler.ServeHTTP(recorder, req)
+			if recorder.Code != http.StatusMethodNotAllowed {
+				t.Fatalf("status = %d, want 405; body = %s", recorder.Code, recorder.Body.String())
+			}
+			assertResponseOmits(t, recorder, profileKey)
+			if signedIn, _, _ := g.authState(); signedIn {
+				t.Fatal("rejected method reloaded authentication")
+			}
+		})
+	}
+
+	for name, body := range map[string]string{
+		"json":       `{}`,
+		"space":      " ",
+		"line_break": "\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			recorder := authReloadRequest(t, g, http.MethodPost, strings.NewReader(body))
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400; body = %s", recorder.Code, recorder.Body.String())
+			}
+			assertResponseOmits(t, recorder, profileKey)
+			if signedIn, _, _ := g.authState(); signedIn {
+				t.Fatal("rejected body reloaded authentication")
+			}
+		})
+	}
+
+	valid := authReloadRequest(t, g, http.MethodPost, bytes.NewReader(nil))
+	if valid.Code != http.StatusOK {
+		t.Fatalf("empty-body reload status = %d, want 200; body = %s", valid.Code, valid.Body.String())
+	}
+	if signedIn, authType, _ := g.authState(); !signedIn || authType != "api_key" {
+		t.Fatalf("valid reload = signed_in %t, auth_type %q", signedIn, authType)
+	}
+	assertResponseOmits(t, valid, profileKey, "Api-Key ")
+}
+
+func TestAdminAuthReloadSerializesWithConfigReload(t *testing.T) {
+	const profileKey = "synthetic-serialized-profile-key"
+	cfg := testConfig(t, "http://baseten.invalid", "http://anthropic.invalid")
+	cfg.OAuthProfile = "profile-before-config-reload"
+	cfg.APIKeyFallback = false
+	cfg.BasetenKey = ""
+	g := newAuthReloadTestGateway(t, cfg)
+	writeAPIKeyProfile(t, profileKey)
+
+	g.reloadMu.Lock()
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		done <- authReloadRequest(t, g, http.MethodPost, nil)
+	}()
+	select {
+	case <-done:
+		g.reloadMu.Unlock()
+		t.Fatal("auth reload completed while config reload lock was held")
+	case <-time.After(25 * time.Millisecond):
+	}
+	next := g.runtimeConfig()
+	next.OAuthProfile = "p"
+	g.setRuntimeConfig(next)
+	g.reloadMu.Unlock()
+
+	select {
+	case recorder := <-done:
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", recorder.Code, recorder.Body.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("auth reload did not complete after config reload lock was released")
+	}
+	selected, ok := g.basetenProfileAuth()
+	if !ok || selected.source != basetenAuthProfileAPIKey || selected.apiKey != profileKey {
+		t.Fatalf("auth reload published stale profile: source %q, selected current key %t", selected.source, selected.apiKey == profileKey)
+	}
+}
+
+func TestAdminAuthReloadClearsCachedIdentityOnCredentialReplacement(t *testing.T) {
+	const (
+		accessA  = "synthetic-access-a"
+		refreshA = "synthetic-refresh-a"
+		accessB  = "synthetic-access-b"
+		refreshB = "synthetic-refresh-b"
+	)
+	var whoamiRequests int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		whoamiRequests++
+		email := ""
+		switch r.Header.Get("Authorization") {
+		case "Bearer " + accessA:
+			email = "account-a@example.invalid"
+		case "Bearer " + accessB:
+			email = "account-b@example.invalid"
+		default:
+			t.Errorf("unexpected Authorization header")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"email":%q}`, email)
+	}))
+	defer upstream.Close()
+
+	cfg := testConfig(t, upstream.URL, upstream.URL)
+	cfg.OAuthProfile = "p"
+	cfg.OAuthHost = upstream.URL
+	cfg.APIKeyFallback = false
+	cfg.BasetenKey = ""
+	g := newAuthReloadTestGateway(t, cfg)
+	writeOAuthProfileWithAccessToken(t, upstream.URL, accessA, refreshA)
+	if recorder := authReloadRequest(t, g, http.MethodPost, nil); recorder.Code != http.StatusOK {
+		t.Fatalf("first reload status = %d", recorder.Code)
+	}
+
+	status := httptest.NewRecorder()
+	g.adminServer.Handler.ServeHTTP(status, httptest.NewRequest(http.MethodGet, "/v1/admin/auth/status", nil))
+	if got := decodeAuthAdminResponse(t, status)["email"]; got != "account-a@example.invalid" {
+		t.Fatalf("first email = %q", got)
+	}
+	if whoamiRequests != 1 {
+		t.Fatalf("first whoami requests = %d, want 1", whoamiRequests)
+	}
+
+	writeOAuthProfileWithAccessToken(t, upstream.URL, accessB, refreshB)
+	if recorder := authReloadRequest(t, g, http.MethodPost, nil); recorder.Code != http.StatusOK {
+		t.Fatalf("replacement reload status = %d", recorder.Code)
+	}
+	if whoamiRequests != 1 {
+		t.Fatalf("replacement reload made an upstream request; hits = %d", whoamiRequests)
+	}
+
+	status = httptest.NewRecorder()
+	g.adminServer.Handler.ServeHTTP(status, httptest.NewRequest(http.MethodGet, "/v1/admin/auth/status", nil))
+	if got := decodeAuthAdminResponse(t, status)["email"]; got != "account-b@example.invalid" {
+		t.Fatalf("replacement email = %q, want account B", got)
+	}
+	if whoamiRequests != 2 {
+		t.Fatalf("replacement whoami requests = %d, want 2", whoamiRequests)
+	}
+}
+
+func TestAdminAuthReloadClearsTransientHealthAcrossLogoutAndLogin(t *testing.T) {
+	cfg := testConfig(t, "http://baseten.invalid", "http://anthropic.invalid")
+	cfg.OAuthProfile = "p"
+	cfg.APIKeyFallback = false
+	cfg.BasetenKey = ""
+	g := newAuthReloadTestGateway(t, cfg)
+	writeOAuthProfileWithAccessToken(t, "http://baseten.invalid", "synthetic-access-a", "synthetic-refresh-a")
+	if recorder := authReloadRequest(t, g, http.MethodPost, nil); recorder.Code != http.StatusOK {
+		t.Fatalf("first reload status = %d", recorder.Code)
+	}
+	g.authMu.Lock()
+	g.authLastErr = "synthetic transient network failure"
+	g.authLastErrAt = time.Now()
+	g.authMu.Unlock()
+
+	if err := os.Remove(os.Getenv("BASETEN_SWITCH_AUTH_FILE")); err != nil {
+		t.Fatal(err)
+	}
+	logout := authReloadRequest(t, g, http.MethodPost, nil)
+	logoutResponse := decodeAuthAdminResponse(t, logout)
+	if logoutResponse["signed_in"] != false || logoutResponse["health"] != "signed_out" {
+		t.Fatalf("logout reload response = %+v", logoutResponse)
+	}
+
+	writeOAuthProfileWithAccessToken(t, "http://baseten.invalid", "synthetic-access-b", "synthetic-refresh-b")
+	login := authReloadRequest(t, g, http.MethodPost, nil)
+	loginResponse := decodeAuthAdminResponse(t, login)
+	if loginResponse["signed_in"] != true || loginResponse["health"] != "ok" {
+		t.Fatalf("replacement login response = %+v", loginResponse)
+	}
+	if health := g.authHealth(); health.LastError != "" || !health.LastErrorAt.IsZero() {
+		t.Fatalf("replacement login retained transient health: %+v", health)
+	}
+}

--- a/gateway/cmd/gateway/gateway.go
+++ b/gateway/cmd/gateway/gateway.go
@@ -808,15 +808,35 @@ func (g *Gateway) shutdownAllClients() {
 }
 
 func (g *Gateway) refreshAuth() {
+	g.reloadMu.Lock()
+	defer g.reloadMu.Unlock()
+	g.refreshAuthLocked()
+}
+
+// refreshAuthLocked reloads the selected CLI credential while reloadMu is
+// held. Config reload and explicit auth reload both use this path so an auth
+// client built for an old profile cannot publish after a newer runtime config.
+// Credential-store and Keychain reads happen outside authMu, keeping status
+// reads and in-flight request auth selection responsive while the load runs.
+// Publishing preserves the existing nonblocking catalog-refresh kick.
+func (g *Gateway) refreshAuthLocked() {
 	cfg := g.runtimeConfig()
 	g.authMu.Lock()
-	defer g.authMu.Unlock()
 	// Each build is a new lineage: outcomes from clients built before
 	// this swap are stale and noteAuthRefresh drops them by generation.
 	g.authGen++
 	gen := g.authGen
+	g.authMu.Unlock()
+
 	notify := func(fp string, err error) { g.noteAuthRefresh(gen, fp, err) }
 	client, tick, credFP, err := auth.HTTPClientWithNotify(context.Background(), cfg.OAuthProfile, cfg.OAuthHost, notify)
+
+	g.authMu.Lock()
+	defer g.authMu.Unlock()
+	if gen != g.authGen {
+		return
+	}
+	previousStoreFP := g.authStoreFP
 	g.cliProfileAPIKey = ""
 	g.authStoreFP = ""
 	switch {
@@ -840,18 +860,30 @@ func (g *Gateway) refreshAuth() {
 			g.cliProfileAPIKey = strings.TrimSpace(apiKeyProfile.Key)
 			g.authStoreFP = apiKeyStoreFingerprint(apiKeyProfile.Profile, g.cliProfileAPIKey)
 		}
-		// API-key profiles have no OAuth refresh lineage. Do not carry
-		// OAuth-only health state across a profile transition.
-		g.authDead = false
-		g.authDeadFP = ""
-		g.authLastErr = ""
-		g.authLastErrAt = time.Time{}
-		g.authLastOKAt = time.Time{}
 	default:
 		g.oauthClient = nil
 		g.authTick = nil
 		g.oauthProfileErr = err
 		fmt.Fprintf(os.Stderr, "[gateway] auth refresh failed: %v\n", err)
+	}
+	credentialChanged := previousStoreFP != g.authStoreFP
+	if credentialChanged {
+		// Health belongs to one credential identity. Login, logout, profile
+		// replacement, and auth-type transitions must not inherit a prior
+		// OAuth failure or success timestamp.
+		g.authDead = false
+		g.authDeadFP = ""
+		g.authLastErr = ""
+		g.authLastErrAt = time.Time{}
+		g.authLastOKAt = time.Time{}
+
+		// Cached identity also belongs to the credential that fetched it.
+		// Clearing on the same store identity transition prevents status from
+		// showing the previous account for up to the cache TTL.
+		g.emailMu.Lock()
+		g.emailCached = ""
+		g.emailFetchedAt = time.Time{}
+		g.emailMu.Unlock()
 	}
 	// Re-login detection: if the credential was marked dead but the
 	// store now holds a DIFFERENT refresh token than the one that died
@@ -4437,7 +4469,7 @@ func (g *Gateway) reloadConfig() {
 		}(lg)
 	}
 
-	g.refreshAuth()
+	g.refreshAuthLocked()
 	runtimeCfg := g.runtimeConfig()
 	runPreflight(&runtimeCfg, desired, os.Stderr)
 }

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/AppVariant.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/AppVariant.swift
@@ -21,20 +21,56 @@ struct RuntimeProfile: Equatable {
 
     static func stable(environment: [String: String] = ProcessInfo.processInfo.environment)
         -> RuntimeProfile {
-        let binaryEnvironment = environment["BASETEN_SWITCH_GATEWAY_BIN"]
-            .flatMap { $0.isEmpty ? nil : ["BASETEN_SWITCH_GATEWAY_BIN": $0] }
-            ?? [:]
+        let adminBaseURL = endpointURL(
+            url: environment["BASETEN_SWITCH_ADMIN_URL"],
+            address: environment["BASETEN_SWITCH_ADMIN_ADDR"],
+            defaultPort: 45273)
+        // Retain only explicit local-runtime coordination overrides. The
+        // child-process allowlist still strips credentials and unrelated
+        // ambient state, while these values keep a Stable development build
+        // connected to the same isolated router for reads and mutations.
+        let coordinationKeys = [
+            "BASETEN_SWITCH_GATEWAY_BIN",
+            "BASETEN_SWITCH_CONFIG_PATH",
+            "BASETEN_SWITCH_ADMIN_ADDR",
+            "BASETEN_SWITCH_ADMIN_URL",
+            "BASETEN_SWITCH_GATEWAY_ADMIN",
+            "BASETEN_SWITCH_GATEWAY_PIDFILE",
+        ]
+        var coordinationEnvironment: [String: String] = [:]
+        for key in coordinationKeys {
+            if let value = environment[key], !value.isEmpty {
+                coordinationEnvironment[key] = value
+            }
+        }
+        let hasExplicitAdminEndpoint =
+            environment["BASETEN_SWITCH_ADMIN_URL"]?.isEmpty == false
+            || environment["BASETEN_SWITCH_ADMIN_ADDR"]?.isEmpty == false
+        if hasExplicitAdminEndpoint,
+           let address = loopbackAdminAddress(adminBaseURL) {
+            // The app accepts ADMIN_URL as the higher-precedence read
+            // endpoint, while the CLI consumes ADMIN_ADDR. Canonicalize both
+            // inputs to the same loopback endpoint for child mutations.
+            coordinationEnvironment["BASETEN_SWITCH_ADMIN_ADDR"] = address
+        }
         return RuntimeProfile(
-            adminBaseURL: endpointURL(
-                url: environment["BASETEN_SWITCH_ADMIN_URL"],
-                address: environment["BASETEN_SWITCH_ADMIN_ADDR"],
-                defaultPort: 45273),
+            adminBaseURL: adminBaseURL,
             doorURLs: doorEndpointURLs(
                 urls: environment["BASETEN_SWITCH_DOOR_URLS"],
                 ports: environment["BASETEN_SWITCH_DOOR_PORTS"],
                 defaultPorts: [45271]),
             expectedConfigPath: nil,
-            environment: binaryEnvironment)
+            environment: coordinationEnvironment)
+    }
+
+    private static func loopbackAdminAddress(_ url: URL) -> String? {
+        guard url.scheme?.lowercased() == "http",
+              let host = url.host?.lowercased(),
+              host == "127.0.0.1" || host == "localhost" || host == "::1",
+              let port = url.port else {
+            return nil
+        }
+        return host == "::1" ? "[::1]:\(port)" : "\(host):\(port)"
     }
 
     static func preview(

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/BasetenSwitchState.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/BasetenSwitchState.swift
@@ -105,6 +105,7 @@ final class BasetenSwitchState: ObservableObject {
     @Published private(set) var mutationRecoveryState: MutationRecoveryState
 
     private let reader: any AdminStatusReading
+    private let authReloader: any AuthReloading
     private let modelCatalogReader: any ModelCatalogReading
     private let reasoningPreflightReader: any ReasoningPreflightReading
     private let cliRunner: any CLIRunning
@@ -117,8 +118,12 @@ final class BasetenSwitchState: ObservableObject {
     private var reconcileTimers: [String: Task<Void, Never>] = [:]
     private var interactiveRefreshTask: Task<Void, Never>?
     private var interactiveStatsRequested = false
+    private var clientPageRefreshTask: Task<Void, Never>?
+    private var clientPageRefreshPending = false
     private var modelCatalogTask: Task<Void, Never>?
     private var modelCatalogGeneration: UInt64 = 0
+    private var refreshingModelCatalog: [LiveModelCatalogEntry]?
+    private var automaticCatalogRecoveryGeneration: UInt64?
     private var mutationRecoveryTask: Task<Void, Never>?
     private var mutationRecoveryKey: MutationRecoveryKey?
     private var unsupportedRecoveryRuntime: String?
@@ -150,6 +155,7 @@ final class BasetenSwitchState: ObservableObject {
 
     init(variant: AppVariant = .current(),
          reader: (any AdminStatusReading)? = nil,
+         authReloader: (any AuthReloading)? = nil,
          modelCatalogReader: (any ModelCatalogReading)? = nil,
          reasoningPreflightReader: (any ReasoningPreflightReading)? = nil,
          cliRunner: any CLIRunning = SystemCLIRunner(),
@@ -163,6 +169,7 @@ final class BasetenSwitchState: ObservableObject {
         self.variant = variant
         let apiClient = GatewayAPIClient(runtime: variant.runtime)
         self.reader = reader ?? apiClient
+        self.authReloader = authReloader ?? apiClient
         self.modelCatalogReader = modelCatalogReader ?? apiClient
         self.reasoningPreflightReader = reasoningPreflightReader ?? apiClient
         self.cliRunner = cliRunner
@@ -215,6 +222,7 @@ final class BasetenSwitchState: ObservableObject {
         self.variant = variant
         let reader = GatewayAPIClient(runtime: variant.runtime)
         self.reader = reader
+        authReloader = reader
         modelCatalogReader = reader
         reasoningPreflightReader = reader
         cliRunner = SystemCLIRunner()
@@ -260,6 +268,9 @@ final class BasetenSwitchState: ObservableObject {
         interactiveRefreshTask?.cancel()
         interactiveRefreshTask = nil
         interactiveStatsRequested = false
+        clientPageRefreshTask?.cancel()
+        clientPageRefreshTask = nil
+        clientPageRefreshPending = false
         invalidateModelCatalog()
         mutationRecoveryTask?.cancel()
         mutationRecoveryTask = nil
@@ -273,9 +284,18 @@ final class BasetenSwitchState: ObservableObject {
         apply(await pollCoordinator.refresh())
     }
 
+    /// Establishes a read barrier after a child-process mutation. A normal
+    /// refresh may join a status request that began before the mutation and
+    /// falsely report that the confirmed change is absent.
+    private func refreshAfterMutation() async {
+        guard let pollCoordinator else { return }
+        apply(await pollCoordinator.refreshFresh())
+    }
+
     private func apply(_ event: PollEvent) {
         switch event {
         case .snapshot(let snapshot):
+            let previousAuth = routingSnapshot?.auth
             let meaningfulChange = routingSnapshot.map {
                 !routingPresentationEqual($0, snapshot)
             } ?? true
@@ -293,6 +313,9 @@ final class BasetenSwitchState: ObservableObject {
                 }
             }
             beginAutomaticMutationRecoveryIfNeeded(snapshot)
+            requestAutomaticModelCatalogRecoveryIfNeeded(
+                previousAuth: previousAuth,
+                currentAuth: snapshot.auth)
         case .unavailable:
             if !snapshotIsStale {
                 snapshotIsStale = true
@@ -493,7 +516,7 @@ final class BasetenSwitchState: ObservableObject {
         for key: MutationRecoveryKey,
         state: MutationRecoveryState
     ) async {
-        await refresh()
+        await refreshAfterMutation()
         guard recoveryKeyIsCurrent(key), !Task.isCancelled else { return }
         mutationRecoveryState = state
     }
@@ -558,6 +581,46 @@ final class BasetenSwitchState: ObservableObject {
         await interactiveRefreshTask?.value
     }
 
+    /// Coalesces client-page toolbar refreshes into one ordered operation.
+    /// Auth reload is best effort for compatibility with older routers, while
+    /// status and catalog retain their existing independent error surfaces.
+    func requestClientPageRefresh() {
+        guard clientPageRefreshTask == nil else {
+            clientPageRefreshPending = true
+            return
+        }
+        beginModelCatalogLoading()
+        clientPageRefreshTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                _ = try await self.authReloader.reloadAuth()
+            } catch {
+                // Older routers do not expose the reload endpoint. Continue
+                // with the normal reads so mixed-version installations remain
+                // usable and surface their existing sanitized state.
+            }
+            guard !Task.isCancelled else { return }
+            if let pollCoordinator = self.pollCoordinator {
+                self.apply(await pollCoordinator.refreshFresh())
+            }
+            guard !Task.isCancelled else { return }
+            self.requestModelCatalogRefresh()
+            await self.waitForModelCatalogRefresh()
+            guard !Task.isCancelled else { return }
+            self.clientPageRefreshTask = nil
+            if self.clientPageRefreshPending {
+                self.clientPageRefreshPending = false
+                self.requestClientPageRefresh()
+            }
+        }
+    }
+
+    func waitForClientPageRefresh() async {
+        while let task = clientPageRefreshTask {
+            await task.value
+        }
+    }
+
     // MARK: - Live model catalog
 
     func ensureModelCatalogLoaded() {
@@ -566,14 +629,15 @@ final class BasetenSwitchState: ObservableObject {
     }
 
     func routerWindowDidClose() {
+        clientPageRefreshTask?.cancel()
+        clientPageRefreshTask = nil
+        clientPageRefreshPending = false
         invalidateModelCatalog()
     }
 
     func requestModelCatalogRefresh() {
-        modelCatalogGeneration &+= 1
-        let generation = modelCatalogGeneration
-        modelCatalogTask?.cancel()
-        liveModelCatalogState = .loading
+        automaticCatalogRecoveryGeneration = nil
+        let generation = beginModelCatalogLoading()
         let reader = modelCatalogReader
         modelCatalogTask = Task { [weak self] in
             do {
@@ -583,8 +647,8 @@ final class BasetenSwitchState: ObservableObject {
                       self.modelCatalogGeneration == generation else {
                     return
                 }
-                self.applyModelCatalog(snapshot)
                 self.modelCatalogTask = nil
+                self.applyModelCatalog(snapshot, generation: generation)
             } catch is CancellationError {
                 return
             } catch {
@@ -593,6 +657,10 @@ final class BasetenSwitchState: ObservableObject {
                       self.modelCatalogGeneration == generation else {
                     return
                 }
+                if self.automaticCatalogRecoveryGeneration == generation {
+                    self.automaticCatalogRecoveryGeneration = nil
+                }
+                self.refreshingModelCatalog = nil
                 self.liveModelCatalogState = .error(
                     "Live model availability could not be loaded.")
                 self.modelCatalogTask = nil
@@ -601,17 +669,37 @@ final class BasetenSwitchState: ObservableObject {
     }
 
     func waitForModelCatalogRefresh() async {
-        await modelCatalogTask?.value
+        while let task = modelCatalogTask {
+            await task.value
+        }
     }
 
     func modelCatalogProjection(for client: ClientStatus)
         -> ModelCatalogProjection {
-        projectModelCatalog(
+        let projectionState: LiveModelCatalogLoadState
+        if case .loading = liveModelCatalogState,
+           let refreshingModelCatalog {
+            projectionState = .ready(refreshingModelCatalog)
+        } else {
+            projectionState = liveModelCatalogState
+        }
+        return projectModelCatalog(
             configured: client.modelCatalog,
-            liveState: liveModelCatalogState)
+            liveState: projectionState)
     }
 
-    private func applyModelCatalog(_ snapshot: LiveModelCatalogSnapshot) {
+    var modelCatalogAllowsMutation: Bool {
+        if case .ready = liveModelCatalogState {
+            return true
+        }
+        return false
+    }
+
+    private func applyModelCatalog(
+        _ snapshot: LiveModelCatalogSnapshot,
+        generation: UInt64
+    ) {
+        refreshingModelCatalog = nil
         switch snapshot.state {
         case .ready:
             liveModelCatalogState = .ready(snapshot.models)
@@ -628,13 +716,71 @@ final class BasetenSwitchState: ObservableObject {
                     ? "Live model availability could not be loaded."
                     : snapshot.error)
         }
+
+        guard automaticCatalogRecoveryGeneration == generation else {
+            return
+        }
+        automaticCatalogRecoveryGeneration = nil
+        if snapshot.state == .signedOut,
+           snapshot.signedOutReason == .notSignedIn {
+            requestModelCatalogRefresh()
+        }
+    }
+
+    private func requestAutomaticModelCatalogRecoveryIfNeeded(
+        previousAuth: AuthStatus?,
+        currentAuth: AuthStatus?
+    ) {
+        guard clientPageRefreshTask == nil,
+              selectedProfileIsUnavailable(previousAuth),
+              selectedProfileIsHealthy(currentAuth) else {
+            return
+        }
+        switch liveModelCatalogState {
+        case .signedOut(.notSignedIn):
+            requestModelCatalogRefresh()
+        case .loading:
+            automaticCatalogRecoveryGeneration = modelCatalogGeneration
+        case .idle, .ready, .signedOut, .error:
+            break
+        }
+    }
+
+    private func selectedProfileIsUnavailable(_ auth: AuthStatus?) -> Bool {
+        guard let auth else { return false }
+        return !auth.signedIn || auth.health == "signed_out"
+    }
+
+    private func selectedProfileIsHealthy(_ auth: AuthStatus?) -> Bool {
+        guard let auth else { return false }
+        return auth.signedIn && auth.health == "ok"
     }
 
     private func invalidateModelCatalog() {
+        refreshingModelCatalog = nil
+        automaticCatalogRecoveryGeneration = nil
         modelCatalogGeneration &+= 1
         modelCatalogTask?.cancel()
         modelCatalogTask = nil
         liveModelCatalogState = .idle
+    }
+
+    @discardableResult
+    private func beginModelCatalogLoading() -> UInt64 {
+        automaticCatalogRecoveryGeneration = nil
+        if case .ready(let models) = liveModelCatalogState {
+            refreshingModelCatalog = models
+        } else if case .loading = liveModelCatalogState {
+            // Preserve the same last confirmed catalog across an ordered
+            // auth/status/catalog refresh or a coalesced refresh rerun.
+        } else {
+            refreshingModelCatalog = nil
+        }
+        modelCatalogGeneration &+= 1
+        modelCatalogTask?.cancel()
+        modelCatalogTask = nil
+        liveModelCatalogState = .loading
+        return modelCatalogGeneration
     }
 
     func refreshStats() async {
@@ -739,7 +885,7 @@ final class BasetenSwitchState: ObservableObject {
         let attempt = await executePolicyMutation(
             arguments,
             operationID: pending.operationID)
-        await refresh()
+        await refreshAfterMutation()
 
         let receipt = attempt.receipt
         let confirmed = attempt.result.succeeded
@@ -852,7 +998,7 @@ final class BasetenSwitchState: ObservableObject {
                 client: client.name,
                 key: "default_model",
                 requestedTarget: model.slug))
-        await refresh()
+        await refreshAfterMutation()
         let receipt = attempt.receipt
         let confirmed = !snapshotIsStale
             && attempt.result.succeeded
@@ -952,7 +1098,7 @@ final class BasetenSwitchState: ObservableObject {
                 client: client.name,
                 key: family,
                 requestedTarget: requestedTarget))
-        await refresh()
+        await refreshAfterMutation()
         let receipt = attempt.receipt
         let confirmed = !snapshotIsStale
             && attempt.result.succeeded
@@ -1036,7 +1182,7 @@ final class BasetenSwitchState: ObservableObject {
                 client: client.name,
                 key: "subagents",
                 requestedTarget: requestedTarget))
-        await refresh()
+        await refreshAfterMutation()
         let receipt = attempt.receipt
         let confirmed = !snapshotIsStale
             && attempt.result.succeeded
@@ -1248,7 +1394,7 @@ final class BasetenSwitchState: ObservableObject {
                 client: client,
                 key: model,
                 requestedTarget: requestedTarget))
-        await refresh()
+        await refreshAfterMutation()
         let receipt = attempt.receipt
         let confirmed = !snapshotIsStale
             && attempt.result.succeeded
@@ -1545,6 +1691,8 @@ final class BasetenSwitchState: ObservableObject {
             return "A previous routing change still needs cleanup."
         case "router_unavailable":
             return "The local gateway is unavailable. Try again after it reconnects."
+        case "router_state_mismatch", "router_identity_mismatch":
+            return "The app and routing command are connected to different local gateways. Restart Baseten Switch and try again."
         case "router_unsupported":
             return "Update the local gateway before changing routing settings."
         case "journal_not_found":
@@ -1887,7 +2035,22 @@ func cliEnvironmentOverrides(configPath: String,
     if variant.channel == .preview {
         return variant.runtime.environment
     }
-    return cliEnvironmentOverrides(configPath: configPath)
+    let coordinationKeys = [
+        "BASETEN_SWITCH_ADMIN_ADDR",
+        "BASETEN_SWITCH_GATEWAY_PIDFILE",
+    ]
+    var overrides = variant.runtime.environment.filter {
+        coordinationKeys.contains($0.key)
+    }
+    let effectiveConfigPath = configPath.isEmpty
+        ? variant.runtime.environment["BASETEN_SWITCH_CONFIG_PATH"] ?? ""
+        : configPath
+    if !effectiveConfigPath.isEmpty {
+        // The explicit launch path is a safe pre-status fallback. Once status
+        // is available, the router-reported path is authoritative.
+        overrides["BASETEN_SWITCH_CONFIG_PATH"] = effectiveConfigPath
+    }
+    return overrides
 }
 
 func canonicalPath(_ path: String) -> String {

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/Display.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/Display.swift
@@ -5,10 +5,9 @@ import Foundation
 // what /v1/admin/status reports.
 
 /// Menubar icon state. Precedence: degraded > active > off.
-/// - degraded: gateway up AND (the stored Baseten credential is dead
-///   (auth health "refresh_failed") OR any enabled client reports
-///   an active fallback), regardless of routes. A dead credential warns
-///   on any route state so the user notices without opening the popup.
+/// - degraded: gateway up AND shared auth attention requires action OR any
+///   enabled client reports an active fallback. Refresh failure remains
+///   route-independent; signed-out attention is route-aware.
 /// - active: gateway up AND any enabled client routes through
 ///   Baseten (route == "baseten").
 /// - off: everything else, including gateway down with stale
@@ -28,7 +27,12 @@ enum MenubarIconState: Equatable {
 func menubarIconState(gatewayUp: Bool, clients: [ClientStatus],
                       auth: AuthStatus? = nil) -> MenubarIconState {
     guard gatewayUp else { return .off }
-    if authNeedsReauth(auth: auth) {
+    if authAttention(
+        gatewayUp: gatewayUp,
+        globalRoutingEnabled: clients.contains(
+            where: clientRequiresBasetenAuth),
+        clients: clients,
+        auth: auth) != .none {
         return .degraded
     }
     if clients.contains(where: { $0.enabled && $0.fallbackActive }) {
@@ -46,7 +50,11 @@ func menubarIconState(gatewayUp: Bool,
                       clients: [ClientStatus],
                       auth: AuthStatus? = nil) -> MenubarIconState {
     guard gatewayUp else { return .off }
-    if authNeedsReauth(auth: auth)
+    if authAttention(
+        gatewayUp: gatewayUp,
+        globalRoutingEnabled: globalRoutingEnabled,
+        clients: clients,
+        auth: auth) != .none
         || clients.contains(where: { $0.enabled && $0.fallbackActive }) {
         return .degraded
     }

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/GatewayClient.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/GatewayClient.swift
@@ -653,6 +653,10 @@ protocol AdminStatusReading: Sendable {
     func fetchStats(windowSeconds: Int, bucketSeconds: Int) async throws -> StatsSnapshot
 }
 
+protocol AuthReloading: Sendable {
+    func reloadAuth() async throws -> AuthStatus
+}
+
 protocol ModelCatalogReading: Sendable {
     func fetchModelCatalog() async throws -> LiveModelCatalogSnapshot
 }
@@ -666,9 +670,12 @@ protocol ReasoningPreflightReading: Sendable {
     ) async throws -> ReasoningPreflightSnapshot
 }
 
-final class GatewayAPIClient: AdminStatusReading, ModelCatalogReading,
+final class GatewayAPIClient: AdminStatusReading, AuthReloading,
+                              ModelCatalogReading,
                               ReasoningPreflightReading,
                               @unchecked Sendable {
+    private static let adminRequestTimeout: TimeInterval = 2
+    private static let modelCatalogRequestTimeout: TimeInterval = 4
     private let runtime: RuntimeProfile
     private let session: URLSession
 
@@ -707,8 +714,18 @@ final class GatewayAPIClient: AdminStatusReading, ModelCatalogReading,
         return StatsSnapshot(dict: dict)
     }
 
+    func reloadAuth() async throws -> AuthStatus {
+        let object = try await postEmptyJSON("v1/admin/auth/reload")
+        guard let dict = object as? [String: Any] else {
+            throw GatewayClientError.invalidPayload
+        }
+        return AuthStatus(dict: dict)
+    }
+
     func fetchModelCatalog() async throws -> LiveModelCatalogSnapshot {
-        let object = try await getJSON("v1/admin/model-catalog")
+        let object = try await getJSON(
+            "v1/admin/model-catalog",
+            timeoutInterval: Self.modelCatalogRequestTimeout)
         guard let dict = object as? [String: Any],
               let snapshot = LiveModelCatalogSnapshot(dict: dict) else {
             throw GatewayClientError.invalidPayload
@@ -739,7 +756,10 @@ final class GatewayAPIClient: AdminStatusReading, ModelCatalogReading,
     }
 
     private func getJSON(_ path: String,
-                         query: [URLQueryItem] = []) async throws -> Any {
+                         query: [URLQueryItem] = [],
+                         timeoutInterval: TimeInterval =
+                            GatewayAPIClient.adminRequestTimeout) async throws
+        -> Any {
         var url = adminBaseURL(runtime: runtime)
         url.appendPathComponent(path)
         if !query.isEmpty,
@@ -749,7 +769,9 @@ final class GatewayAPIClient: AdminStatusReading, ModelCatalogReading,
                 url = queriedURL
             }
         }
-        let (data, response) = try await session.data(from: url)
+        var request = URLRequest(url: url)
+        request.timeoutInterval = timeoutInterval
+        let (data, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse,
               (200..<300).contains(http.statusCode) else {
             throw GatewayClientError.badResponse(
@@ -771,6 +793,22 @@ final class GatewayAPIClient: AdminStatusReading, ModelCatalogReading,
             forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONSerialization.data(
             withJSONObject: body)
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse,
+              (200..<300).contains(http.statusCode) else {
+            throw GatewayClientError.badResponse(
+                (response as? HTTPURLResponse)?.statusCode ?? -1)
+        }
+        return try JSONSerialization.jsonObject(with: data)
+    }
+
+    private func postEmptyJSON(_ path: String) async throws -> Any {
+        var request = URLRequest(
+            url: adminBaseURL(runtime: runtime)
+                .appendingPathComponent(path))
+        request.httpMethod = "POST"
+        request.setValue("1", forHTTPHeaderField: "X-Baseten-Switch-Admin")
+        request.httpBody = Data()
         let (data, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse,
               (200..<300).contains(http.statusCode) else {

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/PopupDisplay.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/PopupDisplay.swift
@@ -81,12 +81,74 @@ func authLineLabel(auth: AuthStatus?) -> String {
     return "Auth: not signed in"
 }
 
-/// True only in the dead-credential state: drives the warning tint on
-/// the auth line, the Reauthenticate button, and (via
-/// menubarIconState) the amber status icon. Transient "error" stays
-/// false so the popup never alarms on a blip.
+/// True only in the dead-credential state. Retained for display call sites
+/// that specifically need refresh-failure detail; shared menu attention is
+/// projected by authAttention so signed-out state can remain route-aware.
 func authNeedsReauth(auth: AuthStatus?) -> Bool {
     auth?.health == "refresh_failed"
+}
+
+enum AuthAttention: Equatable {
+    case none
+    case signIn
+    case reauthenticate
+}
+
+/// Whether this enabled client has any server-resolved destination that needs
+/// Baseten authentication. The gateway remains authoritative for each
+/// effective route; this traversal does not derive a route from configuration.
+func clientRequiresBasetenAuth(_ client: ClientStatus) -> Bool {
+    guard client.enabled else { return false }
+    if client.effectiveRoute == "baseten" { return true }
+    if client.unmatchedNativeModel?.effectiveRoute == "baseten" { return true }
+    return client.families.contains { $0.effectiveRoute == "baseten" }
+}
+
+/// Shared authentication-attention projection for every Mac surface.
+/// Refresh failure remains a route-independent alarm. Explicit signed-out
+/// state is actionable only when confirmed routing is on, an enabled effective
+/// destination needs Baseten, and the router is not using an API-key fallback.
+func authAttention(
+    gatewayUp: Bool,
+    globalRoutingEnabled: Bool,
+    clients: [ClientStatus],
+    auth: AuthStatus?
+) -> AuthAttention {
+    guard gatewayUp, let auth else { return .none }
+    if auth.health == "refresh_failed" { return .reauthenticate }
+    guard auth.health == "signed_out",
+          !auth.fallbackInUse,
+          globalRoutingEnabled,
+          clients.contains(where: clientRequiresBasetenAuth) else {
+        return .none
+    }
+    return .signIn
+}
+
+func authAttentionHeaderSubtitle(_ attention: AuthAttention) -> String? {
+    switch attention {
+    case .none: return nil
+    case .signIn: return "Sign in to use Baseten"
+    case .reauthenticate: return "Reauthentication required"
+    }
+}
+
+func authAttentionActionTitle(_ attention: AuthAttention) -> String? {
+    switch attention {
+    case .none: return nil
+    case .signIn: return "Sign In to Baseten…"
+    case .reauthenticate: return "Reauthenticate with Baseten…"
+    }
+}
+
+func authAttentionWarningMessage(_ attention: AuthAttention) -> String? {
+    switch attention {
+    case .none: return nil
+    case .signIn:
+        return "Sign in to Baseten to use configured Baseten routes."
+    case .reauthenticate:
+        return "Reauthenticate with Baseten to restore authentication."
+    }
 }
 
 /// Secondary detail line under "reauthentication required": the last
@@ -173,10 +235,19 @@ func globalRoutingState(_ clients: [ClientStatus]) -> GlobalRoutingState {
     return .mixed
 }
 
-func globalRoutingSubtitle(gatewayUp: Bool, clients: [ClientStatus],
+func globalRoutingSubtitle(gatewayUp: Bool,
+                           globalRoutingEnabled: Bool = true,
+                           clients: [ClientStatus],
                            auth: AuthStatus?) -> String {
     guard gatewayUp else { return "Gateway stopped" }
-    if authNeedsReauth(auth: auth) { return "Authentication required" }
+    let attention = authAttention(
+        gatewayUp: gatewayUp,
+        globalRoutingEnabled: globalRoutingEnabled,
+        clients: clients,
+        auth: auth)
+    if let subtitle = authAttentionHeaderSubtitle(attention) {
+        return subtitle
+    }
 
     let enabled = clients.filter(\.enabled)
     guard !enabled.isEmpty else { return "No enabled routing clients" }

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/RouterWindow.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/RouterWindow.swift
@@ -230,14 +230,14 @@ final class RouterWindowController: NSObject, NSWindowDelegate, NSToolbarDelegat
             trafficStore.requestRefresh()
         } else if toolbarRefreshesRequests(selection: navigation.selection) {
             requestsStore.refresh()
+        } else if toolbarRefreshesModelCatalog(
+            selection: navigation.selection
+        ) {
+            state.requestClientPageRefresh()
         } else {
             state.requestInteractiveRefresh(includeStats: false)
             if navigation.selection == .overview {
                 doorStore.requestRefresh()
-            } else if toolbarRefreshesModelCatalog(
-                selection: navigation.selection
-            ) {
-                state.requestModelCatalogRefresh()
             }
         }
     }
@@ -1062,10 +1062,14 @@ private struct ClientRoutingView: View {
                 message,
                 state: state)
         }
-        if authNeedsReauth(auth: state.auth),
-           state.displayedGlobalRoutingEnabled {
+        let attention = authAttention(
+            gatewayUp: state.gatewayUp,
+            globalRoutingEnabled: state.confirmedGlobalRoutingEnabled,
+            clients: state.clients,
+            auth: state.auth)
+        if let message = authAttentionWarningMessage(attention) {
             warningBanner(
-                "Baseten authentication requires attention.",
+                message,
                 symbol: "key.fill",
                 color: .orange)
         }
@@ -1422,7 +1426,8 @@ private struct ClientRoutingView: View {
             .labelsHidden()
             .pickerStyle(.menu)
             .frame(width: 230, alignment: .trailing)
-            .disabled(!canEdit || pending)
+            .disabled(
+                !canEdit || pending || !state.modelCatalogAllowsMutation)
             .help(controlHelp)
             .accessibilityLabel(
                 "\(capitalizeFamily(family.family)) model mapping")
@@ -1499,7 +1504,9 @@ private struct ClientRoutingView: View {
             .labelsHidden()
             .pickerStyle(.menu)
             .frame(width: 230, alignment: .trailing)
-            .disabled(!canEdit || pending || projection.selectable.isEmpty)
+            .disabled(
+                !canEdit || pending || !state.modelCatalogAllowsMutation
+                    || projection.selectable.isEmpty)
             .help(controlHelp)
             .accessibilityLabel("Codex model")
             .accessibilityValue(codexRouteConfiguredLabel(
@@ -1606,7 +1613,8 @@ private struct ClientRoutingView: View {
                 .labelsHidden()
                 .pickerStyle(.menu)
                 .frame(width: 230, alignment: .trailing)
-                .disabled(!canEdit || pending)
+                .disabled(
+                    !canEdit || pending || !state.modelCatalogAllowsMutation)
                 .help(subagentControlHelp)
                 .accessibilityLabel("Subagent routing behavior")
                 .accessibilityValue(subagentEffectiveDescription)
@@ -1648,6 +1656,7 @@ private struct ClientRoutingView: View {
             },
             set: { selection in
                 guard !isPreview,
+                      state.modelCatalogAllowsMutation,
                       let choice = familyChoice(
                         selection,
                         catalog: catalog),
@@ -1672,6 +1681,7 @@ private struct ClientRoutingView: View {
             },
             set: { selection in
                 guard !isPreview,
+                      state.modelCatalogAllowsMutation,
                       let model = codexRouteChoice(
                         selection,
                         catalog: catalog),
@@ -1696,6 +1706,7 @@ private struct ClientRoutingView: View {
             get: { displayedSubagentSelection },
             set: { selection in
                 guard !isPreview,
+                      state.modelCatalogAllowsMutation,
                       let choice = subagentChoice(
                         selection,
                         catalog: catalog),

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/RuntimeCoordination.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/RuntimeCoordination.swift
@@ -53,6 +53,25 @@ struct RoutingTokenAcceptance: Equatable, Sendable {
     }
 }
 
+/// Accepts poll responses in request order before applying routing-token
+/// ordering. Equal routing tokens cannot make a late older request current.
+struct PollEventAcceptance: Equatable, Sendable {
+    private(set) var latestRequestID: UInt64 = 0
+    private var routingTokens = RoutingTokenAcceptance()
+
+    mutating func accept(
+        requestID: UInt64,
+        token: RoutingToken?
+    ) -> Bool {
+        guard requestID >= latestRequestID else { return false }
+        latestRequestID = requestID
+        if let token, !routingTokens.accept(token) {
+            return false
+        }
+        return true
+    }
+}
+
 actor PollCoordinator {
     typealias Handler = @MainActor @Sendable (PollEvent) -> Void
 
@@ -60,8 +79,20 @@ actor PollCoordinator {
     private let clock: any RuntimeClock
     private let interval: TimeInterval
     private var loop: Task<Void, Never>?
-    private var inFlight: Task<Result<AdminStatusSnapshot, GatewayClientError>, Never>?
-    private var acceptance = RoutingTokenAcceptance()
+    private struct InFlightStatusRequest {
+        let id: UInt64
+        let task: Task<
+            Result<AdminStatusSnapshot, GatewayClientError>, Never>
+    }
+
+    private struct StatusRequestResult {
+        let id: UInt64
+        let result: Result<AdminStatusSnapshot, GatewayClientError>
+    }
+
+    private var inFlight: InFlightStatusRequest?
+    private var nextRequestID: UInt64 = 0
+    private var acceptance = PollEventAcceptance()
 
     init(reader: any AdminStatusReading,
          clock: any RuntimeClock,
@@ -90,31 +121,63 @@ actor PollCoordinator {
     func stop() {
         loop?.cancel()
         loop = nil
-        inFlight?.cancel()
+        inFlight?.task.cancel()
         inFlight = nil
     }
 
     func refresh() async -> PollEvent {
         let result = await fetchSingleFlight()
-        switch result {
+        return event(for: result)
+    }
+
+    /// Waits out any status request that existed at the call boundary, then
+    /// returns a snapshot from a request that began afterward. This provides
+    /// the read barrier needed after a local admin mutation.
+    func refreshFresh() async -> PollEvent {
+        if let pending = inFlight {
+            _ = await pending.task.value
+            if inFlight?.id == pending.id {
+                inFlight = nil
+            }
+        }
+        return event(for: await fetchSingleFlight())
+    }
+
+    private func event(
+        for request: StatusRequestResult
+    ) -> PollEvent {
+        switch request.result {
         case .success(let status):
-            guard acceptance.accept(status.token) else {
+            guard acceptance.accept(
+                requestID: request.id,
+                token: status.token
+            ) else {
                 return .ignoredStaleToken
             }
             return .snapshot(RoutingSnapshot(
                 status: status,
                 observedAt: clock.now))
         case .failure:
+            guard acceptance.accept(
+                requestID: request.id,
+                token: nil
+            ) else {
+                return .ignoredStaleToken
+            }
             return .unavailable(observedAt: clock.now)
         }
     }
 
     private func fetchSingleFlight()
-        async -> Result<AdminStatusSnapshot, GatewayClientError> {
+        async -> StatusRequestResult {
         if let inFlight {
-            return await inFlight.value
+            return StatusRequestResult(
+                id: inFlight.id,
+                result: await inFlight.task.value)
         }
         let reader = self.reader
+        nextRequestID &+= 1
+        let requestID = nextRequestID
         let task = Task<Result<AdminStatusSnapshot, GatewayClientError>, Never> {
             do {
                 return .success(try await reader.fetchStatus())
@@ -124,10 +187,12 @@ actor PollCoordinator {
                 return .failure(.invalidPayload)
             }
         }
-        inFlight = task
+        inFlight = InFlightStatusRequest(id: requestID, task: task)
         let result = await task.value
-        inFlight = nil
-        return result
+        if inFlight?.id == requestID {
+            inFlight = nil
+        }
+        return StatusRequestResult(id: requestID, result: result)
     }
 }
 

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/StatusItemController.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/StatusItemController.swift
@@ -90,6 +90,30 @@ final class StatusItemController: NSObject, NSMenuDelegate {
                         y: button.bounds.minY - 2),
             in: button)
     }
+
+    var fixedHeaderSubtitleForTesting: String? {
+        headerView?.subtitleForTesting
+    }
+
+    var displayedIconStateForTesting: MenubarIconState? {
+        displayedIconState
+    }
+
+    var menuItemTitlesForTesting: [String] {
+        menu.items.map(\.title)
+    }
+
+    func menuWillOpenForTesting() {
+        menuWillOpen(menu)
+    }
+
+    func menuDidCloseForTesting() {
+        menuDidClose(menu)
+    }
+
+    func menuNeedsUpdateForTesting() {
+        menuNeedsUpdate(menu)
+    }
 #endif
 
     // MARK: - Menu
@@ -175,12 +199,20 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         if !state.gatewayUp {
             return "Local gateway is unavailable"
         }
-        if authNeedsReauth(auth: state.auth) {
-            return "Authentication required"
+        if let subtitle = authAttentionHeaderSubtitle(currentAuthAttention) {
+            return subtitle
         }
         return state.confirmedGlobalRoutingEnabled
             ? "Routing rules are active"
             : "Native providers only"
+    }
+
+    private var currentAuthAttention: AuthAttention {
+        authAttention(
+            gatewayUp: state.gatewayUp,
+            globalRoutingEnabled: state.confirmedGlobalRoutingEnabled,
+            clients: state.clients,
+            auth: state.auth)
     }
 
     /// Updating labels and control state in the existing custom header is
@@ -208,12 +240,15 @@ final class StatusItemController: NSObject, NSMenuDelegate {
             added = true
         }
 
-        if authNeedsReauth(auth: state.auth) {
+        let attention = currentAuthAttention
+        if attention != .none,
+           let stableTitle = authAttentionActionTitle(attention) {
+            let previewTitle = attention == .signIn
+                ? "Preview Sign In Disabled"
+                : "Preview Reauthentication Disabled"
             let item = variant.channel == .preview
-                ? disabledItem("Preview Authentication Disabled")
-                : actionItem(
-                    "Authentication Required…",
-                    action: #selector(reauthenticate))
+                ? disabledItem(previewTitle)
+                : actionItem(stableTitle, action: #selector(reauthenticate))
             item.image = symbol("key.fill")
             item.isEnabled = variant.channel == .stable && !state.reauthenticating
             menu.addItem(item)
@@ -502,6 +537,12 @@ final class StatusMenuHeaderView: NSView {
                 ?? "Routes supported coding traffic using the saved model mappings.")
         toggleControl.synchronize()
     }
+
+#if DEBUG
+    var subtitleForTesting: String {
+        detail.stringValue
+    }
+#endif
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { nil }

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/DisplayTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/DisplayTests.swift
@@ -483,6 +483,126 @@ final class DisplayTests: XCTestCase {
             ["BASETEN_SWITCH_CONFIG_PATH": "/tmp/live/gateway.yaml"])
     }
 
+    func testStableCLIEnvironmentRetainsOnlyRuntimeCoordinationOverrides() {
+        let variant = AppVariant.resolve(
+            infoDictionary: ["BasetenSwitchBuildChannel": "stable"],
+            environment: [
+                "BASETEN_SWITCH_CONFIG_PATH": "/tmp/stale/gateway.yaml",
+                "BASETEN_SWITCH_ADMIN_ADDR": "127.0.0.1:46373",
+                "BASETEN_SWITCH_ADMIN_URL": "http://127.0.0.1:46373",
+                "BASETEN_SWITCH_GATEWAY_ADMIN": "http://127.0.0.1:46373",
+                "BASETEN_SWITCH_GATEWAY_PIDFILE": "/tmp/stale/gateway.pid",
+                "BASETEN_SWITCH_GATEWAY_BIN": "/tmp/bin/baseten-switch",
+                "BASETEN_API_KEY": "must-not-propagate",
+                "ANTHROPIC_AUTH_TOKEN": "must-not-propagate",
+                "UNRELATED": "must-not-propagate",
+            ])
+
+        let overrides = cliEnvironmentOverrides(
+            configPath: "/tmp/authoritative/gateway.yaml",
+            variant: variant)
+
+        XCTAssertEqual(
+            overrides["BASETEN_SWITCH_CONFIG_PATH"],
+            "/tmp/authoritative/gateway.yaml")
+        XCTAssertEqual(
+            overrides["BASETEN_SWITCH_ADMIN_ADDR"],
+            "127.0.0.1:46373")
+        XCTAssertNil(overrides["BASETEN_SWITCH_ADMIN_URL"])
+        XCTAssertNil(overrides["BASETEN_SWITCH_GATEWAY_ADMIN"])
+        XCTAssertEqual(
+            overrides["BASETEN_SWITCH_GATEWAY_PIDFILE"],
+            "/tmp/stale/gateway.pid")
+        XCTAssertNil(overrides["BASETEN_SWITCH_GATEWAY_BIN"])
+        XCTAssertNil(overrides["BASETEN_API_KEY"])
+        XCTAssertNil(overrides["ANTHROPIC_AUTH_TOKEN"])
+        XCTAssertNil(overrides["UNRELATED"])
+
+        let preStatusOverrides = cliEnvironmentOverrides(
+            configPath: "",
+            variant: variant)
+        XCTAssertEqual(
+            preStatusOverrides["BASETEN_SWITCH_CONFIG_PATH"],
+            "/tmp/stale/gateway.yaml")
+    }
+
+    func testStableCLIEnvironmentDerivesAddressFromURLOnly() {
+        let variant = AppVariant.resolve(
+            infoDictionary: ["BasetenSwitchBuildChannel": "stable"],
+            environment: [
+                "BASETEN_SWITCH_CONFIG_PATH": "/tmp/stale/gateway.yaml",
+                "BASETEN_SWITCH_ADMIN_URL": "http://localhost:46373",
+                "BASETEN_SWITCH_GATEWAY_PIDFILE": "/tmp/stale/gateway.pid",
+            ])
+
+        XCTAssertEqual(
+            variant.runtime.adminBaseURL,
+            URL(string: "http://localhost:46373")!)
+        XCTAssertEqual(
+            variant.runtime.environment["BASETEN_SWITCH_ADMIN_ADDR"],
+            "localhost:46373")
+        let overrides = cliEnvironmentOverrides(
+            configPath: "",
+            variant: variant)
+        XCTAssertEqual(
+            overrides["BASETEN_SWITCH_ADMIN_ADDR"],
+            "localhost:46373")
+        XCTAssertEqual(
+            overrides["BASETEN_SWITCH_CONFIG_PATH"],
+            "/tmp/stale/gateway.yaml")
+        XCTAssertEqual(
+            overrides["BASETEN_SWITCH_GATEWAY_PIDFILE"],
+            "/tmp/stale/gateway.pid")
+    }
+
+    func testStableCLIEnvironmentURLWinsOverConflictingAddress() {
+        let variant = AppVariant.resolve(
+            infoDictionary: ["BasetenSwitchBuildChannel": "stable"],
+            environment: [
+                "BASETEN_SWITCH_ADMIN_URL": "http://127.0.0.1:46373",
+                "BASETEN_SWITCH_ADMIN_ADDR": "127.0.0.1:45273",
+            ])
+
+        XCTAssertEqual(
+            variant.runtime.environment["BASETEN_SWITCH_ADMIN_ADDR"],
+            "127.0.0.1:46373")
+        XCTAssertEqual(
+            cliEnvironmentOverrides(configPath: "", variant: variant)[
+                "BASETEN_SWITCH_ADMIN_ADDR"],
+            "127.0.0.1:46373")
+    }
+
+    func testStableCLIEnvironmentCanonicalizesSchemeBearingAddress() {
+        let variant = AppVariant.resolve(
+            infoDictionary: ["BasetenSwitchBuildChannel": "stable"],
+            environment: [
+                "BASETEN_SWITCH_ADMIN_ADDR": "http://127.0.0.1:46373",
+            ])
+
+        XCTAssertEqual(
+            variant.runtime.environment["BASETEN_SWITCH_ADMIN_ADDR"],
+            "127.0.0.1:46373")
+        XCTAssertEqual(
+            cliEnvironmentOverrides(configPath: "", variant: variant)[
+                "BASETEN_SWITCH_ADMIN_ADDR"],
+            "127.0.0.1:46373")
+    }
+
+    func testStableCLIEnvironmentWithoutOverridesKeepsProductionDefaults() {
+        let variant = AppVariant.resolve(
+            infoDictionary: ["BasetenSwitchBuildChannel": "stable"],
+            environment: [:])
+
+        XCTAssertEqual(
+            cliEnvironmentOverrides(
+                configPath: "/Users/test/.config/baseten-switch/gateway.yaml",
+                variant: variant),
+            [
+                "BASETEN_SWITCH_CONFIG_PATH":
+                    "/Users/test/.config/baseten-switch/gateway.yaml",
+            ])
+    }
+
     func testRouterWindowPresentationTransitionsAreIdempotent() {
         var state = RouterWindowPresentationState()
         XCTAssertFalse(state.isOpen)
@@ -988,7 +1108,7 @@ final class DisplayTests: XCTestCase {
                                         auth: authWithHealth("refresh_failed")),
                        .off)
         // Non-dead healths and a missing auth block change nothing.
-        for health in ["ok", "error", "signed_out", ""] {
+        for health in ["ok", "error", ""] {
             XCTAssertEqual(menubarIconState(gatewayUp: true,
                                             clients: [client("claude-code", route: "baseten")],
                                             auth: authWithHealth(health)),
@@ -998,6 +1118,79 @@ final class DisplayTests: XCTestCase {
                                         clients: [client("claude-code", route: "baseten")],
                                         auth: nil),
                        .active)
+    }
+
+    func testMenubarIconStateUsesRouteAwareSignInAttention() {
+        let signedOut = AuthStatus(dict: [
+            "signed_in": false,
+            "health": "signed_out",
+            "fallback_in_use": false,
+        ])
+        let fallbackAuth = AuthStatus(dict: [
+            "signed_in": false,
+            "health": "signed_out",
+            "fallback_in_use": true,
+        ])
+        let baseten = client("claude-code", route: "baseten")
+        let native = client("claude-code", route: "anthropic")
+
+        XCTAssertEqual(menubarIconState(
+            gatewayUp: true,
+            globalRoutingEnabled: true,
+            clients: [baseten],
+            auth: signedOut), .degraded)
+        XCTAssertEqual(menubarIconState(
+            gatewayUp: true,
+            globalRoutingEnabled: false,
+            clients: [baseten],
+            auth: signedOut), .off)
+        XCTAssertEqual(menubarIconState(
+            gatewayUp: true,
+            globalRoutingEnabled: true,
+            clients: [native],
+            auth: signedOut), .active)
+        XCTAssertEqual(menubarIconState(
+            gatewayUp: false,
+            globalRoutingEnabled: true,
+            clients: [baseten],
+            auth: signedOut), .off)
+        XCTAssertEqual(menubarIconState(
+            gatewayUp: true,
+            globalRoutingEnabled: true,
+            clients: [baseten],
+            auth: fallbackAuth), .active)
+    }
+
+    func testMenubarIconStateDetectsNestedBasetenDestinations() {
+        let signedOut = AuthStatus(dict: [
+            "signed_in": false,
+            "health": "signed_out",
+        ])
+        let unmatched = ClientStatus(dict: [
+            "name": "claude-code",
+            "enabled": true,
+            "effective_route": "anthropic",
+            "unmatched_native_model": [
+                "effective_route": "baseten",
+            ],
+        ])!
+        let family = ClientStatus(dict: [
+            "name": "claude-code",
+            "enabled": true,
+            "effective_route": "anthropic",
+            "families": [[
+                "family": "sonnet",
+                "effective_route": "baseten",
+            ]],
+        ])!
+
+        for nestedClient in [unmatched, family] {
+            XCTAssertEqual(menubarIconState(
+                gatewayUp: true,
+                globalRoutingEnabled: true,
+                clients: [nestedClient],
+                auth: signedOut), .degraded)
+        }
     }
 
     // MARK: - Reauthenticate dispatch (Terminal via osascript)

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/ModelCatalogTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/ModelCatalogTests.swift
@@ -70,6 +70,132 @@ private actor FixedModelCatalogAdminReader: AdminStatusReading {
     }
 }
 
+private actor RecordingAuthWorkflow: AdminStatusReading, AuthReloading,
+                                      ModelCatalogReading {
+    private var statuses: [AdminStatusSnapshot]
+    private var catalogs: [LiveModelCatalogSnapshot]
+    private let reloadResult: Result<AuthStatus, Error>
+    private let reloadDelayNanoseconds: UInt64
+    private let suspendFirstReload: Bool
+    private let suspendFirstStatus: Bool
+    private let suspendFirstCatalog: Bool
+    private var firstReloadStarted = false
+    private var firstReloadContinuation: CheckedContinuation<Void, Never>?
+    private var firstStatusStarted = false
+    private var firstStatusContinuation: CheckedContinuation<Void, Never>?
+    private var firstCatalogStarted = false
+    private var firstCatalogContinuation: CheckedContinuation<Void, Never>?
+    private(set) var events: [String] = []
+
+    init(
+        statuses: [AdminStatusSnapshot],
+        catalogs: [LiveModelCatalogSnapshot],
+        reloadResult: Result<AuthStatus, Error> = .success(
+            AuthStatus(dict: ["signed_in": true, "health": "ok"])),
+        reloadDelayNanoseconds: UInt64 = 0,
+        suspendFirstReload: Bool = false,
+        suspendFirstStatus: Bool = false,
+        suspendFirstCatalog: Bool = false
+    ) {
+        self.statuses = statuses
+        self.catalogs = catalogs
+        self.reloadResult = reloadResult
+        self.reloadDelayNanoseconds = reloadDelayNanoseconds
+        self.suspendFirstReload = suspendFirstReload
+        self.suspendFirstStatus = suspendFirstStatus
+        self.suspendFirstCatalog = suspendFirstCatalog
+    }
+
+    func reloadAuth() async throws -> AuthStatus {
+        events.append("reload")
+        if suspendFirstReload, !firstReloadStarted {
+            firstReloadStarted = true
+            await withCheckedContinuation { continuation in
+                firstReloadContinuation = continuation
+            }
+        }
+        if reloadDelayNanoseconds > 0 {
+            try await Task.sleep(nanoseconds: reloadDelayNanoseconds)
+        }
+        return try reloadResult.get()
+    }
+
+    func fetchStatus() async throws -> AdminStatusSnapshot {
+        events.append("status")
+        if suspendFirstStatus, !firstStatusStarted {
+            firstStatusStarted = true
+            await withCheckedContinuation { continuation in
+                firstStatusContinuation = continuation
+            }
+        }
+        guard !statuses.isEmpty else {
+            throw GatewayClientError.invalidPayload
+        }
+        return statuses.removeFirst()
+    }
+
+    func fetchStats(windowSeconds: Int,
+                    bucketSeconds: Int) async throws -> StatsSnapshot {
+        StatsSnapshot(dict: [:])
+    }
+
+    func fetchModelCatalog() async throws -> LiveModelCatalogSnapshot {
+        events.append("catalog")
+        guard !catalogs.isEmpty else {
+            throw GatewayClientError.invalidPayload
+        }
+        let snapshot = catalogs.removeFirst()
+        if suspendFirstCatalog, !firstCatalogStarted {
+            firstCatalogStarted = true
+            await withCheckedContinuation { continuation in
+                firstCatalogContinuation = continuation
+            }
+        }
+        return snapshot
+    }
+
+    func waitForFirstReloadStart() async {
+        while !firstReloadStarted {
+            await Task.yield()
+        }
+    }
+
+    func waitForFirstStatusStart() async {
+        while !firstStatusStarted {
+            await Task.yield()
+        }
+    }
+
+    func waitForFirstCatalogStart() async {
+        while !firstCatalogStarted {
+            await Task.yield()
+        }
+    }
+
+    func waitForEvent(_ event: String) async {
+        while !events.contains(event) {
+            await Task.yield()
+        }
+    }
+
+    func releaseFirstStatus() {
+        firstStatusContinuation?.resume()
+        firstStatusContinuation = nil
+    }
+
+    func releaseFirstReload() {
+        firstReloadContinuation?.resume()
+        firstReloadContinuation = nil
+    }
+
+    func releaseFirstCatalog() {
+        firstCatalogContinuation?.resume()
+        firstCatalogContinuation = nil
+    }
+}
+
+private struct ModelCatalogTransportError: Error {}
+
 @MainActor
 private final class ModelCatalogLoginItemService: LoginItemServicing {
     var status: SMAppService.Status = .notRegistered
@@ -81,7 +207,14 @@ private final class ModelCatalogLoginItemService: LoginItemServicing {
 private final class ModelCatalogURLProtocol: URLProtocol {
     static var responseData = Data()
     static var statusCode = 200
+    static var responseDelay: TimeInterval = 0
     static var observedURL: URL?
+    static var observedMethod: String?
+    static var observedBody: Data?
+    static var observedAdminHeader: String?
+    static var observedTimeoutInterval: TimeInterval?
+
+    private var responseWorkItem: DispatchWorkItem?
 
     override class func canInit(with request: URLRequest) -> Bool {
         true
@@ -94,23 +227,140 @@ private final class ModelCatalogURLProtocol: URLProtocol {
 
     override func startLoading() {
         Self.observedURL = request.url
-        let response = HTTPURLResponse(
-            url: request.url!,
-            statusCode: Self.statusCode,
-            httpVersion: nil,
-            headerFields: ["Content-Type": "application/json"])!
-        client?.urlProtocol(
-            self,
-            didReceive: response,
-            cacheStoragePolicy: .notAllowed)
-        client?.urlProtocol(self, didLoad: Self.responseData)
-        client?.urlProtocolDidFinishLoading(self)
+        Self.observedMethod = request.httpMethod
+        Self.observedBody = request.httpBody
+        Self.observedAdminHeader = request.value(
+            forHTTPHeaderField: "X-Baseten-Switch-Admin")
+        Self.observedTimeoutInterval = request.timeoutInterval
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: Self.statusCode,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"])!
+            client?.urlProtocol(
+                self,
+                didReceive: response,
+                cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Self.responseData)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+        responseWorkItem = workItem
+        if Self.responseDelay > 0 {
+            DispatchQueue.global().asyncAfter(
+                deadline: .now() + Self.responseDelay,
+                execute: workItem)
+        } else {
+            workItem.perform()
+        }
     }
 
-    override func stopLoading() {}
+    override func stopLoading() {
+        responseWorkItem?.cancel()
+        responseWorkItem = nil
+    }
 }
 
 final class ModelCatalogTests: XCTestCase {
+    func testModelCatalogRequestOutlivesOrdinaryAdminTimeout() async throws {
+        ModelCatalogURLProtocol.responseData = Data("""
+        {
+          "state": "ready",
+          "models": [],
+          "signed_out_reason": "",
+          "fetched_at": "2026-08-17T05:00:00Z",
+          "error": ""
+        }
+        """.utf8)
+        ModelCatalogURLProtocol.statusCode = 200
+        ModelCatalogURLProtocol.responseDelay = 2.2
+        ModelCatalogURLProtocol.observedTimeoutInterval = nil
+        defer { ModelCatalogURLProtocol.responseDelay = 0 }
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 2
+        configuration.timeoutIntervalForResource = 5
+        configuration.protocolClasses = [ModelCatalogURLProtocol.self]
+        let client = GatewayAPIClient(
+            runtime: .stable(),
+            session: URLSession(configuration: configuration))
+
+        let snapshot = try await client.fetchModelCatalog()
+
+        XCTAssertEqual(snapshot.state, .ready)
+        XCTAssertEqual(
+            ModelCatalogURLProtocol.observedTimeoutInterval ?? -1,
+            4,
+            accuracy: 0.001)
+    }
+
+    func testOrdinaryAdminReadRetainsTwoSecondTimeout() async throws {
+        ModelCatalogURLProtocol.responseData = Data("""
+        {
+          "router_boot_id": "boot-a",
+          "active_generation": 1,
+          "active_config_hash": "sha256:active",
+          "desired_config_hash": "sha256:active",
+          "capabilities": [],
+          "global_routing_enabled": false,
+          "clients": []
+        }
+        """.utf8)
+        ModelCatalogURLProtocol.statusCode = 200
+        ModelCatalogURLProtocol.responseDelay = 0
+        ModelCatalogURLProtocol.observedTimeoutInterval = nil
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 2
+        configuration.timeoutIntervalForResource = 5
+        configuration.protocolClasses = [ModelCatalogURLProtocol.self]
+        let client = GatewayAPIClient(
+            runtime: .stable(),
+            session: URLSession(configuration: configuration))
+
+        _ = try await client.fetchStatus()
+
+        XCTAssertEqual(
+            ModelCatalogURLProtocol.observedTimeoutInterval ?? -1,
+            2,
+            accuracy: 0.001)
+    }
+
+    func testGatewayClientReloadsAuthWithEmptyPOST() async throws {
+        ModelCatalogURLProtocol.responseData = Data("""
+        {
+          "signed_in": true,
+          "auth_type": "api_key",
+          "profile": "",
+          "fallback_enabled": false,
+          "fallback_in_use": false,
+          "health": "ok",
+          "last_refresh_error": ""
+        }
+        """.utf8)
+        ModelCatalogURLProtocol.statusCode = 200
+        ModelCatalogURLProtocol.observedURL = nil
+        ModelCatalogURLProtocol.observedMethod = nil
+        ModelCatalogURLProtocol.observedBody = nil
+        ModelCatalogURLProtocol.observedAdminHeader = nil
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ModelCatalogURLProtocol.self]
+        let client = GatewayAPIClient(
+            runtime: .stable(),
+            session: URLSession(configuration: configuration))
+
+        let auth = try await client.reloadAuth()
+
+        XCTAssertTrue(auth.signedIn)
+        XCTAssertEqual(auth.authType, "api_key")
+        XCTAssertEqual(auth.health, "ok")
+        XCTAssertEqual(
+            ModelCatalogURLProtocol.observedURL?.path,
+            "/v1/admin/auth/reload")
+        XCTAssertEqual(ModelCatalogURLProtocol.observedMethod, "POST")
+        XCTAssertEqual(ModelCatalogURLProtocol.observedAdminHeader, "1")
+        XCTAssertEqual(ModelCatalogURLProtocol.observedBody?.count ?? 0, 0)
+    }
+
     func testGatewayClientDecodesNarrowModelCatalogContract() async throws {
         ModelCatalogURLProtocol.responseData = Data("""
         {
@@ -447,6 +697,374 @@ final class ModelCatalogTests: XCTestCase {
     }
 
     @MainActor
+    func testClientPageRefreshCoalescesBurstIntoOnePendingRerun() async {
+        let ready = catalogSnapshot(
+            state: .ready,
+            models: [liveModel("vendor/ready")])
+        let signedOut = catalogSnapshot(
+            state: .signedOut,
+            signedOutReason: .notSignedIn)
+        let workflow = RecordingAuthWorkflow(
+            statuses: [
+                adminSnapshot(signedIn: false, health: "signed_out"),
+                adminSnapshot(signedIn: true, health: "ok"),
+            ],
+            catalogs: [signedOut, ready],
+            suspendFirstReload: true)
+        let state = makeState(
+            adminReader: workflow,
+            authReloader: workflow,
+            modelCatalogReader: workflow)
+
+        state.requestClientPageRefresh()
+        await workflow.waitForFirstReloadStart()
+        for _ in 0..<25 {
+            state.requestClientPageRefresh()
+        }
+        await workflow.releaseFirstReload()
+        await state.waitForClientPageRefresh()
+
+        let events = await workflow.events
+        XCTAssertEqual(
+            events,
+            [
+                "reload", "status", "catalog",
+                "reload", "status", "catalog",
+            ])
+        XCTAssertEqual(state.liveModelCatalogState, .ready(ready.models))
+    }
+
+    @MainActor
+    func testClientPageRefreshPreservesSavedPickerSelectionsWhileLoading() async {
+        let old = catalogSnapshot(
+            state: .ready,
+            models: [liveModel("vendor/old", label: "Old Model")])
+        let newest = catalogSnapshot(
+            state: .ready,
+            models: [liveModel("vendor/new", label: "New Model")])
+        let workflow = RecordingAuthWorkflow(
+            statuses: [adminSnapshot(signedIn: true, health: "ok")],
+            catalogs: [old, newest],
+            suspendFirstReload: true)
+        let state = makeState(
+            adminReader: workflow,
+            authReloader: workflow,
+            modelCatalogReader: workflow)
+        let claude = routingClient(name: "claude-code")
+        let codex = routingClient(name: "codex")
+
+        state.requestModelCatalogRefresh()
+        await state.waitForModelCatalogRefresh()
+        state.requestClientPageRefresh()
+        await workflow.waitForFirstReloadStart()
+
+        XCTAssertEqual(state.liveModelCatalogState, .loading)
+        XCTAssertFalse(state.modelCatalogAllowsMutation)
+        let claudeCatalog = state.modelCatalogProjection(for: claude).selectable
+        let codexCatalog = state.modelCatalogProjection(for: codex).selectable
+        XCTAssertEqual(claudeCatalog.map(\.slug), ["vendor/old"])
+        XCTAssertEqual(
+            familyPickerSelection(
+                claude.families[0],
+                catalog: claudeCatalog),
+            .catalog("vendor/old"))
+        XCTAssertEqual(
+            subagentPickerSelection(claude, catalog: claudeCatalog),
+            .catalog("vendor/old"))
+        XCTAssertEqual(
+            codexRoutePickerSelection(codex, catalog: codexCatalog),
+            .catalog("vendor/old"))
+
+        await workflow.releaseFirstReload()
+        await state.waitForClientPageRefresh()
+
+        XCTAssertTrue(state.modelCatalogAllowsMutation)
+        XCTAssertEqual(
+            state.modelCatalogProjection(for: claude).selectable.map(\.slug),
+            ["vendor/new"])
+    }
+
+    @MainActor
+    func testClientPageRefreshClearsPreservedCatalogOnTerminalResult() async {
+        let old = catalogSnapshot(
+            state: .ready,
+            models: [liveModel("vendor/old")])
+        let terminalResults = [
+            catalogSnapshot(
+                state: .signedOut,
+                signedOutReason: .notSignedIn),
+            catalogSnapshot(
+                state: .error,
+                error: "Catalog unavailable."),
+        ]
+
+        for terminal in terminalResults {
+            let workflow = RecordingAuthWorkflow(
+                statuses: [adminSnapshot(signedIn: true, health: "ok")],
+                catalogs: [old, terminal])
+            let state = makeState(
+                adminReader: workflow,
+                authReloader: workflow,
+                modelCatalogReader: workflow)
+            let claude = routingClient(name: "claude-code")
+
+            state.requestModelCatalogRefresh()
+            await state.waitForModelCatalogRefresh()
+            state.requestClientPageRefresh()
+            await state.waitForClientPageRefresh()
+
+            XCTAssertFalse(state.modelCatalogAllowsMutation)
+            XCTAssertTrue(
+                state.modelCatalogProjection(for: claude).selectable.isEmpty)
+        }
+    }
+
+    @MainActor
+    func testWindowCloseClearsCatalogPreservedDuringRefresh() async {
+        let old = catalogSnapshot(
+            state: .ready,
+            models: [liveModel("vendor/old")])
+        let workflow = RecordingAuthWorkflow(
+            statuses: [adminSnapshot(signedIn: true, health: "ok")],
+            catalogs: [old],
+            suspendFirstReload: true)
+        let state = makeState(
+            adminReader: workflow,
+            authReloader: workflow,
+            modelCatalogReader: workflow)
+        let claude = routingClient(name: "claude-code")
+
+        state.requestModelCatalogRefresh()
+        await state.waitForModelCatalogRefresh()
+        state.requestClientPageRefresh()
+        await workflow.waitForFirstReloadStart()
+        XCTAssertFalse(
+            state.modelCatalogProjection(for: claude).selectable.isEmpty)
+
+        state.routerWindowDidClose()
+        XCTAssertEqual(state.liveModelCatalogState, .idle)
+        XCTAssertTrue(
+            state.modelCatalogProjection(for: claude).selectable.isEmpty)
+        await workflow.releaseFirstReload()
+    }
+
+    @MainActor
+    func testClientPageRefreshBoundsReloadFailuresAndContinues() async {
+        let failures: [Error] = [
+            GatewayClientError.badResponse(405),
+            GatewayClientError.invalidPayload,
+            GatewayClientError.badResponse(500),
+            ModelCatalogTransportError(),
+        ]
+        for failure in failures {
+            let ready = catalogSnapshot(
+                state: .ready,
+                models: [liveModel("vendor/ready")])
+            let workflow = RecordingAuthWorkflow(
+                statuses: [adminSnapshot(signedIn: true, health: "ok")],
+                catalogs: [ready],
+                reloadResult: .failure(failure))
+            let state = makeState(
+                adminReader: workflow,
+                authReloader: workflow,
+                modelCatalogReader: workflow)
+
+            state.requestClientPageRefresh()
+            await state.waitForClientPageRefresh()
+
+            let events = await workflow.events
+            XCTAssertEqual(events, ["reload", "status", "catalog"])
+            XCTAssertEqual(state.liveModelCatalogState, .ready(ready.models))
+        }
+    }
+
+    @MainActor
+    func testClientPageRefreshWaitsOutPreReloadStatusRequest() async {
+        let ready = catalogSnapshot(
+            state: .ready,
+            models: [liveModel("vendor/ready")])
+        let workflow = RecordingAuthWorkflow(
+            statuses: [
+                adminSnapshot(signedIn: false, health: "signed_out"),
+                adminSnapshot(signedIn: true, health: "ok"),
+            ],
+            catalogs: [ready],
+            suspendFirstStatus: true)
+        let state = makeState(
+            adminReader: workflow,
+            authReloader: workflow,
+            modelCatalogReader: workflow)
+
+        let preReloadPoll = Task { await state.refresh() }
+        await workflow.waitForFirstStatusStart()
+        state.requestClientPageRefresh()
+        await workflow.waitForEvent("reload")
+        await workflow.releaseFirstStatus()
+        await preReloadPoll.value
+        await state.waitForClientPageRefresh()
+
+        let events = await workflow.events
+        XCTAssertEqual(
+            events,
+            ["status", "reload", "status", "catalog"])
+        XCTAssertTrue(state.auth?.signedIn == true)
+        XCTAssertEqual(state.auth?.health, "ok")
+        XCTAssertEqual(state.liveModelCatalogState, .ready(ready.models))
+    }
+
+    @MainActor
+    func testClientPageRefreshInvalidatesPreReloadCatalogResult() async {
+        let signedOut = catalogSnapshot(
+            state: .signedOut,
+            signedOutReason: .notSignedIn)
+        let ready = catalogSnapshot(
+            state: .ready,
+            models: [liveModel("vendor/ready")])
+        let workflow = RecordingAuthWorkflow(
+            statuses: [adminSnapshot(signedIn: true, health: "ok")],
+            catalogs: [signedOut, ready],
+            suspendFirstCatalog: true)
+        let state = makeState(
+            adminReader: workflow,
+            authReloader: workflow,
+            modelCatalogReader: workflow)
+
+        state.requestModelCatalogRefresh()
+        await workflow.waitForFirstCatalogStart()
+        state.requestClientPageRefresh()
+        await state.waitForClientPageRefresh()
+        await workflow.releaseFirstCatalog()
+        await Task.yield()
+
+        let events = await workflow.events
+        XCTAssertEqual(events, ["catalog", "reload", "status", "catalog"])
+        XCTAssertEqual(state.liveModelCatalogState, .ready(ready.models))
+    }
+
+    @MainActor
+    func testClosingWindowCancelsOrderedRefreshBeforeLateReads() async {
+        let workflow = RecordingAuthWorkflow(
+            statuses: [adminSnapshot(signedIn: true, health: "ok")],
+            catalogs: [catalogSnapshot(state: .ready)],
+            suspendFirstReload: true)
+        let state = makeState(
+            adminReader: workflow,
+            authReloader: workflow,
+            modelCatalogReader: workflow)
+
+        state.requestClientPageRefresh()
+        await workflow.waitForFirstReloadStart()
+        state.routerWindowDidClose()
+        await workflow.releaseFirstReload()
+        await Task.yield()
+
+        let events = await workflow.events
+        XCTAssertEqual(events, ["reload"])
+        XCTAssertEqual(state.liveModelCatalogState, .idle)
+    }
+
+    @MainActor
+    func testHealthyAuthTransitionRetriesNotSignedInCatalogOnce() async {
+        let signedOut = catalogSnapshot(
+            state: .signedOut,
+            signedOutReason: .notSignedIn)
+        let ready = catalogSnapshot(
+            state: .ready,
+            models: [liveModel("vendor/recovered")])
+        let workflow = RecordingAuthWorkflow(
+            statuses: [
+                adminSnapshot(signedIn: false, health: "signed_out"),
+                adminSnapshot(signedIn: true, health: "ok"),
+                adminSnapshot(signedIn: true, health: "ok"),
+            ],
+            catalogs: [signedOut, ready])
+        let state = makeState(
+            adminReader: workflow,
+            authReloader: workflow,
+            modelCatalogReader: workflow)
+
+        await state.refresh()
+        state.requestModelCatalogRefresh()
+        await state.waitForModelCatalogRefresh()
+        await state.refresh()
+        await state.waitForModelCatalogRefresh()
+        await state.refresh()
+        await state.waitForModelCatalogRefresh()
+
+        let events = await workflow.events
+        XCTAssertEqual(
+            events,
+            ["status", "catalog", "status", "catalog", "status"])
+        XCTAssertEqual(state.liveModelCatalogState, .ready(ready.models))
+    }
+
+    @MainActor
+    func testHealthyTransitionRetriesLateNotSignedInCatalogOnce() async {
+        let signedOut = catalogSnapshot(
+            state: .signedOut,
+            signedOutReason: .notSignedIn)
+        let ready = catalogSnapshot(
+            state: .ready,
+            models: [liveModel("vendor/recovered")])
+        let workflow = RecordingAuthWorkflow(
+            statuses: [
+                adminSnapshot(signedIn: false, health: "signed_out"),
+                adminSnapshot(signedIn: true, health: "ok"),
+            ],
+            catalogs: [signedOut, ready],
+            suspendFirstCatalog: true)
+        let state = makeState(
+            adminReader: workflow,
+            authReloader: workflow,
+            modelCatalogReader: workflow)
+
+        await state.refresh()
+        state.requestModelCatalogRefresh()
+        await workflow.waitForFirstCatalogStart()
+        await state.refresh()
+        await workflow.releaseFirstCatalog()
+        await state.waitForModelCatalogRefresh()
+
+        let events = await workflow.events
+        XCTAssertEqual(
+            events,
+            ["status", "catalog", "status", "catalog"])
+        XCTAssertEqual(state.liveModelCatalogState, .ready(ready.models))
+    }
+
+    @MainActor
+    func testHealthyAuthTransitionDoesNotRetryTerminalSignedOutCatalogs() async {
+        for reason in [
+            LiveModelCatalogSignedOutReason.sessionExpired,
+            .credentialRejected,
+        ] {
+            let terminal = catalogSnapshot(
+                state: .signedOut,
+                signedOutReason: reason)
+            let workflow = RecordingAuthWorkflow(
+                statuses: [
+                    adminSnapshot(signedIn: false, health: "signed_out"),
+                    adminSnapshot(signedIn: true, health: "ok"),
+                ],
+                catalogs: [terminal])
+            let state = makeState(
+                adminReader: workflow,
+                authReloader: workflow,
+                modelCatalogReader: workflow)
+
+            await state.refresh()
+            state.requestModelCatalogRefresh()
+            await state.waitForModelCatalogRefresh()
+            await state.refresh()
+            await state.waitForModelCatalogRefresh()
+
+            let events = await workflow.events
+            XCTAssertEqual(events, ["status", "catalog", "status"])
+            XCTAssertEqual(state.liveModelCatalogState, .signedOut(reason))
+        }
+    }
+
+    @MainActor
     func testNewerCatalogRefreshWinsWhenCancelledReaderReturnsLate() async {
         let old = catalogSnapshot(
             state: .ready,
@@ -549,8 +1167,11 @@ final class ModelCatalogTests: XCTestCase {
         ])!
     }
 
-    private func adminSnapshot() -> AdminStatusSnapshot {
-        AdminStatusSnapshot(dict: [
+    private func adminSnapshot(
+        signedIn: Bool? = nil,
+        health: String = ""
+    ) -> AdminStatusSnapshot {
+        var dict: [String: Any] = [
             "router_boot_id": "boot-a",
             "active_generation": 1,
             "active_config_hash": "sha256:active",
@@ -558,12 +1179,48 @@ final class ModelCatalogTests: XCTestCase {
             "capabilities": ["global_routing"],
             "global_routing_enabled": true,
             "clients": [],
-        ])
+        ]
+        if let signedIn {
+            dict["auth"] = [
+                "signed_in": signedIn,
+                "health": health,
+            ]
+        }
+        return AdminStatusSnapshot(dict: dict)
+    }
+
+    private func routingClient(name: String) -> ClientStatus {
+        ClientStatus(dict: [
+            "name": name,
+            "enabled": true,
+            "subagent_model": "old-alias",
+            "subagent_routing": "baseten",
+            "unmatched_native_model": [
+                "configured_target": "old-alias",
+                "effective_route": "baseten",
+                "effective_model": "vendor/old",
+            ],
+            "families": [[
+                "family": "fable",
+                "configured_target": "old-alias",
+                "configured_source": "explicit",
+                "effective_route": "baseten",
+                "effective_model": "vendor/old",
+            ]],
+            "model_catalog": [[
+                "label": "Configured Old",
+                "storage_target": "old-alias",
+                "slug": "vendor/old",
+                "alias": "old-alias",
+                "available": true,
+            ]],
+        ])!
     }
 
     @MainActor
     private func makeState(
         adminReader: (any AdminStatusReading)? = nil,
+        authReloader: (any AuthReloading)? = nil,
         modelCatalogReader: any ModelCatalogReading
     ) -> BasetenSwitchState {
         BasetenSwitchState(
@@ -572,6 +1229,7 @@ final class ModelCatalogTests: XCTestCase {
                 environment: [:]),
             reader: adminReader ?? FixedModelCatalogAdminReader(
                 snapshot: adminSnapshot()),
+            authReloader: authReloader,
             modelCatalogReader: modelCatalogReader,
             loginItemService: ModelCatalogLoginItemService(),
             startPolling: false)

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/PopupDisplayTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/PopupDisplayTests.swift
@@ -147,6 +147,159 @@ final class PopupDisplayTests: XCTestCase {
         XCTAssertFalse(authNeedsReauth(auth: nil))
     }
 
+    private func routedClient(
+        enabled: Bool = true,
+        route: String = "anthropic",
+        unmatchedRoute: String? = nil,
+        familyRoutes: [String] = [],
+        fallbackActive: Bool = false
+    ) -> ClientStatus {
+        var dict: [String: Any] = [
+            "name": "claude-code",
+            "enabled": enabled,
+            "effective_route": route,
+            "fallback": ["active": fallbackActive],
+        ]
+        if let unmatchedRoute {
+            dict["unmatched_native_model"] = [
+                "effective_route": unmatchedRoute,
+            ]
+        }
+        dict["families"] = familyRoutes.enumerated().map { index, route in
+            [
+                "family": "family-\(index)",
+                "effective_route": route,
+            ]
+        }
+        return ClientStatus(dict: dict)!
+    }
+
+    func testClientRequiresBasetenAuthAcrossEffectiveDestinations() {
+        XCTAssertTrue(clientRequiresBasetenAuth(routedClient(route: "baseten")))
+        XCTAssertTrue(clientRequiresBasetenAuth(routedClient(
+            unmatchedRoute: "baseten")))
+        XCTAssertTrue(clientRequiresBasetenAuth(routedClient(
+            familyRoutes: ["anthropic", "baseten"])))
+
+        XCTAssertFalse(clientRequiresBasetenAuth(routedClient()))
+        XCTAssertFalse(clientRequiresBasetenAuth(routedClient(
+            unmatchedRoute: "anthropic",
+            familyRoutes: ["anthropic"])))
+        XCTAssertFalse(clientRequiresBasetenAuth(routedClient(
+            enabled: false,
+            route: "baseten",
+            unmatchedRoute: "baseten",
+            familyRoutes: ["baseten"])))
+    }
+
+    func testAuthAttentionDecisionTable() {
+        let baseten = routedClient(route: "baseten")
+        let native = routedClient()
+        let disabled = routedClient(enabled: false, route: "baseten")
+        let signedOut = auth(
+            signedIn: false, profile: "", fallbackInUse: false,
+            health: "signed_out")
+
+        XCTAssertEqual(authAttention(
+            gatewayUp: true, globalRoutingEnabled: true,
+            clients: [baseten], auth: signedOut), .signIn)
+        XCTAssertEqual(authAttention(
+            gatewayUp: true, globalRoutingEnabled: true,
+            clients: [routedClient(unmatchedRoute: "baseten")],
+            auth: signedOut), .signIn)
+        XCTAssertEqual(authAttention(
+            gatewayUp: true, globalRoutingEnabled: true,
+            clients: [routedClient(familyRoutes: ["baseten"])],
+            auth: signedOut), .signIn)
+
+        XCTAssertEqual(authAttention(
+            gatewayUp: false, globalRoutingEnabled: true,
+            clients: [baseten], auth: signedOut), .none)
+        XCTAssertEqual(authAttention(
+            gatewayUp: true, globalRoutingEnabled: false,
+            clients: [baseten], auth: signedOut), .none)
+        XCTAssertEqual(authAttention(
+            gatewayUp: true, globalRoutingEnabled: true,
+            clients: [native], auth: signedOut), .none)
+        XCTAssertEqual(authAttention(
+            gatewayUp: true, globalRoutingEnabled: true,
+            clients: [disabled], auth: signedOut), .none)
+        XCTAssertEqual(authAttention(
+            gatewayUp: true, globalRoutingEnabled: true,
+            clients: [], auth: signedOut), .none)
+        XCTAssertEqual(authAttention(
+            gatewayUp: true, globalRoutingEnabled: true,
+            clients: [baseten], auth: nil), .none)
+    }
+
+    func testAuthAttentionFallbackAndHealthStates() {
+        let baseten = routedClient(route: "baseten")
+
+        XCTAssertEqual(authAttention(
+            gatewayUp: true, globalRoutingEnabled: true,
+            clients: [baseten],
+            auth: auth(signedIn: false, profile: "", fallbackInUse: true,
+                       health: "signed_out")), .none)
+        XCTAssertEqual(authAttention(
+            gatewayUp: true, globalRoutingEnabled: true,
+            clients: [routedClient(route: "baseten", fallbackActive: true)],
+            auth: auth(signedIn: false, profile: "", fallbackInUse: false,
+                       health: "signed_out")), .signIn)
+
+        // Preserve the existing route-independent dead-credential alarm.
+        for globalRoutingEnabled in [false, true] {
+            XCTAssertEqual(authAttention(
+                gatewayUp: true,
+                globalRoutingEnabled: globalRoutingEnabled,
+                clients: [],
+                auth: auth(signedIn: true, profile: "", fallbackInUse: false,
+                           health: "refresh_failed")), .reauthenticate)
+        }
+        XCTAssertEqual(authAttention(
+            gatewayUp: true, globalRoutingEnabled: false, clients: [],
+            auth: auth(signedIn: true, profile: "", fallbackInUse: true,
+                       health: "refresh_failed")), .reauthenticate)
+
+        // Transient and mixed-version health values remain quiet.
+        for health in ["ok", "error", ""] {
+            XCTAssertEqual(authAttention(
+                gatewayUp: true, globalRoutingEnabled: true,
+                clients: [baseten],
+                auth: auth(signedIn: true, profile: "", fallbackInUse: false,
+                           health: health)), .none, "health \(health)")
+        }
+        // Only an explicit signed_out health value triggers sign-in attention.
+        XCTAssertEqual(authAttention(
+            gatewayUp: true, globalRoutingEnabled: true,
+            clients: [baseten],
+            auth: auth(signedIn: false, profile: "", fallbackInUse: false,
+                       health: "")), .none)
+    }
+
+    func testAuthAttentionPresentation() {
+        XCTAssertNil(authAttentionHeaderSubtitle(.none))
+        XCTAssertNil(authAttentionActionTitle(.none))
+        XCTAssertNil(authAttentionWarningMessage(.none))
+        XCTAssertEqual(
+            authAttentionHeaderSubtitle(.signIn),
+            "Sign in to use Baseten")
+        XCTAssertEqual(
+            authAttentionActionTitle(.signIn),
+            "Sign In to Baseten…")
+        XCTAssertEqual(
+            authAttentionWarningMessage(.signIn),
+            "Sign in to Baseten to use configured Baseten routes.")
+        XCTAssertEqual(
+            authAttentionHeaderSubtitle(.reauthenticate),
+            "Reauthentication required")
+        XCTAssertEqual(
+            authAttentionActionTitle(.reauthenticate),
+            "Reauthenticate with Baseten…")
+        XCTAssertEqual(
+            authAttentionWarningMessage(.reauthenticate),
+            "Reauthenticate with Baseten to restore authentication.")
+    }
+
     // The detail line renders only in the dead-credential state, and
     // reuses the menu-safe truncation.
     func testAuthDetailLine() {
@@ -295,7 +448,17 @@ final class PopupDisplayTests: XCTestCase {
         let deadAuth = AuthStatus(dict: ["health": "refresh_failed"])
         XCTAssertEqual(globalRoutingSubtitle(gatewayUp: true, clients: [baseten],
                                              auth: deadAuth),
-                       "Authentication required")
+                       "Reauthentication required")
+        let signedOut = AuthStatus(dict: [
+            "signed_in": false,
+            "health": "signed_out",
+        ])
+        XCTAssertEqual(globalRoutingSubtitle(
+            gatewayUp: true,
+            globalRoutingEnabled: true,
+            clients: [baseten],
+            auth: signedOut),
+            "Sign in to use Baseten")
     }
 
     // MARK: - Sparkline bucket-to-points mapping

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/RuntimeCoordinationTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/RuntimeCoordinationTests.swift
@@ -39,12 +39,15 @@ private actor CountingAdminReader: AdminStatusReading {
 private actor SequencedAdminReader: AdminStatusReading {
     private var statuses: [AdminStatusSnapshot]
     private var index = 0
+    private(set) var statusCalls = 0
+    private(set) var statsCalls = 0
 
     init(statuses: [AdminStatusSnapshot]) {
         self.statuses = statuses
     }
 
     func fetchStatus() async throws -> AdminStatusSnapshot {
+        statusCalls += 1
         guard !statuses.isEmpty else {
             throw GatewayClientError.invalidPayload
         }
@@ -55,7 +58,55 @@ private actor SequencedAdminReader: AdminStatusReading {
 
     func fetchStats(windowSeconds: Int,
                     bucketSeconds: Int) async throws -> StatsSnapshot {
+        statsCalls += 1
+        return StatsSnapshot(dict: [:])
+    }
+}
+
+private actor SuspendingMutationAdminReader: AdminStatusReading {
+    private let initial: AdminStatusSnapshot
+    private let stale: AdminStatusSnapshot
+    private let confirmed: AdminStatusSnapshot
+    private var continuation: CheckedContinuation<Void, Never>?
+    private(set) var statusCalls = 0
+
+    init(initial: AdminStatusSnapshot,
+         stale: AdminStatusSnapshot,
+         confirmed: AdminStatusSnapshot) {
+        self.initial = initial
+        self.stale = stale
+        self.confirmed = confirmed
+    }
+
+    func fetchStatus() async throws -> AdminStatusSnapshot {
+        statusCalls += 1
+        switch statusCalls {
+        case 1:
+            return initial
+        case 2:
+            await withCheckedContinuation { continuation in
+                self.continuation = continuation
+            }
+            return stale
+        default:
+            return confirmed
+        }
+    }
+
+    func fetchStats(windowSeconds: Int,
+                    bucketSeconds: Int) async throws -> StatsSnapshot {
         StatsSnapshot(dict: [:])
+    }
+
+    func waitForStaleRequest() async {
+        while statusCalls < 2 {
+            await Task.yield()
+        }
+    }
+
+    func releaseStaleRequest() {
+        continuation?.resume()
+        continuation = nil
     }
 }
 
@@ -125,6 +176,8 @@ private actor PrimaryFailureRunner: CLIRunning {
         case failedReconciliation
         case malformedSecondary
         case mismatchedSecondary
+        case routerIdentityMismatch
+        case routerStateMismatch
         case timedTypedError
         case timedSuccess
     }
@@ -210,6 +263,14 @@ private actor PrimaryFailureRunner: CLIRunning {
         if mode == .blocker {
             errorCode = "unfinished_mutation"
             blockingID = "older-operation"
+            reconciliationRequired = false
+        } else if mode == .routerIdentityMismatch {
+            errorCode = "router_identity_mismatch"
+            blockingID = nil
+            reconciliationRequired = false
+        } else if mode == .routerStateMismatch {
+            errorCode = "router_state_mismatch"
+            blockingID = nil
             reconciliationRequired = false
         } else if mode == .timedTypedError {
             errorCode = "stale_config_hash"
@@ -522,6 +583,24 @@ final class RuntimeCoordinationTests: XCTestCase {
             environment: ["BASETEN_SWITCH_GATEWAY_BIN": binaryPath])
     }
 
+    private func stableTestVariant(
+        binaryPath: String = "/usr/bin/true"
+    ) -> AppVariant {
+        AppVariant.resolve(
+            infoDictionary: [:],
+            homeDirectory: "/tmp/baseten-switch-home",
+            environment: ["BASETEN_SWITCH_GATEWAY_BIN": binaryPath])
+    }
+
+    @MainActor
+    private func drainMainQueue() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                continuation.resume()
+            }
+        }
+    }
+
     private func isolatedPreviewVariant() throws -> AppVariant {
         let home = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -597,6 +676,36 @@ final class RuntimeCoordinationTests: XCTestCase {
                     "storage_target": "zai-org/GLM-5.2",
                     "available": true,
                 ]],
+            ]],
+        ])
+    }
+
+    private func menuAuthStatus(
+        generation: Int,
+        signedIn: Bool,
+        health: String
+    ) -> AdminStatusSnapshot {
+        AdminStatusSnapshot(dict: [
+            "router_boot_id": "boot-menu-auth",
+            "active_generation": generation,
+            "active_config_hash": "sha256:menu-auth-\(generation)",
+            "desired_config_hash": "sha256:menu-auth-\(generation)",
+            "capabilities": ["global_routing"],
+            "health": "ready",
+            "config_path": previewConfigPath,
+            "global_routing_enabled": true,
+            "auth": [
+                "signed_in": signedIn,
+                "health": health,
+                "fallback_in_use": false,
+            ],
+            "clients": [[
+                "name": "claude-code",
+                "enabled": true,
+                "bind_addr": "127.0.0.1:45372",
+                "protocol_shape": "anthropic",
+                "effective_route": "baseten",
+                "native_route": "anthropic",
             ]],
         ])
     }
@@ -708,6 +817,32 @@ final class RuntimeCoordinationTests: XCTestCase {
         XCTAssertFalse(missing.isAuthoritative)
         XCTAssertFalse(acceptance.accept(missing))
         XCTAssertNil(acceptance.current)
+    }
+
+    func testPollEventAcceptanceRejectsLateOlderRequestWithSameToken() {
+        var acceptance = PollEventAcceptance()
+        let token = RoutingToken(
+            routerBootID: "boot-a",
+            activeGeneration: 4)
+
+        XCTAssertTrue(acceptance.accept(requestID: 2, token: token))
+        XCTAssertFalse(acceptance.accept(requestID: 1, token: token))
+        XCTAssertEqual(acceptance.latestRequestID, 2)
+    }
+
+    func testRejectedNewerTokenStillBlocksOlderRequest() {
+        var acceptance = PollEventAcceptance()
+        let current = RoutingToken(
+            routerBootID: "boot-a",
+            activeGeneration: 4)
+        let stale = RoutingToken(
+            routerBootID: "boot-a",
+            activeGeneration: 3)
+
+        XCTAssertTrue(acceptance.accept(requestID: 0, token: current))
+        XCTAssertFalse(acceptance.accept(requestID: 2, token: stale))
+        XCTAssertEqual(acceptance.latestRequestID, 2)
+        XCTAssertFalse(acceptance.accept(requestID: 1, token: current))
     }
 
     func testPollCoordinatorCoalescesConcurrentRefreshes() async {
@@ -1149,6 +1284,27 @@ final class RuntimeCoordinationTests: XCTestCase {
     }
 
     @MainActor
+    func testRouterMismatchFailuresUseReviewedActionableMessage() async {
+        for mode in [
+            PrimaryFailureRunner.Mode.routerStateMismatch,
+            .routerIdentityMismatch,
+        ] {
+            let runner = PrimaryFailureRunner(mode: mode)
+            let state = mutationTestState(runner: runner)
+            await state.refresh()
+
+            await state.setAllRoutesThroughBaseten(true)
+
+            XCTAssertEqual(
+                state.lastError,
+                "The app and routing command are connected to different local gateways. Restart Baseten Switch and try again.")
+            XCTAssertFalse(state.lastError?.contains("/Users/") == true)
+            XCTAssertFalse(state.lastError?.contains("model-id") == true)
+            state.stop()
+        }
+    }
+
+    @MainActor
     func testFailedSecondaryReconciliationCannotMaskPrimaryFailure() async {
         let runner = PrimaryFailureRunner(mode: .failedReconciliation)
         let state = mutationTestState(runner: runner)
@@ -1534,6 +1690,82 @@ final class RuntimeCoordinationTests: XCTestCase {
     }
 
     @MainActor
+    func testTrackedStatusMenuRefreshProjectsAndRebuildsAuthAttention() async {
+        let reader = SequencedAdminReader(statuses: [
+            menuAuthStatus(generation: 4, signedIn: true, health: "ok"),
+            menuAuthStatus(
+                generation: 5,
+                signedIn: false,
+                health: "signed_out"),
+            menuAuthStatus(generation: 6, signedIn: true, health: "ok"),
+        ])
+        let runner = ConcurrencyRecordingRunner()
+        let variant = stableTestVariant()
+        let state = BasetenSwitchState(
+            variant: variant,
+            reader: reader,
+            cliRunner: runner,
+            loginItemService: FakeLoginItemService(),
+            previewRuntimeValidator: { _ in nil },
+            startPolling: false)
+
+        await state.refresh()
+        let controller = StatusItemController(state: state, variant: variant)
+        XCTAssertEqual(
+            controller.fixedHeaderSubtitleForTesting,
+            "Routing rules are active")
+        XCTAssertEqual(controller.displayedIconStateForTesting, .active)
+        let healthyMenuTitles = controller.menuItemTitlesForTesting
+        XCTAssertFalse(healthyMenuTitles.contains("Sign In to Baseten…"))
+
+        // Opening the menu schedules one asynchronous status pass. A later
+        // signed-out snapshot must immediately project warning copy into the
+        // fixed header and amber icon. AppKit can add the action row on the
+        // next structural rebuild without mutating the tracked menu.
+        controller.menuWillOpenForTesting()
+        await state.waitForInteractiveRefresh()
+        await drainMainQueue()
+
+        XCTAssertEqual(
+            controller.fixedHeaderSubtitleForTesting,
+            "Sign in to use Baseten")
+        XCTAssertEqual(controller.displayedIconStateForTesting, .degraded)
+        XCTAssertEqual(
+            controller.menuItemTitlesForTesting,
+            healthyMenuTitles)
+        XCTAssertFalse(
+            controller.menuItemTitlesForTesting.contains("Sign In to Baseten…"))
+
+        controller.menuDidCloseForTesting()
+        controller.menuNeedsUpdateForTesting()
+        XCTAssertEqual(
+            controller.fixedHeaderSubtitleForTesting,
+            "Sign in to use Baseten")
+        XCTAssertTrue(
+            controller.menuItemTitlesForTesting.contains("Sign In to Baseten…"))
+
+        // A later healthy snapshot clears all three projections after the
+        // closed menu is rebuilt.
+        await state.refresh()
+        await drainMainQueue()
+        controller.menuNeedsUpdateForTesting()
+        XCTAssertEqual(
+            controller.fixedHeaderSubtitleForTesting,
+            "Routing rules are active")
+        XCTAssertEqual(controller.displayedIconStateForTesting, .active)
+        XCTAssertFalse(
+            controller.menuItemTitlesForTesting.contains("Sign In to Baseten…"))
+
+        let statusCalls = await reader.statusCalls
+        let statsCalls = await reader.statsCalls
+        let versionCalls = await runner.arguments
+        XCTAssertEqual(statusCalls, 3)
+        XCTAssertEqual(statsCalls, 1)
+        XCTAssertEqual(versionCalls, [["--version"]])
+        state.stop()
+    }
+
+    @MainActor
     func testFamilyMutationUsesCASAndReconcilesBeforeClearingPending() async {
         let reader = SequencedAdminReader(statuses: [
             previewStatus(
@@ -1583,6 +1815,56 @@ final class RuntimeCoordinationTests: XCTestCase {
                 client: "claude-code",
                 family: "opus"))
         XCTAssertNil(state.lastError)
+        state.stop()
+    }
+
+    @MainActor
+    func testFamilyMutationWaitsOutPreMutationStatusRequest() async {
+        let oldStatus = previewStatus(
+            generation: 4,
+            hash: "sha256:old",
+            familyTarget: "zai-org/GLM-5.2")
+        let confirmedStatus = previewStatus(
+            generation: 5,
+            hash: "sha256:new",
+            familyTarget: "native")
+        let reader = SuspendingMutationAdminReader(
+            initial: oldStatus,
+            stale: oldStatus,
+            confirmed: confirmedStatus)
+        let runner = ReconciliationReceiptRunner()
+        let state = BasetenSwitchState(
+            variant: previewVariant(),
+            reader: reader,
+            cliRunner: runner,
+            loginItemService: FakeLoginItemService(),
+            previewRuntimeValidator: { _ in nil },
+            startPolling: false)
+        await state.refresh()
+        let client = try! XCTUnwrap(state.clients.first)
+
+        let stalePoll = Task { @MainActor in
+            await state.refresh()
+        }
+        await reader.waitForStaleRequest()
+        let mutation = Task { @MainActor in
+            await state.routeFamily(client, family: "opus", choice: .native)
+        }
+        while (await runner.arguments).count < 2 {
+            await Task.yield()
+        }
+        await reader.releaseStaleRequest()
+        await stalePoll.value
+        await mutation.value
+
+        let statusCalls = await reader.statusCalls
+        XCTAssertEqual(statusCalls, 3)
+        XCTAssertNil(state.lastError)
+        XCTAssertEqual(
+            state.clients.first?.families.first(where: {
+                $0.family == "opus"
+            })?.configuredTarget,
+            "native")
         state.stop()
     }
 


### PR DESCRIPTION
## What

- Add a loopback auth reload endpoint with a narrow, non-secret status receipt.
- Make client-page Refresh reload authentication, fetch fresh router status, and reload the model catalog in order, with stale-response and coalescing guards.
- Preserve confirmed model selections while catalog refresh is pending, keep routing controls disabled until fresh availability is known, and show route-aware authentication attention consistently across the menu bar and routing window.
- Keep Stable development reads and CLI mutations on the same explicitly configured local router.

## Why

A Baseten CLI login updates the credential store independently of the running router. The app could continue showing signed-out state until background polling noticed the new credential, and a manual Refresh did not force that reload. Concurrent status and catalog requests could also leave model availability or saved picker presentation temporarily inconsistent.

Stable development builds attached to an isolated router also need their child CLI mutations to use that same router rather than the default Stable runtime.

## Testing

- `scripts/check.sh --offline`
- Packaged Stable app against an isolated local router: signed-out presentation, one-click authentication recovery, stable model selections during Refresh, and a model mapping change and restore.
- Added Go coverage for OAuth and API-key reload, credential replacement, request validation, serialization, and credential-scoped state reset.
- Added Swift coverage for refresh ordering, coalescing, cancellation, recovery, picker-state preservation, route-aware authentication attention, menu updates, older-router compatibility, request timeouts, and isolated runtime coordination.

## Security and privacy

The new localhost endpoint accepts only POST requests with the Switch admin header and returns no credential material. Authentication reload reads the existing local credential store; it does not add credential or prompt logging. Stable child commands receive only explicit config, admin endpoint, and PID-file coordination values, excluding credentials and unrelated environment state. This adds no dependencies, telemetry, release artifacts, or network destinations.
