### PR TITLE
Improve credential reload resilience and auth diagnostics

### DIFF
--- a/gateway/cmd/baseten-switch/doctor.go
+++ b/gateway/cmd/baseten-switch/doctor.go
@@ -191,7 +191,8 @@ func runDoctor(o doctorOpts) doctorReport {
 	routerState := probePort(adminAddr, routerHealthPath, routerHealthMarker)
 
 	// --- 3. auth ----------------------------------------------------------
-	storeAuth := doctorAuthCheck(add, f, unresolved, envFile, envFilePath)
+	routerProfile, routerProfileKnown := doctorRouterAuthProfile(adminAddr, routerState == portOurs)
+	storeAuth := doctorAuthCheck(add, f, unresolved, envFile, envFilePath, routerProfile, routerProfileKnown)
 	doctorAuthHealthCheck(add, adminAddr, routerState == portOurs, storeAuth)
 	doctorBasetenCLICheck(add)
 
@@ -424,27 +425,39 @@ func doctorConfigChecks(add addCheck, cfgPath string, cfgErr error, f *config.Fi
 // only when something actually depends on a Baseten credential: a
 // baseten-routed client, or an unresolved auth placeholder.
 type doctorStoreAuth struct {
-	apiKeyProfile string
-	apiKeyReady   bool
+	profile  string
+	authType string
+	ready    bool
 }
 
-func doctorAuthCheck(add addCheck, f *config.File, unresolved []string, envFile map[string]string, envFilePath string) doctorStoreAuth {
-	tok, _, err := auth.Load("")
+func doctorAuthCheck(add addCheck, f *config.File, unresolved []string, envFile map[string]string, envFilePath, routerProfile string, routerProfileKnown bool) doctorStoreAuth {
+	profile := doctorEnvValue("BASETEN_SWITCH_OAUTH_PROFILE", envFile)
+	if routerProfileKnown {
+		profile = routerProfile
+	}
+	tok, loc, err := auth.LoadDetailed(profile)
 	var ak *auth.APIKeyProfileError
 	switch {
 	case err != nil && errors.As(err, &ak):
 		if ak.Key != "" {
 			add("auth", "signin", docOK, fmt.Sprintf("signed in with API key (profile %q)", ak.Profile), "")
-			return doctorStoreAuth{apiKeyProfile: ak.Profile, apiKeyReady: true}
+			return doctorStoreAuth{profile: ak.Profile, authType: "API-key", ready: true}
 		} else {
 			add("auth", "signin", docWarn, fmt.Sprintf("profile %q uses API key auth but the key is not readable", ak.Profile),
 				"check the keyring or auth.json, or run 'baseten auth login'")
 		}
-		return doctorStoreAuth{apiKeyProfile: ak.Profile}
+		return doctorStoreAuth{profile: ak.Profile, authType: "API-key"}
+	case errors.Is(err, auth.ErrStoreUnreadable), errors.Is(err, auth.ErrStoreMalformed):
+		add("auth", "signin", docFail, err.Error(), "repair the credential store or run 'baseten auth login'")
+		return doctorStoreAuth{}
 	case err != nil:
-		add("auth", "signin", docWarn, fmt.Sprintf("credential store unreadable: %v", err), "baseten auth login")
+		add("auth", "signin", docWarn, fmt.Sprintf("credential store check failed: %v", err), "baseten auth login")
 		return doctorStoreAuth{}
 	case tok != nil:
+		loadedProfile := profile
+		if loc != nil && loc.Account != "" {
+			loadedProfile = loc.Account
+		}
 		if !tok.Expiry.IsZero() && tok.Expiry.Before(time.Now()) {
 			add("auth", "signin", docWarn,
 				fmt.Sprintf("signed in (OAuth) but the access token expired %s; a refresh is attempted on the next request", tok.Expiry.UTC().Format(time.RFC3339)),
@@ -453,17 +466,26 @@ func doctorAuthCheck(add addCheck, f *config.File, unresolved []string, envFile 
 		} else {
 			add("auth", "signin", docOK, "signed in (OAuth)", "")
 		}
-		return doctorStoreAuth{}
+		return doctorStoreAuth{profile: loadedProfile, authType: "OAuth", ready: true}
 	}
 
-	// Not signed in. BASETEN_API_KEY (env or env file) still counts as
-	// a credential, matching the gateway preflight.
-	apiKey := os.Getenv("BASETEN_API_KEY")
-	if apiKey == "" {
-		apiKey = envFile["BASETEN_API_KEY"]
+	// Not signed in. The environment fallback is usable only when both the
+	// key and its explicit opt-in flag resolve, matching the router.
+	apiKey := doctorEnvValue("BASETEN_API_KEY", envFile)
+	apiKeyFallback := doctorAPIKeyFallbackEnabled(envFile)
+	if apiKey != "" && apiKeyFallback {
+		add("auth", "signin", docOK, "no profile sign-in, but the enabled BASETEN_API_KEY fallback is usable", "")
+		return doctorStoreAuth{}
 	}
 	if apiKey != "" {
-		add("auth", "signin", docOK, "no OAuth sign-in, but BASETEN_API_KEY is set (API key fallback)", "")
+		finding := "BASETEN_API_KEY is set but ignored because BASETEN_SWITCH_API_KEY_FALLBACK is not enabled"
+		status := docWarn
+		if names := doctorBasetenRouted(f); len(names) > 0 {
+			status = docFail
+			finding += "; baseten-routed requests have no usable credential: " + strings.Join(names, ", ")
+		}
+		add("auth", "signin", status, finding,
+			fmt.Sprintf("set BASETEN_SWITCH_API_KEY_FALLBACK=1 in %s, or run 'baseten auth login'", envFilePath))
 		return doctorStoreAuth{}
 	}
 	bothFixes := fmt.Sprintf("baseten auth login   (or set the key in %s)", envFilePath)
@@ -475,12 +497,54 @@ func doctorAuthCheck(add addCheck, f *config.File, unresolved []string, envFile 
 	}
 	if names := doctorBasetenRouted(f); len(names) > 0 {
 		add("auth", "signin", docFail,
-			"not signed in (no OAuth, no API key); these clients route to baseten and their requests will fail: "+strings.Join(names, ", "),
+			"not signed in (no OAuth, no API key); these clients cannot use Baseten, and a configured native fallback may serve their requests instead: "+strings.Join(names, ", "),
 			bothFixes)
 		return doctorStoreAuth{}
 	}
 	add("auth", "signin", docWarn, "not signed in (no enabled client routes to baseten, so nothing breaks yet)", "baseten auth login")
 	return doctorStoreAuth{}
+}
+
+// doctorEnvValue mirrors the gateway's process-environment-first lookup over
+// the Switch env file without mutating the doctor process environment.
+func doctorEnvValue(name string, envFile map[string]string) string {
+	if value := os.Getenv(name); value != "" {
+		return value
+	}
+	value := envFile[name]
+	if len(value) >= 2 && ((value[0] == '"' && value[len(value)-1] == '"') || (value[0] == '\'' && value[len(value)-1] == '\'')) {
+		value = value[1 : len(value)-1]
+	}
+	return value
+}
+
+// doctorRouterAuthProfile returns the credential profile selected by the
+// running router. Launchd does not inherit later shell overrides, so this is
+// authoritative when available; offline doctor falls back to local env.
+func doctorRouterAuthProfile(adminAddr string, routerUp bool) (string, bool) {
+	if !routerUp {
+		return "", false
+	}
+	body, ok := doctorAdminGetOK(&http.Client{Timeout: 2 * time.Second}, adminAddr, "/v1/admin/auth/status")
+	if !ok {
+		return "", false
+	}
+	var payload struct {
+		Profile string `json:"profile"`
+	}
+	if json.Unmarshal([]byte(body), &payload) != nil {
+		return "", false
+	}
+	return payload.Profile, true
+}
+
+func doctorAPIKeyFallbackEnabled(envFile map[string]string) bool {
+	switch strings.ToLower(doctorEnvValue("BASETEN_SWITCH_API_KEY_FALLBACK", envFile)) {
+	case "1", "true", "yes":
+		return true
+	default:
+		return false
+	}
 }
 
 // doctorAuthHealthCheck reads the running router's credential health
@@ -519,9 +583,13 @@ func doctorAuthHealthCheck(add addCheck, adminAddr string, routerUp bool, store 
 	lastErr := sanitizeAdminText(payload["last_refresh_error"], 200)
 	lastErrAt := sanitizeAdminText(payload["last_refresh_error_at"], 40)
 	routerSignedIn, _ := payload["signed_in"].(bool)
-	if store.apiKeyReady && (!routerSignedIn || health == "signed_out") {
+	if store.ready && (!routerSignedIn || health == "signed_out") {
+		storedCredential := store.authType + " credential"
+		if store.profile != "" {
+			storedCredential = fmt.Sprintf("%s profile %q", store.authType, store.profile)
+		}
 		add("auth", "health", docFail,
-			fmt.Sprintf("the credential store has readable API-key profile %q, but the running router reports signed out", store.apiKeyProfile),
+			fmt.Sprintf("the credential store has readable %s, but the running router reports signed out", storedCredential),
 			"baseten-switch up   (adopt the current router binary and reload the selected profile)")
 		return
 	}
@@ -1591,25 +1659,35 @@ func doctorE2EChecks(add addCheck, o doctorOpts, doorSpecs []door.Config, doorUp
 		port := portOf(t.BindAddr)
 		probeStart := time.Now()
 		p := doctorProbeClient(httpC, t)
-		if doctorProbeOK(p) {
+		if doctorProbeOK(p) && p.FallbackTrigger == "auth_unavailable" {
+			add("e2e", "probe:"+port, docFail,
+				fmt.Sprintf("1-token request succeeded through native fallback because Baseten auth was unavailable (status %d, %dms, model %s%s)", p.Status, p.LatencyMs, orDash(p.Model), doctorProbeResponseSuffix(p)),
+				"configure a usable Baseten credential, then rerun the probe")
+		} else if doctorProbeOK(p) {
 			add("e2e", "probe:"+port, docOK,
-				fmt.Sprintf("1-token request through the door succeeded (status %d, %dms, model %s)", p.Status, p.LatencyMs, orDash(p.Model)), "")
+				fmt.Sprintf("1-token request through the door succeeded (status %d, %dms, model %s%s)", p.Status, p.LatencyMs, orDash(p.Model), doctorProbeResponseSuffix(p)), "")
 		} else {
 			add("e2e", "probe:"+port, docFail,
-				fmt.Sprintf("1-token request through the door failed (status %d%s): %s", p.Status, doctorProbeViaSuffix(p.DoorVia), orDash(p.Error)),
+				fmt.Sprintf("1-token request through the door failed (status %d%s): %s", p.Status, doctorProbeResponseSuffix(p), orDash(p.Error)),
 				"baseten-switch status   (then check the router and door logs)")
 		}
 		doctorProbeRouteCheck(add, port, p, probeStart, f, routerTargets[t.BindAddr], t.ProtocolShape, telPath)
 	}
 }
 
-func doctorProbeViaSuffix(via string) string {
-	switch via {
+func doctorProbeResponseSuffix(p *doctorProbeResult) string {
+	var details []string
+	switch p.DoorVia {
 	case "router", "fallback":
-		return ", served via " + via
-	default:
+		details = append(details, "served via "+p.DoorVia)
+	}
+	if trigger := sanitizeAdminText(p.FallbackTrigger, 80); trigger != "" {
+		details = append(details, "fallback trigger "+strconv.Quote(trigger))
+	}
+	if len(details) == 0 {
 		return ""
 	}
+	return ", " + strings.Join(details, ", ")
 }
 
 // doctorProbeRouteCheck asserts the probe was served by the route the

--- a/gateway/cmd/baseten-switch/doctor.go
+++ b/gateway/cmd/baseten-switch/doctor.go
@@ -191,9 +191,9 @@ func runDoctor(o doctorOpts) doctorReport {
 	routerState := probePort(adminAddr, routerHealthPath, routerHealthMarker)
 
 	// --- 3. auth ----------------------------------------------------------
-	routerProfile, routerProfileKnown := doctorRouterAuthProfile(adminAddr, routerState == portOurs)
-	storeAuth := doctorAuthCheck(add, f, unresolved, envFile, envFilePath, routerProfile, routerProfileKnown)
-	doctorAuthHealthCheck(add, adminAddr, routerState == portOurs, storeAuth)
+	routerAuth, routerAuthKnown := doctorRouterAuthSnapshot(adminAddr, routerState == portOurs)
+	storeAuth := doctorAuthCheck(add, f, unresolved, envFile, envFilePath, routerAuth, routerAuthKnown)
+	doctorAuthHealthCheck(add, routerState == portOurs, routerAuth, routerAuthKnown, storeAuth)
 	doctorBasetenCLICheck(add)
 
 	// --- 4. router --------------------------------------------------------
@@ -430,10 +430,10 @@ type doctorStoreAuth struct {
 	ready    bool
 }
 
-func doctorAuthCheck(add addCheck, f *config.File, unresolved []string, envFile map[string]string, envFilePath, routerProfile string, routerProfileKnown bool) doctorStoreAuth {
+func doctorAuthCheck(add addCheck, f *config.File, unresolved []string, envFile map[string]string, envFilePath string, routerAuth doctorRouterAuth, routerAuthKnown bool) doctorStoreAuth {
 	profile := doctorEnvValue("BASETEN_SWITCH_OAUTH_PROFILE", envFile)
-	if routerProfileKnown {
-		profile = routerProfile
+	if routerAuthKnown {
+		profile = routerAuth.Profile
 	}
 	tok, loc, err := auth.LoadDetailed(profile)
 	var ak *auth.APIKeyProfileError
@@ -467,6 +467,51 @@ func doctorAuthCheck(add addCheck, f *config.File, unresolved []string, envFile 
 			add("auth", "signin", docOK, "signed in (OAuth)", "")
 		}
 		return doctorStoreAuth{profile: loadedProfile, authType: "OAuth", ready: true}
+	}
+	if routerAuthKnown && routerAuth.SignedIn {
+		authType := strings.TrimSpace(routerAuth.AuthType)
+		if authType == "" {
+			authType = "credential"
+		}
+		finding := fmt.Sprintf("the running router is signed in with %s auth", authType)
+		if routerAuth.Profile != "" {
+			finding += fmt.Sprintf(" (profile %q)", routerAuth.Profile)
+		}
+		add("auth", "signin", docOK, finding, "")
+		return doctorStoreAuth{}
+	}
+
+	// A reachable router is authoritative for environment fallback state.
+	// Launchd does not inherit later shell exports, and the Switch env file can
+	// also change after the process starts. Local values are used only offline.
+	if routerAuthKnown {
+		if routerAuth.FallbackInUse {
+			add("auth", "signin", docOK, "no profile sign-in, but the running router's enabled BASETEN_API_KEY fallback is usable", "")
+			return doctorStoreAuth{}
+		}
+		if authVars := doctorAuthPlaceholders(f, unresolved); len(authVars) > 0 {
+			add("auth", "signin", docFail,
+				fmt.Sprintf("the running router is signed out and gateway.yaml references ${%s} which is unset; baseten-routed requests have no credential", strings.Join(authVars, "}, ${")),
+				fmt.Sprintf("baseten auth login   (or set %s=... in %s)", authVars[0], envFilePath))
+			return doctorStoreAuth{}
+		}
+		finding := "the running router has no usable profile credential"
+		if routerAuth.FallbackEnabled {
+			finding += " and API-key fallback is enabled but has no usable key loaded"
+		} else {
+			finding += " and API-key fallback is disabled"
+		}
+		if doctorEnvValue("BASETEN_API_KEY", envFile) != "" && doctorAPIKeyFallbackEnabled(envFile) {
+			finding += "; the current shell's BASETEN_API_KEY fallback is not loaded by the running router"
+		}
+		status := docWarn
+		if names := doctorBasetenRouted(f); len(names) > 0 {
+			status = docFail
+			finding += "; baseten-routed requests have no usable credential: " + strings.Join(names, ", ")
+		}
+		add("auth", "signin", status, finding,
+			"baseten-switch up   (reload the running router's credential state, or run 'baseten auth login')")
+		return doctorStoreAuth{}
 	}
 
 	// Not signed in. The environment fallback is usable only when both the
@@ -518,24 +563,36 @@ func doctorEnvValue(name string, envFile map[string]string) string {
 	return value
 }
 
-// doctorRouterAuthProfile returns the credential profile selected by the
-// running router. Launchd does not inherit later shell overrides, so this is
-// authoritative when available; offline doctor falls back to local env.
-func doctorRouterAuthProfile(adminAddr string, routerUp bool) (string, bool) {
+type doctorRouterAuth struct {
+	SignedIn         bool   `json:"signed_in"`
+	AuthType         string `json:"auth_type"`
+	Profile          string `json:"profile"`
+	Health           string `json:"health"`
+	LastRefreshError string `json:"last_refresh_error"`
+	LastRefreshErrAt string `json:"last_refresh_error_at"`
+	FallbackEnabled  bool   `json:"fallback_enabled"`
+	FallbackInUse    bool   `json:"fallback_in_use"`
+}
+
+// doctorRouterAuthSnapshot reads the local-only auth projection from the
+// general status endpoint. It avoids /v1/admin/auth/status, whose identity
+// fields may require a synchronous upstream request. When unavailable, doctor
+// retains its offline environment-based checks.
+func doctorRouterAuthSnapshot(adminAddr string, routerUp bool) (doctorRouterAuth, bool) {
 	if !routerUp {
-		return "", false
+		return doctorRouterAuth{}, false
 	}
-	body, ok := doctorAdminGetOK(&http.Client{Timeout: 2 * time.Second}, adminAddr, "/v1/admin/auth/status")
+	body, ok := doctorAdminGetOK(&http.Client{Timeout: 2 * time.Second}, adminAddr, "/v1/admin/status")
 	if !ok {
-		return "", false
+		return doctorRouterAuth{}, false
 	}
 	var payload struct {
-		Profile string `json:"profile"`
+		Auth *doctorRouterAuth `json:"auth"`
 	}
-	if json.Unmarshal([]byte(body), &payload) != nil {
-		return "", false
+	if json.Unmarshal([]byte(body), &payload) != nil || payload.Auth == nil {
+		return doctorRouterAuth{}, false
 	}
-	return payload.Profile, true
+	return *payload.Auth, true
 }
 
 func doctorAPIKeyFallbackEnabled(envFile map[string]string) bool {
@@ -548,27 +605,20 @@ func doctorAPIKeyFallbackEnabled(envFile map[string]string) bool {
 }
 
 // doctorAuthHealthCheck reads the running router's credential health
-// (auth.health in /v1/admin/auth/status, derived from real refresh
+// (auth.health in /v1/admin/status, derived from real refresh
 // outcomes). The store-based signin check above cannot detect a dead
 // refresh token: the credential is present, but the token endpoint rejects
 // it. The current admin contract requires the health field.
-func doctorAuthHealthCheck(add addCheck, adminAddr string, routerUp bool, store doctorStoreAuth) {
+func doctorAuthHealthCheck(add addCheck, routerUp bool, routerAuth doctorRouterAuth, routerAuthKnown bool, store doctorStoreAuth) {
 	if !routerUp {
 		add("auth", "health", docSkip, "router not up; credential health is derived from the running router's refresh outcomes", "")
 		return
 	}
-	httpC := &http.Client{Timeout: 2 * time.Second}
-	body, ok := doctorAdminGetOK(httpC, adminAddr, "/v1/admin/auth/status")
-	if !ok {
-		add("auth", "health", docSkip, "admin /v1/admin/auth/status unavailable; cannot read credential health", "")
+	if !routerAuthKnown {
+		add("auth", "health", docSkip, "admin /v1/admin/status auth projection unavailable; cannot read credential health", "")
 		return
 	}
-	var payload map[string]any
-	if err := json.Unmarshal([]byte(body), &payload); err != nil {
-		add("auth", "health", docSkip, fmt.Sprintf("auth status does not parse: %v", err), "")
-		return
-	}
-	health, _ := payload["health"].(string)
+	health := routerAuth.Health
 	if health == "" {
 		add("auth", "health", docFail,
 			"router auth status omitted the required health field",
@@ -580,9 +630,9 @@ func doctorAuthHealthCheck(add addCheck, adminAddr string, routerUp bool, store 
 	// the raw body); a hostile or misconfigured endpoint could otherwise
 	// inject newlines/ANSI sequences that forge or hide check lines in
 	// the report, or flood the terminal.
-	lastErr := sanitizeAdminText(payload["last_refresh_error"], 200)
-	lastErrAt := sanitizeAdminText(payload["last_refresh_error_at"], 40)
-	routerSignedIn, _ := payload["signed_in"].(bool)
+	lastErr := sanitizeAdminText(routerAuth.LastRefreshError, 200)
+	lastErrAt := sanitizeAdminText(routerAuth.LastRefreshErrAt, 40)
+	routerSignedIn := routerAuth.SignedIn
 	if store.ready && (!routerSignedIn || health == "signed_out") {
 		storedCredential := store.authType + " credential"
 		if store.profile != "" {

--- a/gateway/cmd/baseten-switch/doctor_probe.go
+++ b/gateway/cmd/baseten-switch/doctor_probe.go
@@ -17,10 +17,11 @@ type doctorProbeTarget struct {
 }
 
 type doctorProbeResult struct {
-	Status    int
-	LatencyMs int64
-	Model     string
-	Error     string
+	Status          int
+	LatencyMs       int64
+	Model           string
+	Error           string
+	FallbackTrigger string
 
 	// DoorVia is the X-Baseten-Switch-Door response header: "router" when the
 	// router answered and "fallback" when the door's native failover
@@ -71,10 +72,16 @@ func doctorProbeClient(c *http.Client, target doctorProbeTarget) *doctorProbeRes
 	}
 	defer resp.Body.Close()
 	respBody, _ := io.ReadAll(resp.Body)
+	doorVia := resp.Header.Get("X-Baseten-Switch-Door")
+	fallbackTrigger := ""
+	if doorVia == "router" {
+		fallbackTrigger = resp.Header.Get("X-Baseten-Switch-Fallback")
+	}
 	result := &doctorProbeResult{
-		Status:    resp.StatusCode,
-		LatencyMs: latency,
-		DoorVia:   resp.Header.Get("X-Baseten-Switch-Door"),
+		Status:          resp.StatusCode,
+		LatencyMs:       latency,
+		DoorVia:         doorVia,
+		FallbackTrigger: fallbackTrigger,
 	}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		var payload struct {

--- a/gateway/cmd/baseten-switch/doctor_test.go
+++ b/gateway/cmd/baseten-switch/doctor_test.go
@@ -90,11 +90,12 @@ type doctorFixtureCfg struct {
 	// client, requested model, and status), emulating the router's
 	// write. Empty probeTelRoute = no row (door-fallback case, or the
 	// no-row skip case).
-	probeTelRoute        string
-	probeTelEffective    string
-	probeFallbackTrigger string
-	probeStatus          int
-	probeError           string
+	probeTelRoute         string
+	probeTelEffective     string
+	probeFallbackTrigger  string
+	probeResponseFallback string
+	probeStatus           int
+	probeError            string
 	// probeConcurrentModel, when non-empty, makes the fake door append a
 	// second v1 event AFTER the probe's event: a concurrent harness
 	// request completing just behind the probe, the misattribution
@@ -237,7 +238,11 @@ func newDoctorFixture(t *testing.T, mut func(*doctorFixtureCfg)) *doctorFixture 
 					cfg.authHealth, errJSON)
 			}
 			signedIn := !cfg.routerSignedOut
-			fmt.Fprintf(w, `{"signed_in":%t,%s"profile":"doc","fallback_enabled":false,"fallback_in_use":false,"email":"doc@example.com"}`, signedIn, healthPart)
+			profile := "doc@example.com"
+			if cfg.apiKeyProfile {
+				profile = "example-profile"
+			}
+			fmt.Fprintf(w, `{"signed_in":%t,%s"profile":%q,"fallback_enabled":false,"fallback_in_use":false,"email":"doc@example.com"}`, signedIn, healthPart, profile)
 		})
 		srv := httptest.NewServer(mux)
 		t.Cleanup(srv.Close)
@@ -302,6 +307,9 @@ func newDoctorFixture(t *testing.T, mut func(*doctorFixtureCfg)) *doctorFixture 
 				}
 				if cfg.doorProbe != "none" {
 					w.Header().Set("X-Baseten-Switch-Door", cfg.doorProbe)
+				}
+				if cfg.probeResponseFallback != "" {
+					w.Header().Set("X-Baseten-Switch-Fallback", cfg.probeResponseFallback)
 				}
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(probeStatus)
@@ -550,6 +558,8 @@ func newDoctorFixture(t *testing.T, mut func(*doctorFixtureCfg)) *doctorFixture 
 	t.Setenv("BASETEN_SWITCH_LAUNCHD", "off")
 	t.Setenv("ANTHROPIC_BASE_URL", "")
 	t.Setenv("BASETEN_API_KEY", "")
+	t.Setenv("BASETEN_SWITCH_API_KEY_FALLBACK", "")
+	t.Setenv("BASETEN_SWITCH_OAUTH_PROFILE", "")
 	t.Setenv(claudeSubagentEnvKey, "")
 	// Clear the harness env slots the model_env check scans for, so the
 	// green run does not pick up a real shell value.
@@ -1462,6 +1472,96 @@ func TestDoctorUnresolvedAPIKeyNoOAuth(t *testing.T) {
 	}
 }
 
+func TestDoctorEnvironmentAPIKeyRequiresFallbackFlag(t *testing.T) {
+	t.Run("process environment key without flag fails", func(t *testing.T) {
+		newDoctorFixture(t, func(c *doctorFixtureCfg) { c.signedIn = false })
+		t.Setenv("BASETEN_API_KEY", "synthetic-ignored-key")
+
+		rep := runDoctor(doctorOpts{})
+		c := findCheck(t, rep, "auth", "signin")
+		if c.Status != docFail ||
+			!strings.Contains(c.Finding, "BASETEN_API_KEY is set but ignored") ||
+			!strings.Contains(c.Finding, "BASETEN_SWITCH_API_KEY_FALLBACK") {
+			t.Fatalf("signin = %+v, want ignored-key failure naming the opt-in flag", c)
+		}
+	})
+
+	t.Run("process environment key and truthy flag pass", func(t *testing.T) {
+		newDoctorFixture(t, func(c *doctorFixtureCfg) { c.signedIn = false })
+		t.Setenv("BASETEN_API_KEY", "synthetic-enabled-key")
+		t.Setenv("BASETEN_SWITCH_API_KEY_FALLBACK", "yes")
+
+		rep := runDoctor(doctorOpts{})
+		c := findCheck(t, rep, "auth", "signin")
+		if c.Status != docOK || !strings.Contains(c.Finding, "enabled BASETEN_API_KEY fallback") {
+			t.Fatalf("signin = %+v, want enabled environment fallback", c)
+		}
+	})
+
+	t.Run("Switch env file key and flag pass", func(t *testing.T) {
+		newDoctorFixture(t, func(c *doctorFixtureCfg) { c.signedIn = false })
+		envPath := os.Getenv("BASETEN_SWITCH_ENV_FILE")
+		if err := os.WriteFile(envPath, []byte("BASETEN_API_KEY='synthetic-file-key'\nBASETEN_SWITCH_API_KEY_FALLBACK=\"true\"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		rep := runDoctor(doctorOpts{})
+		c := findCheck(t, rep, "auth", "signin")
+		if c.Status != docOK || !strings.Contains(c.Finding, "enabled BASETEN_API_KEY fallback") {
+			t.Fatalf("signin = %+v, want enabled env-file fallback", c)
+		}
+	})
+
+	t.Run("process environment takes precedence over Switch env file", func(t *testing.T) {
+		newDoctorFixture(t, func(c *doctorFixtureCfg) { c.signedIn = false })
+		envPath := os.Getenv("BASETEN_SWITCH_ENV_FILE")
+		if err := os.WriteFile(envPath, []byte("BASETEN_API_KEY=synthetic-file-key\nBASETEN_SWITCH_API_KEY_FALLBACK=1\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("BASETEN_SWITCH_API_KEY_FALLBACK", "0")
+
+		rep := runDoctor(doctorOpts{})
+		c := findCheck(t, rep, "auth", "signin")
+		if c.Status != docFail || !strings.Contains(c.Finding, "is set but ignored") {
+			t.Fatalf("signin = %+v, want process flag to disable env-file fallback", c)
+		}
+	})
+}
+
+func TestDoctorNamesCredentialStoreFailure(t *testing.T) {
+	t.Run("malformed JSON", func(t *testing.T) {
+		newDoctorFixture(t, func(c *doctorFixtureCfg) { c.signedIn = false })
+		path := os.Getenv("BASETEN_SWITCH_AUTH_FILE")
+		if err := os.WriteFile(path, []byte(`{"version":`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		check := findCheck(t, runDoctor(doctorOpts{}), "auth", "signin")
+		if check.Status != docFail || !strings.Contains(check.Finding, path) || !strings.Contains(check.Finding, "cannot parse") {
+			t.Fatalf("signin = %+v, want failure naming malformed store %q", check, path)
+		}
+		if strings.Contains(check.Finding, "BASETEN_API_KEY") {
+			t.Fatalf("malformed store was misattributed to the environment key: %+v", check)
+		}
+	})
+
+	t.Run("unreadable path", func(t *testing.T) {
+		newDoctorFixture(t, func(c *doctorFixtureCfg) { c.signedIn = false })
+		path := os.Getenv("BASETEN_SWITCH_AUTH_FILE")
+		if err := os.Remove(path); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Mkdir(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+
+		check := findCheck(t, runDoctor(doctorOpts{}), "auth", "signin")
+		if check.Status != docFail || !strings.Contains(check.Finding, path) || !strings.Contains(check.Finding, "cannot read") {
+			t.Fatalf("signin = %+v, want failure naming unreadable store %q", check, path)
+		}
+	})
+}
+
 func TestDoctorReadableAPIKeyProfileRouterSignedOutFails(t *testing.T) {
 	newDoctorFixture(t, func(c *doctorFixtureCfg) {
 		c.apiKeyProfile = true
@@ -1478,6 +1578,70 @@ func TestDoctorReadableAPIKeyProfileRouterSignedOutFails(t *testing.T) {
 	}
 	if rep.FirstFailure != "auth/health" {
 		t.Fatalf("first failure = %q, want auth/health", rep.FirstFailure)
+	}
+}
+
+func TestDoctorReadableOAuthProfileRouterSignedOutFails(t *testing.T) {
+	newDoctorFixture(t, func(c *doctorFixtureCfg) {
+		c.routerSignedOut = true
+		c.authHealth = "signed_out"
+	})
+	rep := runDoctor(doctorOpts{})
+	if c := findCheck(t, rep, "auth", "signin"); c.Status != docOK || !strings.Contains(c.Finding, "OAuth") {
+		t.Fatalf("signin = %+v, want readable OAuth profile", c)
+	}
+	c := findCheck(t, rep, "auth", "health")
+	if c.Status != docFail ||
+		!strings.Contains(c.Finding, "OAuth profile") ||
+		!strings.Contains(c.Finding, "doc@example.com") ||
+		!strings.Contains(c.Finding, "router reports signed out") {
+		t.Fatalf("health = %+v, want OAuth store/router inconsistency failure", c)
+	}
+	if rep.FirstFailure != "auth/health" {
+		t.Fatalf("first failure = %q, want auth/health", rep.FirstFailure)
+	}
+}
+
+func TestDoctorUsesRouterSelectedCredentialProfile(t *testing.T) {
+	writeAuthJSON(t, `{
+  "version": 1,
+  "current": "current-oauth",
+  "profiles": {
+    "current-oauth": {
+      "remote_url": "https://app.example.com",
+      "auth_type": "oauth",
+      "oauth_credential": {"access_token": "at", "refresh_token": "rt"}
+    },
+    "selected-api-key": {
+      "remote_url": "https://api.example.com",
+      "auth_type": "api_key",
+      "api_key": "synthetic-selected-key"
+    }
+  }
+}`)
+	t.Setenv("BASETEN_SWITCH_OAUTH_PROFILE", "selected-api-key")
+	t.Setenv("BASETEN_API_KEY", "")
+	t.Setenv("BASETEN_SWITCH_API_KEY_FALLBACK", "")
+
+	var check doctorCheck
+	store := doctorAuthCheck(func(section, name, status, finding, fix string, fixArgv ...string) {
+		check = doctorCheck{Section: section, Name: name, Status: status, Finding: finding, Fix: fix}
+	}, &config.File{}, nil, map[string]string{}, filepath.Join(t.TempDir(), "env"), "", false)
+	if check.Status != docOK || !strings.Contains(check.Finding, "selected-api-key") {
+		t.Fatalf("signin = %+v, want explicitly selected API-key profile", check)
+	}
+	if !store.ready || store.authType != "API-key" || store.profile != "selected-api-key" {
+		t.Fatalf("store = %+v, want selected API-key profile metadata", store)
+	}
+}
+
+func TestDoctorUsesRunningRouterCredentialProfile(t *testing.T) {
+	newDoctorFixture(t, nil)
+	t.Setenv("BASETEN_SWITCH_OAUTH_PROFILE", "shell-profile-not-used-by-router")
+
+	check := findCheck(t, runDoctor(doctorOpts{}), "auth", "signin")
+	if check.Status != docOK || !strings.Contains(check.Finding, "OAuth") {
+		t.Fatalf("signin = %+v, want the running router's readable OAuth profile", check)
 	}
 }
 
@@ -2243,6 +2407,48 @@ func TestDoctorFailedProbeNamesDoorFallback(t *testing.T) {
 	routeCheck := findCheck(t, rep, "e2e", "route:"+fx.doorPort)
 	if routeCheck.Status != docFail || !strings.Contains(routeCheck.Finding, "native failover served it") || !strings.Contains(routeCheck.Finding, `"baseten"`) {
 		t.Fatalf("route = %+v, want configured-versus-fallback attribution", routeCheck)
+	}
+}
+
+func TestDoctorProbeFindingNamesAuthUnavailableResponseMarker(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+		want   string
+	}{
+		{name: "successful fallback", status: http.StatusOK, want: docFail},
+		{name: "failed fallback", status: http.StatusUnauthorized, want: docFail},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newDoctorFixture(t, func(c *doctorFixtureCfg) {
+				c.doorProbe = "router"
+				c.probeStatus = tc.status
+				c.probeError = `{"error":"synthetic native credential failure"}`
+				c.probeTelRoute = "baseten"
+				c.probeTelEffective = "anthropic"
+				c.probeFallbackTrigger = "auth_unavailable"
+				c.probeResponseFallback = "auth_unavailable"
+			})
+			rep := runDoctor(doctorOpts{probe: true, yes: true, timeoutSec: 5})
+			probe := findCheck(t, rep, "e2e", "probe:"+fx.doorPort)
+			if probe.Status != tc.want || !strings.Contains(probe.Finding, `fallback trigger "auth_unavailable"`) {
+				t.Fatalf("probe = %+v, want %s finding naming auth_unavailable response marker", probe, tc.want)
+			}
+		})
+	}
+}
+
+func TestDoctorIgnoresFallbackMarkerWithoutRouterProvenance(t *testing.T) {
+	fx := newDoctorFixture(t, func(c *doctorFixtureCfg) {
+		c.doorProbe = "fallback"
+		c.probeStatus = http.StatusUnauthorized
+		c.probeError = `{"error":"synthetic native failure"}`
+		c.probeResponseFallback = "auth_unavailable"
+	})
+	rep := runDoctor(doctorOpts{probe: true, yes: true, timeoutSec: 5})
+	probe := findCheck(t, rep, "e2e", "probe:"+fx.doorPort)
+	if strings.Contains(probe.Finding, "auth_unavailable") {
+		t.Fatalf("probe trusted a native fallback response marker: %+v", probe)
 	}
 }
 

--- a/gateway/cmd/baseten-switch/doctor_test.go
+++ b/gateway/cmd/baseten-switch/doctor_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -69,8 +70,10 @@ type doctorFixtureCfg struct {
 	// apiKeyProfile makes the selected local profile a readable API-key
 	// profile. routerSignedOut independently models a stale router that has
 	// not loaded that credential.
-	apiKeyProfile   bool
-	routerSignedOut bool
+	apiKeyProfile         bool
+	routerSignedOut       bool
+	routerFallbackEnabled bool
+	routerFallbackInUse   bool
 	// authLastError sets last_refresh_error alongside authHealth.
 	authLastError string
 	// basetenVersions writes one fake baseten CLI per entry (each in
@@ -168,12 +171,13 @@ func writeDoctorTelemetryEvents(dir string, events ...telemetry.EventV1) error {
 }
 
 type doctorFixture struct {
-	clientAddr string
-	doorAddr   string
-	doorPort   string
-	cfgPath    string
-	settings   string
-	codexHome  string
+	clientAddr     string
+	doorAddr       string
+	doorPort       string
+	cfgPath        string
+	settings       string
+	codexHome      string
+	authStatusHits *atomic.Int32
 }
 
 // startClientListener opens a listener that stays bound for the test:
@@ -195,7 +199,10 @@ func newDoctorFixture(t *testing.T, mut func(*doctorFixtureCfg)) *doctorFixture 
 		mut(&cfg)
 	}
 	dir := t.TempDir()
-	fx := &doctorFixture{clientAddr: startClientListener(t)}
+	fx := &doctorFixture{
+		clientAddr:     startClientListener(t),
+		authStatusHits: &atomic.Int32{},
+	}
 	// Resolved up front: the fake door's probe handler (below) appends
 	// the probe's telemetry v1 event here, emulating the router's write.
 	telDir := filepath.Join(dir, "telemetry")
@@ -220,13 +227,36 @@ func newDoctorFixture(t *testing.T, mut func(*doctorFixtureCfg)) *doctorFixture 
 			clientRoute = "baseten"
 		}
 		mux.HandleFunc("/v1/admin/status", func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprintf(w, `{"uptime_seconds":42,"version":%q,
-				"auth":{"signed_in":true,"profile":"doc","fallback_enabled":false,"fallback_in_use":false},
-				"clients":[{"name":"claude-code","enabled":true,"bind_addr":%q,"protocol_shape":"anthropic",
-					"effective_route":%q,"fallback_route":%q,"auth_set":true,"currently_bound":true}]}`,
-				version.Version, fx.clientAddr, clientRoute, cfg.fallbackRoute)
+			profile := "doc@example.com"
+			if cfg.apiKeyProfile {
+				profile = "example-profile"
+			}
+			authStatus := map[string]any{
+				"signed_in":        !cfg.routerSignedOut,
+				"profile":          profile,
+				"fallback_enabled": cfg.routerFallbackEnabled,
+				"fallback_in_use":  cfg.routerFallbackInUse,
+			}
+			if cfg.authHealth != "-" {
+				authStatus["health"] = cfg.authHealth
+				authStatus["last_refresh_error"] = cfg.authLastError
+				authStatus["last_refresh_error_at"] = "2026-07-13T09:55:00Z"
+			}
+			writeJSON := map[string]any{
+				"uptime_seconds": 42,
+				"version":        version.Version,
+				"auth":           authStatus,
+				"clients": []map[string]any{{
+					"name": "claude-code", "enabled": true,
+					"bind_addr": fx.clientAddr, "protocol_shape": "anthropic",
+					"effective_route": clientRoute, "fallback_route": cfg.fallbackRoute,
+					"auth_set": true, "currently_bound": true,
+				}},
+			}
+			_ = json.NewEncoder(w).Encode(writeJSON)
 		})
 		mux.HandleFunc("/v1/admin/auth/status", func(w http.ResponseWriter, r *http.Request) {
+			fx.authStatusHits.Add(1)
 			healthPart := ""
 			if cfg.authHealth != "-" {
 				// json.Marshal, not %q: the error text is server
@@ -1454,6 +1484,8 @@ func TestDoctorForeignAdminPort(t *testing.T) {
 func TestDoctorUnresolvedAPIKeyNoOAuth(t *testing.T) {
 	newDoctorFixture(t, func(c *doctorFixtureCfg) {
 		c.signedIn = false
+		c.routerSignedOut = true
+		c.authHealth = "signed_out"
 		c.globalAuth = "${BASETEN_API_KEY}"
 	})
 	rep := runDoctor(doctorOpts{})
@@ -1474,7 +1506,10 @@ func TestDoctorUnresolvedAPIKeyNoOAuth(t *testing.T) {
 
 func TestDoctorEnvironmentAPIKeyRequiresFallbackFlag(t *testing.T) {
 	t.Run("process environment key without flag fails", func(t *testing.T) {
-		newDoctorFixture(t, func(c *doctorFixtureCfg) { c.signedIn = false })
+		newDoctorFixture(t, func(c *doctorFixtureCfg) {
+			c.signedIn = false
+			c.adminDown = true
+		})
 		t.Setenv("BASETEN_API_KEY", "synthetic-ignored-key")
 
 		rep := runDoctor(doctorOpts{})
@@ -1487,7 +1522,10 @@ func TestDoctorEnvironmentAPIKeyRequiresFallbackFlag(t *testing.T) {
 	})
 
 	t.Run("process environment key and truthy flag pass", func(t *testing.T) {
-		newDoctorFixture(t, func(c *doctorFixtureCfg) { c.signedIn = false })
+		newDoctorFixture(t, func(c *doctorFixtureCfg) {
+			c.signedIn = false
+			c.adminDown = true
+		})
 		t.Setenv("BASETEN_API_KEY", "synthetic-enabled-key")
 		t.Setenv("BASETEN_SWITCH_API_KEY_FALLBACK", "yes")
 
@@ -1499,7 +1537,10 @@ func TestDoctorEnvironmentAPIKeyRequiresFallbackFlag(t *testing.T) {
 	})
 
 	t.Run("Switch env file key and flag pass", func(t *testing.T) {
-		newDoctorFixture(t, func(c *doctorFixtureCfg) { c.signedIn = false })
+		newDoctorFixture(t, func(c *doctorFixtureCfg) {
+			c.signedIn = false
+			c.adminDown = true
+		})
 		envPath := os.Getenv("BASETEN_SWITCH_ENV_FILE")
 		if err := os.WriteFile(envPath, []byte("BASETEN_API_KEY='synthetic-file-key'\nBASETEN_SWITCH_API_KEY_FALLBACK=\"true\"\n"), 0o600); err != nil {
 			t.Fatal(err)
@@ -1513,7 +1554,10 @@ func TestDoctorEnvironmentAPIKeyRequiresFallbackFlag(t *testing.T) {
 	})
 
 	t.Run("process environment takes precedence over Switch env file", func(t *testing.T) {
-		newDoctorFixture(t, func(c *doctorFixtureCfg) { c.signedIn = false })
+		newDoctorFixture(t, func(c *doctorFixtureCfg) {
+			c.signedIn = false
+			c.adminDown = true
+		})
 		envPath := os.Getenv("BASETEN_SWITCH_ENV_FILE")
 		if err := os.WriteFile(envPath, []byte("BASETEN_API_KEY=synthetic-file-key\nBASETEN_SWITCH_API_KEY_FALLBACK=1\n"), 0o600); err != nil {
 			t.Fatal(err)
@@ -1626,7 +1670,7 @@ func TestDoctorUsesRouterSelectedCredentialProfile(t *testing.T) {
 	var check doctorCheck
 	store := doctorAuthCheck(func(section, name, status, finding, fix string, fixArgv ...string) {
 		check = doctorCheck{Section: section, Name: name, Status: status, Finding: finding, Fix: fix}
-	}, &config.File{}, nil, map[string]string{}, filepath.Join(t.TempDir(), "env"), "", false)
+	}, &config.File{}, nil, map[string]string{}, filepath.Join(t.TempDir(), "env"), doctorRouterAuth{}, false)
 	if check.Status != docOK || !strings.Contains(check.Finding, "selected-api-key") {
 		t.Fatalf("signin = %+v, want explicitly selected API-key profile", check)
 	}
@@ -1643,6 +1687,60 @@ func TestDoctorUsesRunningRouterCredentialProfile(t *testing.T) {
 	if check.Status != docOK || !strings.Contains(check.Finding, "OAuth") {
 		t.Fatalf("signin = %+v, want the running router's readable OAuth profile", check)
 	}
+}
+
+func TestDoctorUsesRunningRouterSignedInStateWhenLocalStoreIsMissing(t *testing.T) {
+	t.Setenv("BASETEN_SWITCH_AUTH_FILE", filepath.Join(t.TempDir(), "missing-auth.json"))
+	var check doctorCheck
+	doctorAuthCheck(func(section, name, status, finding, fix string, fixArgv ...string) {
+		check = doctorCheck{Section: section, Name: name, Status: status, Finding: finding, Fix: fix}
+	}, &config.File{}, nil, map[string]string{}, filepath.Join(t.TempDir(), "env"), doctorRouterAuth{
+		SignedIn: true,
+		AuthType: "oauth",
+		Profile:  "router-profile",
+	}, true)
+	if check.Status != docOK || !strings.Contains(check.Finding, "router-profile") {
+		t.Fatalf("signin = %+v, want authoritative running-router sign-in", check)
+	}
+}
+
+func TestDoctorUsesRunningRouterEnvironmentFallbackState(t *testing.T) {
+	t.Run("later shell key is not treated as router credential", func(t *testing.T) {
+		fx := newDoctorFixture(t, func(c *doctorFixtureCfg) {
+			c.signedIn = false
+			c.routerSignedOut = true
+			c.authHealth = "signed_out"
+		})
+		t.Setenv("BASETEN_API_KEY", "synthetic-shell-only-key")
+		t.Setenv("BASETEN_SWITCH_API_KEY_FALLBACK", "1")
+
+		check := findCheck(t, runDoctor(doctorOpts{}), "auth", "signin")
+		if check.Status != docFail ||
+			!strings.Contains(check.Finding, "not loaded by the running router") {
+			t.Fatalf("signin = %+v, want running-router credential failure", check)
+		}
+		if got := fx.authStatusHits.Load(); got != 0 {
+			t.Fatalf("/v1/admin/auth/status requests = %d, want 0", got)
+		}
+	})
+
+	t.Run("router fallback in use is authoritative", func(t *testing.T) {
+		fx := newDoctorFixture(t, func(c *doctorFixtureCfg) {
+			c.signedIn = false
+			c.routerSignedOut = true
+			c.authHealth = "signed_out"
+			c.routerFallbackEnabled = true
+			c.routerFallbackInUse = true
+		})
+
+		check := findCheck(t, runDoctor(doctorOpts{}), "auth", "signin")
+		if check.Status != docOK || !strings.Contains(check.Finding, "running router") {
+			t.Fatalf("signin = %+v, want authoritative running-router fallback", check)
+		}
+		if got := fx.authStatusHits.Load(); got != 0 {
+			t.Fatalf("/v1/admin/auth/status requests = %d, want 0", got)
+		}
+	})
 }
 
 func TestDoctorJSONShape(t *testing.T) {

--- a/gateway/cmd/baseten-switch/lifecycle.go
+++ b/gateway/cmd/baseten-switch/lifecycle.go
@@ -740,6 +740,9 @@ func printStatus(lc *lifecycleConfig, out io.Writer, verbose bool) int {
 
 	// Auth.
 	fmt.Fprintf(out, "Auth:    %s\n", authLine(lc.adminAddr, routerState == portOurs))
+	if line := authUnavailableFallbackLine(lc.adminAddr, routerState == portOurs); line != "" {
+		fmt.Fprintf(out, "Fallback: %s\n", line)
+	}
 
 	// Logs (verbose only).
 	if verbose {
@@ -889,6 +892,40 @@ func authLine(adminAddr string, routerUp bool) string {
 	default:
 		return "not signed in (run 'baseten auth login')"
 	}
+}
+
+// authUnavailableFallbackLine surfaces otherwise successful requests that
+// bypassed Baseten because the router had no usable credential. Older routers
+// omit this additive status object, so an empty or unavailable value renders
+// no extra line.
+func authUnavailableFallbackLine(adminAddr string, routerUp bool) string {
+	if !routerUp {
+		return ""
+	}
+	var payload struct {
+		AuthUnavailableFallback struct {
+			Count      uint64 `json:"count"`
+			LastAt     string `json:"last_at"`
+			LastClient string `json:"last_client"`
+			LastRoute  string `json:"last_route"`
+		} `json:"auth_unavailable_fallback"`
+	}
+	if err := getJSON(adminAddr, "/v1/admin/status", &payload); err != nil || payload.AuthUnavailableFallback.Count == 0 {
+		return ""
+	}
+	fallback := payload.AuthUnavailableFallback
+	detail := ""
+	if fallback.LastClient != "" && fallback.LastRoute != "" {
+		detail = fmt.Sprintf("; last %s -> %s", fallback.LastClient, fallback.LastRoute)
+	}
+	if fallback.LastAt != "" {
+		detail += " at " + fallback.LastAt
+	}
+	return fmt.Sprintf(
+		"%d request(s) used native fallback because Baseten auth was unavailable since router start%s",
+		fallback.Count,
+		detail,
+	)
 }
 
 func getJSON(addr, path string, v any) error {

--- a/gateway/cmd/baseten-switch/lifecycle_test.go
+++ b/gateway/cmd/baseten-switch/lifecycle_test.go
@@ -180,7 +180,7 @@ func fakeAdmin(t *testing.T) *httptest.Server {
 		fmt.Fprint(w, `{"ok":true,"uptime_seconds":42,"version":"dev"}`)
 	})
 	mux.HandleFunc("/v1/admin/status", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `{"clients":[
+		fmt.Fprint(w, `{"auth_unavailable_fallback":{"count":2,"last_at":"2026-08-15T12:00:00Z","last_client":"claude-code","last_route":"anthropic"},"clients":[
 			{"name":"claude-code","enabled":true,"bind_addr":"127.0.0.1:18081","effective_route":"baseten","protocol_shape":"anthropic"},
 			{"name":"codex","enabled":true,"bind_addr":"127.0.0.1:18081","effective_route":"openai","protocol_shape":"openai"},
 			{"name":"parked","enabled":false,"bind_addr":"127.0.0.1:18082","effective_route":"baseten","protocol_shape":"openai"}
@@ -245,7 +245,9 @@ func TestPrintStatusExitCodes(t *testing.T) {
 			0,
 			[]string{"Router:  up", "claude-code", "switch ON", "codex", "switch OFF",
 				"Door:    up", "not tripped", "3 fallback rules",
-				"Auth:    user@example.com OAuth"},
+				"Auth:    user@example.com OAuth",
+				"Fallback: 2 request(s) used native fallback because Baseten auth was unavailable",
+				"last claude-code -> anthropic"},
 		},
 		{
 			"router down",
@@ -321,6 +323,24 @@ func TestAuthLineCredentialLabels(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAuthUnavailableFallbackLine(t *testing.T) {
+	t.Run("older router omits line", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, `{"clients":[]}`)
+		}))
+		defer srv.Close()
+		if got := authUnavailableFallbackLine(hostPort(t, srv.URL), true); got != "" {
+			t.Fatalf("line = %q, want empty", got)
+		}
+	})
+
+	t.Run("router down omits line", func(t *testing.T) {
+		if got := authUnavailableFallbackLine("127.0.0.1:1", false); got != "" {
+			t.Fatalf("line = %q, want empty", got)
+		}
+	})
 }
 
 // TestPrintStatusVerbose pins the --verbose output: every fact dropped

--- a/gateway/cmd/gateway/admin.go
+++ b/gateway/cmd/gateway/admin.go
@@ -553,6 +553,7 @@ func (g *Gateway) adminStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	signedIn, authType, fallbackInUse := g.authState()
 	ah := g.authHealth()
+	authUnavailableFallback := g.authUnavailableFallbackStatus()
 	writeJSON(w, 200, map[string]any{
 		"router_pid":          os.Getpid(),
 		"router_boot_id":      state.bootID,
@@ -588,8 +589,24 @@ func (g *Gateway) adminStatus(w http.ResponseWriter, r *http.Request) {
 			"fallback_enabled":      runtimeCfg.APIKeyFallback,
 			"fallback_in_use":       fallbackInUse,
 		},
-		"clients": clients,
+		"auth_unavailable_fallback": authUnavailableFallback,
+		"clients":                   clients,
 	})
+}
+
+func (g *Gateway) authUnavailableFallbackStatus() map[string]any {
+	g.authUnavailableFallbackMu.RLock()
+	count := g.authUnavailableFallbackCount
+	lastAt := g.authUnavailableFallbackAt
+	lastClient := g.authUnavailableFallbackClient
+	lastRoute := g.authUnavailableFallbackRoute
+	g.authUnavailableFallbackMu.RUnlock()
+	return map[string]any{
+		"count":       count,
+		"last_at":     rfc3339OrEmpty(lastAt),
+		"last_client": lastClient,
+		"last_route":  lastRoute,
+	}
 }
 
 // modelCatalogHealthJSON reports the active normalized catalog for each

--- a/gateway/cmd/gateway/auth_admin_reload_test.go
+++ b/gateway/cmd/gateway/auth_admin_reload_test.go
@@ -422,3 +422,112 @@ func TestAdminAuthReloadClearsTransientHealthAcrossLogoutAndLogin(t *testing.T) 
 		t.Fatalf("replacement login retained transient health: %+v", health)
 	}
 }
+
+func TestAdminAuthReloadPreservesHealthyCredentialOnStoreFailure(t *testing.T) {
+	tests := []struct {
+		name       string
+		mutate     func(*testing.T, string)
+		wantReason string
+	}{
+		{
+			name: "malformed",
+			mutate: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.WriteFile(path, []byte("{"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantReason: "credential store malformed",
+		},
+		{
+			name: "unreadable",
+			mutate: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Mkdir(path, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantReason: "credential store unreadable",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := testConfig(t, "http://baseten.invalid", "http://anthropic.invalid")
+			cfg.OAuthProfile = "p"
+			cfg.APIKeyFallback = false
+			cfg.BasetenKey = ""
+			g := newAuthReloadTestGateway(t, cfg)
+			writeOAuthProfileWithAccessToken(t, "http://baseten.invalid", "synthetic-access", "synthetic-refresh")
+			if recorder := authReloadRequest(t, g, http.MethodPost, nil); recorder.Code != http.StatusOK {
+				t.Fatalf("initial reload status = %d", recorder.Code)
+			}
+
+			g.authMu.Lock()
+			previousClient := g.oauthClient
+			previousStoreFP := g.authStoreFP
+			previousCredFP := g.authCredFP
+			previousGen := g.authGen
+			g.authMu.Unlock()
+			if previousClient == nil {
+				t.Fatal("initial reload did not publish OAuth client")
+			}
+
+			path := os.Getenv("BASETEN_SWITCH_AUTH_FILE")
+			tc.mutate(t, path)
+
+			stderrReader, stderrWriter, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			oldStderr := os.Stderr
+			os.Stderr = stderrWriter
+			defer func() {
+				os.Stderr = oldStderr
+				_ = stderrWriter.Close()
+				_ = stderrReader.Close()
+			}()
+
+			recorder := authReloadRequest(t, g, http.MethodPost, nil)
+			os.Stderr = oldStderr
+			if err := stderrWriter.Close(); err != nil {
+				t.Fatal(err)
+			}
+			stderr, err := io.ReadAll(stderrReader)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(stderr), tc.wantReason) ||
+				!strings.Contains(string(stderr), "preserving current auth") {
+				t.Fatalf("stderr = %q, want classified preservation log", stderr)
+			}
+
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("failed-store reload status = %d, want 200; body = %s", recorder.Code, recorder.Body.String())
+			}
+			response := decodeAuthAdminResponse(t, recorder)
+			if response["signed_in"] != true || response["auth_type"] != "oauth" || response["health"] != "ok" {
+				t.Fatalf("failed-store reload response = %+v", response)
+			}
+
+			g.authMu.Lock()
+			defer g.authMu.Unlock()
+			if g.oauthClient != previousClient ||
+				g.authStoreFP != previousStoreFP ||
+				g.authCredFP != previousCredFP ||
+				g.authGen != previousGen {
+				t.Fatalf(
+					"auth snapshot changed on store failure: client_same=%t store_fp_same=%t cred_fp_same=%t gen=%d want=%d",
+					g.oauthClient == previousClient,
+					g.authStoreFP == previousStoreFP,
+					g.authCredFP == previousCredFP,
+					g.authGen,
+					previousGen,
+				)
+			}
+		})
+	}
+}

--- a/gateway/cmd/gateway/gateway.go
+++ b/gateway/cmd/gateway/gateway.go
@@ -692,9 +692,6 @@ func newGatewayWithSnapshot(
 	if snapshot != nil {
 		g.activateConfigSnapshot(snapshot.file, snapshot.raw)
 	}
-	if err := auth.CheckStore(); err != nil {
-		fmt.Fprintf(os.Stderr, "[gateway] auth: credential store load failed at boot: %v\n", err)
-	}
 	g.refreshAuth()
 	return g, nil
 }
@@ -834,20 +831,34 @@ func (g *Gateway) refreshAuth() {
 func (g *Gateway) refreshAuthLocked() {
 	cfg := g.runtimeConfig()
 	g.authMu.Lock()
-	// Each build is a new lineage: outcomes from clients built before
-	// this swap are stale and noteAuthRefresh drops them by generation.
-	g.authGen++
-	gen := g.authGen
+	previousGen := g.authGen
+	gen := previousGen + 1
 	g.authMu.Unlock()
 
 	notify := func(fp string, err error) { g.noteAuthRefresh(gen, fp, err) }
-	client, tick, credFP, err := auth.HTTPClientWithNotify(context.Background(), cfg.OAuthProfile, cfg.OAuthHost, notify)
+	client, tick, credFP, err := auth.HTTPClientWithNotifyDetailed(context.Background(), cfg.OAuthProfile, cfg.OAuthHost, notify)
+	storeFailure := ""
+	switch {
+	case errors.Is(err, auth.ErrStoreUnreadable):
+		storeFailure = "unreadable"
+	case errors.Is(err, auth.ErrStoreMalformed):
+		storeFailure = "malformed"
+	}
+	if storeFailure != "" {
+		fmt.Fprintf(os.Stderr, "[gateway] auth: credential store %s; preserving current auth: %v\n", storeFailure, err)
+		return
+	}
 
 	g.authMu.Lock()
 	defer g.authMu.Unlock()
-	if gen != g.authGen {
+	if previousGen != g.authGen {
 		return
 	}
+	// Publishing a successfully resolved credential starts a new lineage.
+	// Outcomes from clients built before this swap are stale and
+	// noteAuthRefresh drops them by generation. A classified store failure
+	// returns above without invalidating the client that remains in use.
+	g.authGen = gen
 	previousStoreFP := g.authStoreFP
 	g.cliProfileAPIKey = ""
 	g.authStoreFP = ""
@@ -2185,20 +2196,11 @@ func (g *Gateway) noteAuthUnavailableFallback(
 	g.authUnavailableFallbackMu.Lock()
 	now := time.Now().UTC()
 	g.authUnavailableFallbackCount++
-	count := g.authUnavailableFallbackCount
 	g.authUnavailableFallbackAt = now
 	g.authUnavailableFallbackClient = cl.cfg.Name
 	g.authUnavailableFallbackRoute = at.route
 	g.authUnavailableFallbackMu.Unlock()
 	w.Header().Set(authUnavailableFallbackHeader, fallbackTriggerAuthUnavailable)
-	fmt.Fprintf(
-		os.Stderr,
-		"[gateway] fallback client=%s route=baseten trigger=%s -> serving %s count=%d\n",
-		cl.cfg.Name,
-		fallbackTriggerAuthUnavailable,
-		at.route,
-		count,
-	)
 }
 
 // errNeedsLogin marks an attempt whose route has no usable credentials

--- a/gateway/cmd/gateway/gateway.go
+++ b/gateway/cmd/gateway/gateway.go
@@ -577,6 +577,15 @@ type Gateway struct {
 	fallbackMu    sync.Mutex
 	fallbackUntil map[string]time.Time
 
+	// authUnavailableFallbackCount and its last-occurrence fields make the
+	// otherwise successful auth_unavailable fallback visible in admin status.
+	// The count is process-local, so it naturally represents this gateway boot.
+	authUnavailableFallbackCount  uint64
+	authUnavailableFallbackMu     sync.RWMutex
+	authUnavailableFallbackAt     time.Time
+	authUnavailableFallbackClient string
+	authUnavailableFallbackRoute  string
+
 	// Active routing snapshot. Admin status reads this exact accepted
 	// configuration instead of independently parsing gateway.yaml.
 	stateMu          sync.RWMutex
@@ -682,6 +691,9 @@ func newGatewayWithSnapshot(
 	g.mu.Unlock()
 	if snapshot != nil {
 		g.activateConfigSnapshot(snapshot.file, snapshot.raw)
+	}
+	if err := auth.CheckStore(); err != nil {
+		fmt.Fprintf(os.Stderr, "[gateway] auth: credential store load failed at boot: %v\n", err)
 	}
 	g.refreshAuth()
 	return g, nil
@@ -2120,6 +2132,39 @@ func (g *Gateway) tripFallback(name string) {
 	g.fallbackUntil[name] = time.Now().Add(fallbackCooldown)
 }
 
+const authUnavailableFallbackHeader = "X-Baseten-Switch-Fallback"
+
+// noteAuthUnavailableFallback marks a response served by a configured native
+// fallback because the Baseten primary had no usable credential. This remains
+// an allowed fallback, but callers and local operators can now distinguish it
+// from a response served by the configured primary.
+func (g *Gateway) noteAuthUnavailableFallback(
+	w http.ResponseWriter,
+	cl *clientListener,
+	at upstreamAttempt,
+) {
+	if at.fallbackTrigger != fallbackTriggerAuthUnavailable {
+		return
+	}
+	g.authUnavailableFallbackMu.Lock()
+	now := time.Now().UTC()
+	g.authUnavailableFallbackCount++
+	count := g.authUnavailableFallbackCount
+	g.authUnavailableFallbackAt = now
+	g.authUnavailableFallbackClient = cl.cfg.Name
+	g.authUnavailableFallbackRoute = at.route
+	g.authUnavailableFallbackMu.Unlock()
+	w.Header().Set(authUnavailableFallbackHeader, fallbackTriggerAuthUnavailable)
+	fmt.Fprintf(
+		os.Stderr,
+		"[gateway] fallback client=%s route=baseten trigger=%s -> serving %s count=%d\n",
+		cl.cfg.Name,
+		fallbackTriggerAuthUnavailable,
+		at.route,
+		count,
+	)
+}
+
 // errNeedsLogin marks an attempt whose route has no usable credentials
 // (baseten without a CLI login or API-key fallback).
 var errNeedsLogin = errors.New("baseten route needs login")
@@ -3240,6 +3285,8 @@ attemptLoop:
 		break
 	}
 	res := at.res
+	resp.Header.Del(authUnavailableFallbackHeader)
+	g.noteAuthUnavailableFallback(w, cl, at)
 	defer resp.Body.Close()
 
 	if at.translate {

--- a/gateway/cmd/gateway/preflight.go
+++ b/gateway/cmd/gateway/preflight.go
@@ -79,11 +79,11 @@ func basetenRoutedClients(resolved []resolvedClientConfig) []string {
 }
 
 // hasBasetenCredential reports whether any Baseten credential is
-// available: a non-empty API key, an OAuth credential loadable from the
-// baseten CLI store, or an api_key-type CLI profile whose key is
-// readable.
-func hasBasetenCredential(profile, apiKey string) bool {
-	if apiKey != "" {
+// available: an enabled, non-empty environment fallback key; an OAuth
+// credential loadable from the baseten CLI store; or an api_key-type CLI
+// profile whose key is readable.
+func hasBasetenCredential(profile, apiKey string, apiKeyFallback bool) bool {
+	if apiKeyFallback && apiKey != "" {
 		return true
 	}
 	tok, _, err := auth.Load(profile)
@@ -99,20 +99,25 @@ func hasBasetenCredential(profile, apiKey string) bool {
 
 // warnMissingBasetenCreds prints a prominent banner naming the affected
 // clients and the fix. Warn-only.
-func warnMissingBasetenCreds(names []string, out io.Writer) {
+func warnMissingBasetenCreds(names []string, apiKeyIgnored bool, out io.Writer) {
 	if len(names) == 0 {
 		return
 	}
 	rule := "[gateway] =============================================================="
 	fmt.Fprintln(out, rule)
-	fmt.Fprintln(out, "[gateway] WARNING: no Baseten credential found (no OAuth login and no")
-	fmt.Fprintln(out, "[gateway] API key). These clients route to baseten and their requests")
-	fmt.Fprintln(out, "[gateway] will fail until a credential is configured:")
+	fmt.Fprintln(out, "[gateway] WARNING: no Baseten credential found that the router can use.")
+	fmt.Fprintln(out, "[gateway] These clients")
+	fmt.Fprintln(out, "[gateway] cannot use Baseten until a credential is configured;")
+	fmt.Fprintln(out, "[gateway] a configured native fallback may serve their requests instead:")
 	for _, n := range names {
 		fmt.Fprintf(out, "[gateway]   - %s\n", n)
 	}
-	fmt.Fprintln(out, "[gateway] Fix: run 'baseten auth login', or set BASETEN_API_KEY in")
-	fmt.Fprintf(out, "[gateway] %s (or via global.auth.baseten in gateway.yaml).\n", config.EnvFilePath())
+	if apiKeyIgnored {
+		fmt.Fprintln(out, "[gateway] BASETEN_API_KEY is set but ignored because")
+		fmt.Fprintln(out, "[gateway] BASETEN_SWITCH_API_KEY_FALLBACK is not enabled.")
+	}
+	fmt.Fprintln(out, "[gateway] Fix: run 'baseten auth login', or set BASETEN_API_KEY and")
+	fmt.Fprintf(out, "[gateway] BASETEN_SWITCH_API_KEY_FALLBACK=1 in %s.\n", config.EnvFilePath())
 	fmt.Fprintln(out, rule)
 }
 
@@ -127,8 +132,8 @@ func runPreflight(cfg *Config, resolved []resolvedClientConfig, out io.Writer) {
 	if len(names) == 0 {
 		return
 	}
-	if hasBasetenCredential(cfg.OAuthProfile, cfg.BasetenKey) {
+	if hasBasetenCredential(cfg.OAuthProfile, cfg.BasetenKey, cfg.APIKeyFallback) {
 		return
 	}
-	warnMissingBasetenCreds(names, out)
+	warnMissingBasetenCreds(names, cfg.BasetenKey != "" && !cfg.APIKeyFallback, out)
 }

--- a/gateway/cmd/gateway/preflight_test.go
+++ b/gateway/cmd/gateway/preflight_test.go
@@ -132,11 +132,13 @@ func TestRunPreflightBanner(t *testing.T) {
 	apiKeyAuthJSON := `{"version":1,"current":"svc","profiles":{"svc":{"remote_url":"https://api.baseten.co","auth_type":"api_key","api_key":"sk-1"}}}`
 
 	cases := []struct {
-		name       string
-		resolved   []resolvedClientConfig
-		basetenKey string
-		authJSON   string // "" = empty store
-		wantBanner bool
+		name                 string
+		resolved             []resolvedClientConfig
+		basetenKey           string
+		apiKeyFallback       bool
+		authJSON             string // "" = empty store
+		wantBanner           bool
+		wantIgnoredKeyNotice bool
 	}{
 		{
 			name:       "baseten route without creds warns",
@@ -154,10 +156,18 @@ func TestRunPreflightBanner(t *testing.T) {
 			wantBanner: false,
 		},
 		{
-			name:       "api key suppresses banner",
-			resolved:   []resolvedClientConfig{{Name: "claude-code", Route: "baseten"}},
-			basetenKey: "sk-x",
-			wantBanner: false,
+			name:           "enabled api key fallback suppresses banner",
+			resolved:       []resolvedClientConfig{{Name: "claude-code", Route: "baseten"}},
+			basetenKey:     "sk-x",
+			apiKeyFallback: true,
+			wantBanner:     false,
+		},
+		{
+			name:                 "api key without fallback flag warns",
+			resolved:             []resolvedClientConfig{{Name: "claude-code", Route: "baseten"}},
+			basetenKey:           "sk-ignored",
+			wantBanner:           true,
+			wantIgnoredKeyNotice: true,
 		},
 		{
 			name:       "oauth credential suppresses banner",
@@ -183,17 +193,27 @@ func TestRunPreflightBanner(t *testing.T) {
 				t.Setenv("BASETEN_SWITCH_AUTH_FILE", path)
 			}
 			cfg := Config{
-				ConfigPath: filepath.Join(t.TempDir(), "no-such.yaml"),
-				BasetenKey: tc.basetenKey,
+				ConfigPath:     filepath.Join(t.TempDir(), "no-such.yaml"),
+				BasetenKey:     tc.basetenKey,
+				APIKeyFallback: tc.apiKeyFallback,
 			}
 			var buf bytes.Buffer
 			runPreflight(&cfg, tc.resolved, &buf)
 			out := buf.String()
-			gotBanner := strings.Contains(out, "WARNING: no Baseten credential")
+			gotBanner := strings.Contains(out, "WARNING: no Baseten credential found")
 			if gotBanner != tc.wantBanner {
 				t.Fatalf("banner = %t, want %t; output:\n%s", gotBanner, tc.wantBanner, out)
 			}
+			gotIgnoredKeyNotice := strings.Contains(out, "BASETEN_SWITCH_API_KEY_FALLBACK is not enabled")
+			if gotIgnoredKeyNotice != tc.wantIgnoredKeyNotice {
+				t.Fatalf("ignored-key notice = %t, want %t; output:\n%s", gotIgnoredKeyNotice, tc.wantIgnoredKeyNotice, out)
+			}
 			if tc.wantBanner {
+				if !strings.Contains(out, "cannot use Baseten") ||
+					!strings.Contains(out, "configured native fallback may serve") ||
+					strings.Contains(out, "requests will fail") {
+					t.Fatalf("banner does not describe the credential/fallback outcome accurately:\n%s", out)
+				}
 				if !strings.Contains(out, tc.resolved[0].Name) {
 					t.Fatalf("banner does not name client %q:\n%s", tc.resolved[0].Name, out)
 				}
@@ -228,7 +248,7 @@ clients:
 	if !strings.Contains(out, "${TEST_PF_MISSING_KEY}") {
 		t.Fatalf("expected placeholder warning, got:\n%s", out)
 	}
-	if strings.Contains(out, "WARNING: no Baseten credential") {
+	if strings.Contains(out, "WARNING: no Baseten credential found") {
 		t.Fatalf("passthrough-only client should not trigger the credential banner:\n%s", out)
 	}
 }

--- a/gateway/cmd/gateway/ttft_test.go
+++ b/gateway/cmd/gateway/ttft_test.go
@@ -16,7 +16,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -183,17 +182,6 @@ func TestAuthUnavailableBypassRecordsFallback(t *testing.T) {
 	defer adminL.Close()
 	stop := start(t, g)
 	defer stop()
-	stderrReader, stderrWriter, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	oldStderr := os.Stderr
-	os.Stderr = stderrWriter
-	defer func() {
-		os.Stderr = oldStderr
-		_ = stderrWriter.Close()
-		_ = stderrReader.Close()
-	}()
 
 	resp, body := ttftPost(
 		t,
@@ -228,6 +216,14 @@ func TestAuthUnavailableBypassRecordsFallback(t *testing.T) {
 			t.Fatalf("row %d fallback telemetry = provider %q, %+v; want anthropic auth-unavailable bypass",
 				i, row.EffectiveProvider, row.Fallback)
 		}
+		if primary := row.Primary; primary == nil ||
+			primary.Provider != "baseten" ||
+			primary.Model != "zai-org/GLM-5.2" ||
+			primary.Attempted ||
+			primary.Outcome != telemetry.PrimaryOutcomeAuthUnavailable ||
+			primary.Status != nil {
+			t.Errorf("row %d auth-unavailable primary = %+v, want unattempted baseten zai-org/GLM-5.2", i, primary)
+		}
 	}
 
 	statusResp, err := http.Get(adminURL(g, "/v1/admin/status"))
@@ -252,32 +248,6 @@ func TestAuthUnavailableBypassRecordsFallback(t *testing.T) {
 		t.Fatalf("auth_unavailable_fallback status = %+v", gotStatus)
 	}
 
-	os.Stderr = oldStderr
-	if err := stderrWriter.Close(); err != nil {
-		t.Fatal(err)
-	}
-	stderr, err := io.ReadAll(stderrReader)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, want := range []string{
-		"fallback client=claude-code",
-		"trigger=auth_unavailable",
-		"serving anthropic count=1",
-		"serving anthropic count=2",
-	} {
-		if !strings.Contains(string(stderr), want) {
-			t.Fatalf("stderr missing %q, got:\n%s", want, stderr)
-		}
-	}
-	if primary := row.Primary; primary == nil ||
-		primary.Provider != "baseten" ||
-		primary.Model != "zai-org/GLM-5.2" ||
-		primary.Attempted ||
-		primary.Outcome != telemetry.PrimaryOutcomeAuthUnavailable ||
-		primary.Status != nil {
-		t.Errorf("auth-unavailable primary = %+v, want unattempted baseten zai-org/GLM-5.2", primary)
-	}
 }
 
 // TestTTFTHeadersWithoutBodyFiresFallback: an SSE upstream that sends

--- a/gateway/cmd/gateway/ttft_test.go
+++ b/gateway/cmd/gateway/ttft_test.go
@@ -12,9 +12,11 @@ package gateway
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -141,8 +143,14 @@ func TestTTFTFiresFallbackBeforeFirstByteWithCooldown(t *testing.T) {
 }
 
 func TestAuthUnavailableBypassRecordsFallback(t *testing.T) {
+	var fallbackHits atomic.Int32
 	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		if fallbackHits.Add(1) == 2 {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":{"type":"authentication_error","message":"invalid native credential"}}`))
+			return
+		}
 		_, _ = w.Write([]byte(
 			`{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"FALLBACK"}],"model":"claude-opus-4-8","usage":{"input_tokens":2,"output_tokens":1}}`,
 		))
@@ -158,6 +166,17 @@ func TestAuthUnavailableBypassRecordsFallback(t *testing.T) {
 	defer adminL.Close()
 	stop := start(t, g)
 	defer stop()
+	stderrReader, stderrWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldStderr := os.Stderr
+	os.Stderr = stderrWriter
+	defer func() {
+		os.Stderr = oldStderr
+		_ = stderrWriter.Close()
+		_ = stderrReader.Close()
+	}()
 
 	resp, body := ttftPost(
 		t,
@@ -167,14 +186,72 @@ func TestAuthUnavailableBypassRecordsFallback(t *testing.T) {
 	if resp.StatusCode != http.StatusOK || !strings.Contains(body, "FALLBACK") {
 		t.Fatalf("status=%d body=%s, want fallback response", resp.StatusCode, body)
 	}
-	rows := waitForRows(t, cfg.TelemetryDir, 1, 2*time.Second)
-	row := rows[0]
-	if row.EffectiveProvider != "anthropic" ||
-		!row.Fallback.Attempted ||
-		row.Fallback.Count != 1 ||
-		valueOrZero(row.Fallback.Trigger) != fallbackTriggerAuthUnavailable {
-		t.Fatalf("fallback telemetry = provider %q, %+v; want anthropic auth-unavailable bypass",
-			row.EffectiveProvider, row.Fallback)
+	if got := resp.Header.Get(authUnavailableFallbackHeader); got != fallbackTriggerAuthUnavailable {
+		t.Fatalf("%s = %q, want %q", authUnavailableFallbackHeader, got, fallbackTriggerAuthUnavailable)
+	}
+
+	resp, _ = ttftPost(
+		t,
+		g,
+		`{"model":"claude-opus-4-8","stream":false,"messages":[{"role":"user","content":"ping again"}]}`,
+	)
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("second fallback status = %d, want 401", resp.StatusCode)
+	}
+	if got := resp.Header.Get(authUnavailableFallbackHeader); got != fallbackTriggerAuthUnavailable {
+		t.Fatalf("second %s = %q, want %q", authUnavailableFallbackHeader, got, fallbackTriggerAuthUnavailable)
+	}
+
+	rows := waitForRows(t, cfg.TelemetryDir, 2, 2*time.Second)
+	for i, row := range rows {
+		if row.EffectiveProvider != "anthropic" ||
+			!row.Fallback.Attempted ||
+			row.Fallback.Count != 1 ||
+			valueOrZero(row.Fallback.Trigger) != fallbackTriggerAuthUnavailable {
+			t.Fatalf("row %d fallback telemetry = provider %q, %+v; want anthropic auth-unavailable bypass",
+				i, row.EffectiveProvider, row.Fallback)
+		}
+	}
+
+	statusResp, err := http.Get(adminURL(g, "/v1/admin/status"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer statusResp.Body.Close()
+	var status struct {
+		AuthUnavailableFallback struct {
+			Count      uint64 `json:"count"`
+			LastAt     string `json:"last_at"`
+			LastClient string `json:"last_client"`
+			LastRoute  string `json:"last_route"`
+		} `json:"auth_unavailable_fallback"`
+	}
+	if err := json.NewDecoder(statusResp.Body).Decode(&status); err != nil {
+		t.Fatal(err)
+	}
+	gotStatus := status.AuthUnavailableFallback
+	if gotStatus.Count != 2 || gotStatus.LastAt == "" ||
+		gotStatus.LastClient != "claude-code" || gotStatus.LastRoute != "anthropic" {
+		t.Fatalf("auth_unavailable_fallback status = %+v", gotStatus)
+	}
+
+	os.Stderr = oldStderr
+	if err := stderrWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	stderr, err := io.ReadAll(stderrReader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"fallback client=claude-code",
+		"trigger=auth_unavailable",
+		"serving anthropic count=1",
+		"serving anthropic count=2",
+	} {
+		if !strings.Contains(string(stderr), want) {
+			t.Fatalf("stderr missing %q, got:\n%s", want, stderr)
+		}
 	}
 }
 

--- a/gateway/internal/auth/store.go
+++ b/gateway/internal/auth/store.go
@@ -22,12 +22,43 @@ var (
 	errNoLocator       = errors.New("baseten-switch: no save locator (cannot persist credential)")
 	errKeyringNotFound = errors.New("keyring: not found")
 
+	// LoadDetailed exposes filesystem and JSON failures that Load preserves as
+	// the historical signed-out result.
+	ErrStoreUnreadable = errors.New("baseten-switch: credential store unreadable")
+	ErrStoreMalformed  = errors.New("baseten-switch: credential store malformed")
+
 	// ErrAPIKeyProfile is the sentinel matched by errors.Is when the
 	// resolved profile authenticates with an API key rather than OAuth.
 	// The concrete error is *APIKeyProfileError, which carries the
 	// resolved profile name and (when readable) the key itself.
 	ErrAPIKeyProfile = errors.New("baseten-switch: profile uses api_key auth (not OAuth)")
 )
+
+// StoreLoadError describes a local store read or parse failure. It never
+// contains credential values.
+type StoreLoadError struct {
+	Reason error
+	Path   string
+	Err    error
+}
+
+func (e *StoreLoadError) Error() string {
+	switch e.Reason {
+	case ErrStoreUnreadable:
+		return fmt.Sprintf("baseten-switch: cannot read credential store %q: %v", e.Path, e.Err)
+	case ErrStoreMalformed:
+		return fmt.Sprintf("baseten-switch: cannot parse credential store %q: %v", e.Path, e.Err)
+	default:
+		return "baseten-switch: credential store load failed"
+	}
+}
+
+// Is lets callers classify the failure without parsing its text.
+func (e *StoreLoadError) Is(target error) bool { return target == e.Reason }
+
+// Unwrap retains the underlying filesystem, JSON, or keyring error when one
+// exists.
+func (e *StoreLoadError) Unwrap() error { return e.Err }
 
 // APIKeyProfileError reports that the resolved profile's auth_type is
 // "api_key". It is a distinct signed-in state, not "not signed in":
@@ -149,6 +180,38 @@ func storedCredentialToToken(s *storedOAuthCredential) *StoredToken {
 // auth_type is "api_key" it returns (nil, nil, *APIKeyProfileError) so
 // callers can distinguish "signed in with API key" from "not signed in".
 func Load(profile string) (*StoredToken, *SaveLocator, error) {
+	tok, loc, err := LoadDetailed(profile)
+	var storeErr *StoreLoadError
+	if errors.As(err, &storeErr) {
+		return nil, nil, nil
+	}
+	return tok, loc, err
+}
+
+// CheckStore validates only the auth.json file. It does not resolve a profile
+// or access the keyring, so startup diagnostics can retry a transient file
+// failure without performing credential resolution twice.
+func CheckStore() error {
+	path := ProfilePath()
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return &StoreLoadError{Reason: ErrStoreUnreadable, Path: path, Err: err}
+	}
+	var store credentialStoreFile
+	if err := json.Unmarshal(data, &store); err != nil {
+		return &StoreLoadError{Reason: ErrStoreMalformed, Path: path, Err: err}
+	}
+	return nil
+}
+
+// LoadDetailed resolves a credential using the same precedence and keyring
+// fallback as Load, but returns a typed *StoreLoadError when auth.json exists
+// but cannot be read or parsed. Missing stores and profiles remain ordinary
+// signed-out states. API-key profiles still return *APIKeyProfileError.
+func LoadDetailed(profile string) (*StoredToken, *SaveLocator, error) {
 	path := ProfilePath()
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -157,10 +220,72 @@ func Load(profile string) (*StoredToken, *SaveLocator, error) {
 		if tok, loc := loadKeyringCredential(profile); tok != nil {
 			return tok, loc, nil
 		}
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil, nil
+		}
+		return nil, nil, &StoreLoadError{
+			Reason: ErrStoreUnreadable,
+			Path:   path,
+			Err:    err,
+		}
+	}
+
+	var af credentialStoreFile
+	if err := json.Unmarshal(data, &af); err != nil {
+		return nil, nil, &StoreLoadError{
+			Reason: ErrStoreMalformed,
+			Path:   path,
+			Err:    err,
+		}
+	}
+	name := profile
+	if name == "" {
+		name = af.Current
+	}
+	if name == "" || af.Profiles == nil {
 		return nil, nil, nil
 	}
-	if tok, loc, err, ok := loadCredentialProfile(data, profile); ok {
-		return tok, loc, err
+	p, ok := af.Profiles[name]
+	if !ok {
+		return nil, nil, nil
+	}
+
+	// api_key-type profile: a distinct signed-in state, not an OAuth
+	// credential. Surface the key when it is readable (plaintext auth.json
+	// first, then the keyring entry).
+	if p.AuthType == "api_key" {
+		key := p.InsecureAPIKey
+		if key == "" {
+			if value, err := keyringGet(keyringService, name); err == nil {
+				key = extractAPIKey(value)
+			}
+		}
+		return nil, nil, &APIKeyProfileError{Profile: name, Key: key}
+	}
+
+	remote := strings.TrimRight(p.RemoteURL, "/")
+	// Keyring first.
+	if value, err := keyringGet(keyringService, name); err == nil {
+		var s storedOAuthCredential
+		if err := json.Unmarshal([]byte(value), &s); err == nil && s.AccessToken != "" {
+			tok := storedCredentialToToken(&s)
+			tok.RemoteURL = remote
+			return tok, &SaveLocator{
+				Service: keyringService,
+				Account: name,
+				Source:  "keyring",
+			}, nil
+		}
+	}
+	// Plaintext fallback in auth.json.
+	if p.InsecureOAuthCredential != nil && p.InsecureOAuthCredential.AccessToken != "" {
+		tok := storedCredentialToToken(p.InsecureOAuthCredential)
+		tok.RemoteURL = remote
+		return tok, &SaveLocator{
+			Service: keyringService,
+			Account: name,
+			Source:  "auth-file",
+		}, nil
 	}
 	return nil, nil, nil
 }
@@ -184,67 +309,6 @@ func loadKeyringCredential(profile string) (*StoredToken, *SaveLocator) {
 		Account: profile,
 		Source:  "keyring",
 	}
-}
-
-// loadCredentialProfile resolves a credential from the current auth.json
-// shape. The final bool reports whether the file resolved to a profile, with
-// either a token or a typed error.
-func loadCredentialProfile(data []byte, profile string) (*StoredToken, *SaveLocator, error, bool) {
-	var af credentialStoreFile
-	if err := json.Unmarshal(data, &af); err != nil {
-		return nil, nil, nil, false
-	}
-	if af.Profiles == nil {
-		return nil, nil, nil, false
-	}
-	name := profile
-	if name == "" {
-		name = af.Current
-	}
-	if name == "" {
-		return nil, nil, nil, false
-	}
-	p, ok := af.Profiles[name]
-	if !ok {
-		return nil, nil, nil, false
-	}
-	// api_key-type profile: a distinct signed-in state, not an OAuth
-	// credential. Surface the key when it is readable (plaintext
-	// auth.json first, then the keyring entry).
-	if p.AuthType == "api_key" {
-		key := p.InsecureAPIKey
-		if key == "" {
-			if v, err := keyringGet(keyringService, name); err == nil {
-				key = extractAPIKey(v)
-			}
-		}
-		return nil, nil, &APIKeyProfileError{Profile: name, Key: key}, true
-	}
-	remote := strings.TrimRight(p.RemoteURL, "/")
-	// Keyring first.
-	if v, err := keyringGet(keyringService, name); err == nil {
-		var s storedOAuthCredential
-		if json.Unmarshal([]byte(v), &s) == nil && s.AccessToken != "" {
-			tok := storedCredentialToToken(&s)
-			tok.RemoteURL = remote
-			return tok, &SaveLocator{
-				Service: keyringService,
-				Account: name,
-				Source:  "keyring",
-			}, nil, true
-		}
-	}
-	// Plaintext fallback in auth.json.
-	if p.InsecureOAuthCredential != nil && p.InsecureOAuthCredential.AccessToken != "" {
-		tok := storedCredentialToToken(p.InsecureOAuthCredential)
-		tok.RemoteURL = remote
-		return tok, &SaveLocator{
-			Service: keyringService,
-			Account: name,
-			Source:  "auth-file",
-		}, nil, true
-	}
-	return nil, nil, nil, false
 }
 
 // extractAPIKey interprets a keyring value stored for an api_key-type

--- a/gateway/internal/auth/store_test.go
+++ b/gateway/internal/auth/store_test.go
@@ -150,6 +150,77 @@ func TestLoadMissingReturnsNil(t *testing.T) {
 	}
 }
 
+func TestLoadDetailedDiagnostics(t *testing.T) {
+	tests := []struct {
+		name       string
+		prepare    func(t *testing.T, path string)
+		wantReason error
+	}{
+		{
+			name: "store unreadable",
+			prepare: func(t *testing.T, path string) {
+				if err := os.Mkdir(path, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantReason: ErrStoreUnreadable,
+		},
+		{
+			name: "store malformed",
+			prepare: func(t *testing.T, path string) {
+				if err := os.WriteFile(path, []byte(`{"version":`), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantReason: ErrStoreMalformed,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := setAuthFile(t, t.TempDir())
+			tc.prepare(t, path)
+			if err := CheckStore(); !errors.Is(err, tc.wantReason) {
+				t.Fatalf("CheckStore error = %v, want errors.Is(_, %v)", err, tc.wantReason)
+			}
+
+			tok, loc, err := LoadDetailed("svc")
+			if tok != nil || loc != nil {
+				t.Fatalf("LoadDetailed returned token=%v locator=%+v, want neither", tok != nil, loc)
+			}
+			if !errors.Is(err, tc.wantReason) {
+				t.Fatalf("LoadDetailed error = %v, want errors.Is(_, %v)", err, tc.wantReason)
+			}
+			var diagnostic *StoreLoadError
+			if !errors.As(err, &diagnostic) {
+				t.Fatalf("LoadDetailed error %v is not *StoreLoadError", err)
+			}
+			if diagnostic.Path != path {
+				t.Fatalf("diagnostic path = %q, want %q", diagnostic.Path, path)
+			}
+
+			legacyToken, legacyLocator, legacyErr := Load("svc")
+			if legacyToken != nil || legacyLocator != nil {
+				t.Fatalf("legacy Load returned token=%v locator=%+v, want neither", legacyToken != nil, legacyLocator)
+			}
+			if legacyErr != nil {
+				t.Fatalf("legacy Load error = %v, want nil", legacyErr)
+			}
+		})
+	}
+
+	t.Run("missing store remains signed out", func(t *testing.T) {
+		setAuthFile(t, t.TempDir())
+		if err := CheckStore(); err != nil {
+			t.Fatalf("CheckStore missing = %v, want nil", err)
+		}
+		tok, loc, err := LoadDetailed("svc")
+		if tok != nil || loc != nil || err != nil {
+			t.Fatalf("LoadDetailed missing = token:%v locator:%+v err:%v, want signed out", tok != nil, loc, err)
+		}
+	})
+}
+
 // TestLoadEmptyProfileResolvesCurrent verifies that Load("") falls back to the
 // auth.json `current` field when no profile name is supplied, mirroring how the
 // gateway now invokes Load when BASETEN_SWITCH_OAUTH_PROFILE is unset.

--- a/gateway/internal/auth/transport.go
+++ b/gateway/internal/auth/transport.go
@@ -141,6 +141,15 @@ func HTTPClientWithNotify(ctx context.Context, profile string, host string, noti
 	return httpClient(ctx, profile, host, false, notify)
 }
 
+// HTTPClientWithNotifyDetailed is the gateway reload variant of
+// HTTPClientWithNotify. It preserves StoreLoadError so the gateway can keep a
+// previously loaded credential through a transient auth.json read or parse
+// failure. The legacy client builders continue to preserve their historical
+// signed-out behavior for the same failures.
+func HTTPClientWithNotifyDetailed(ctx context.Context, profile string, host string, notify func(fp string, err error)) (client *http.Client, tick func() error, credFP string, err error) {
+	return httpClientWithLoader(ctx, profile, host, false, notify, LoadDetailed)
+}
+
 // RefreshErrorCode classifies a token-refresh error: it returns RFC 6749's
 // error code (e.g. "invalid_grant") when err came from the token endpoint
 // rejecting the grant, "http_<status>" for a token-endpoint response with
@@ -161,7 +170,18 @@ func RefreshErrorCode(err error) string {
 }
 
 func httpClient(ctx context.Context, profile string, host string, forceRefresh bool, notify func(fp string, err error)) (*http.Client, func() error, string, error) {
-	stored, loc, err := Load(profile)
+	return httpClientWithLoader(ctx, profile, host, forceRefresh, notify, Load)
+}
+
+func httpClientWithLoader(
+	ctx context.Context,
+	profile string,
+	host string,
+	forceRefresh bool,
+	notify func(fp string, err error),
+	load func(string) (*StoredToken, *SaveLocator, error),
+) (*http.Client, func() error, string, error) {
+	stored, loc, err := load(profile)
 	if err != nil {
 		return nil, nil, "", err
 	}

--- a/gateway/internal/auth/transport_test.go
+++ b/gateway/internal/auth/transport_test.go
@@ -3,9 +3,11 @@ package auth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -13,6 +15,33 @@ import (
 
 	"golang.org/x/oauth2"
 )
+
+func TestHTTPClientWithNotifyDetailedPreservesStoreErrors(t *testing.T) {
+	path := setAuthFile(t, t.TempDir())
+	if err := os.WriteFile(path, []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, _, err := HTTPClientWithNotifyDetailed(
+		context.Background(),
+		"p",
+		"https://api.baseten.co",
+		func(string, error) {},
+	)
+	if !errors.Is(err, ErrStoreMalformed) {
+		t.Fatalf("HTTPClientWithNotifyDetailed error = %v, want ErrStoreMalformed", err)
+	}
+
+	_, _, _, err = HTTPClientWithNotify(
+		context.Background(),
+		"p",
+		"https://api.baseten.co",
+		func(string, error) {},
+	)
+	if !errors.Is(err, ErrNotSignedIn) {
+		t.Fatalf("legacy HTTPClientWithNotify error = %v, want ErrNotSignedIn", err)
+	}
+}
 
 // refreshRecorder is an httptest server that counts POSTs to the token
 // endpoint and returns a fresh access token.

--- a/scripts/tests/test_api_key_profile_live.sh
+++ b/scripts/tests/test_api_key_profile_live.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Opt-in live contract for a Baseten CLI API-key profile.
 #
-# This script creates all credentials and runtime state under one temporary
-# directory. It never starts, stops, or reconfigures an installed Switch.
+# This script creates runtime state under one temporary directory. Its optional
+# macOS Keychain mode creates one uniquely named credential and removes it
+# before exit. It never starts, stops, or reconfigures an installed Switch.
 
 set -euo pipefail
 
@@ -13,6 +14,7 @@ if [[ "${1:-}" == "--dry-run" ]]; then
     printf '%s\n' \
         "api-key profile live contract: dry run" \
         "would create an isolated Baseten CLI profile and Switch runtime" \
+        "would use a uniquely named temporary Keychain entry when requested" \
         "would test /v1/models and one minimal inference through a scratch door" \
         "would scan scratch output for credential disclosure before cleanup"
     exit 0
@@ -32,10 +34,40 @@ for command_name in baseten curl go lsof; do
         || fail "required command is unavailable: $command_name"
 done
 
+use_keyring="${BASETEN_SWITCH_TEST_USE_KEYRING:-0}"
+read_key_stdin="${BASETEN_SWITCH_TEST_API_KEY_STDIN:-0}"
+unset BASETEN_SWITCH_TEST_USE_KEYRING BASETEN_SWITCH_TEST_API_KEY_STDIN
+case "$use_keyring" in
+    0|1) ;;
+    *) fail "BASETEN_SWITCH_TEST_USE_KEYRING must be 0 or 1" ;;
+esac
+case "$read_key_stdin" in
+    0|1) ;;
+    *) fail "BASETEN_SWITCH_TEST_API_KEY_STDIN must be 0 or 1" ;;
+esac
+if [[ "$use_keyring" == 1 ]]; then
+    [[ "$(uname -s)" == "Darwin" ]] \
+        || fail "the keyring live contract currently requires macOS"
+    command -v security >/dev/null 2>&1 \
+        || fail "required command is unavailable: security"
+    keychain_home="${HOME:-}"
+    [[ -n "$keychain_home" ]] \
+        || fail "HOME must be set for the keyring live contract"
+fi
+
 api_key="${BASETEN_SWITCH_TEST_API_KEY:-}"
 unset BASETEN_SWITCH_TEST_API_KEY
+if [[ "$read_key_stdin" == 1 ]]; then
+    [[ -z "$api_key" ]] \
+        || fail "choose stdin or BASETEN_SWITCH_TEST_API_KEY, not both"
+    IFS= read -r api_key \
+        || fail "could not read the test key from stdin"
+    if IFS= read -r extra_input && [[ -n "$extra_input" ]]; then
+        fail "stdin must contain exactly one API-key line"
+    fi
+fi
 [[ -n "$api_key" ]] \
-    || fail "BASETEN_SWITCH_TEST_API_KEY must contain an inference-capable test key"
+    || fail "an inference-capable test key is required"
 
 model="${BASETEN_SWITCH_TEST_MODEL:-zai-org/GLM-5.2}"
 if [[ "$model" != */* || ! "$model" =~ ^[A-Za-z0-9._/-]+$ ]]; then
@@ -50,6 +82,19 @@ scratch_dir="$(mktemp -d "$scratch_parent/baseten-switch-api-key-live.XXXXXX")"
 chmod 700 "$scratch_dir"
 
 profile="switch-api-key-test"
+auth_no_keyring="1"
+credential_home="$scratch_dir/home"
+if [[ "$use_keyring" == 1 ]]; then
+    profile="switch-api-key-test-keyring-$$"
+    auth_no_keyring=""
+    # macOS resolves the login Keychain from the real user home. Keep Baseten
+    # configuration isolated below while allowing native Keychain access.
+    credential_home="$keychain_home"
+fi
+login_args=(auth login --with-api-key --profile "$profile" --no-switch --output none)
+if [[ "$use_keyring" == 0 ]]; then
+    login_args+=(--insecure-storage)
+fi
 baseten_config_dir="$scratch_dir/baseten"
 auth_file="$baseten_config_dir/auth.json"
 switch_dir="$scratch_dir/switch"
@@ -70,14 +115,21 @@ chmod 700 "$baseten_config_dir" "$switch_dir" "$output_dir" "$telemetry_dir"
 chmod 600 "$env_file"
 
 pids=()
+keyring_profile_owned=0
 scan_for_key() {
     local found=""
     [[ -d "$scratch_dir" && -n "$api_key" ]] || return 0
     found="$({
-        find "$scratch_dir" -type f \
-            ! -path "$auth_file" \
-            ! -path "$binary" \
-            -exec grep -Fl -- "$api_key" {} + 2>/dev/null || true
+        if [[ "$use_keyring" == 1 ]]; then
+            find "$scratch_dir" -type f \
+                ! -path "$binary" \
+                -exec grep -Fl -- "$api_key" {} + 2>/dev/null || true
+        else
+            find "$scratch_dir" -type f \
+                ! -path "$auth_file" \
+                ! -path "$binary" \
+                -exec grep -Fl -- "$api_key" {} + 2>/dev/null || true
+        fi
     } | head -1)"
     [[ -z "$found" ]]
 }
@@ -93,6 +145,25 @@ cleanup() {
             wait "$pid" 2>/dev/null || true
         fi
     done
+    if [[ "$use_keyring" == 1 && "$keyring_profile_owned" == 1 ]]; then
+        if [[ -f "$auth_file" ]]; then
+            if ! env HOME="$credential_home" BASETEN_CONFIG_DIR="$baseten_config_dir" \
+                baseten auth logout --profile "$profile" --output none \
+                > "$output_dir/logout.out" 2>&1; then
+                printf '%s\n' \
+                    "api-key profile live contract: Baseten CLI could not remove the temporary keyring profile" >&2
+                status=1
+            fi
+        fi
+        if security find-generic-password -s baseten-profile -a "$profile" \
+            >/dev/null 2>&1; then
+            security delete-generic-password -s baseten-profile -a "$profile" \
+                >/dev/null 2>&1 || true
+            printf '%s\n' \
+                "api-key profile live contract: temporary keyring entry survived normal logout" >&2
+            status=1
+        fi
+    fi
     if ! scan_for_key; then
         printf '%s\n' \
             "api-key profile live contract: test key appeared outside the temporary credential file" >&2
@@ -161,21 +232,33 @@ if [[ -z "${BASETEN_SWITCH_TEST_BINARY:-}" ]]; then
 fi
 [[ -x "$binary" ]] || fail "test binary is not executable"
 
-# The API key travels over stdin. The CLI stores it only in the isolated,
-# insecure-storage auth.json that cleanup removes.
+if [[ "$use_keyring" == 1 ]] && security find-generic-password \
+    -s baseten-profile -a "$profile" >/dev/null 2>&1; then
+    fail "refusing to overwrite an existing keyring profile"
+fi
+
+# The API key travels over stdin. The default test mode stores it only in the
+# isolated auth.json. The keyring mode omits --insecure-storage and cleanup
+# removes the exact temporary profile from the macOS Keychain.
+if [[ "$use_keyring" == 1 ]]; then
+    keyring_profile_owned=1
+fi
 printf '%s\n' "$api_key" |
-    env HOME="$scratch_dir/home" \
+    env HOME="$credential_home" \
         BASETEN_CONFIG_DIR="$baseten_config_dir" \
         BASETEN_REMOTE_URL="https://app.baseten.co" \
-        baseten auth login \
-            --with-api-key \
-            --profile "$profile" \
-            --insecure-storage \
-            --output none \
+        baseten "${login_args[@]}" \
             > "$output_dir/login.out" 2>&1 \
     || fail "Baseten CLI API-key login failed"
 
 [[ -f "$auth_file" ]] || fail "Baseten CLI did not create the isolated credential file"
+if [[ "$use_keyring" == 1 ]] && grep -Fq -- "$api_key" "$auth_file"; then
+    fail "Baseten CLI wrote the API key to auth.json in keyring mode"
+fi
+if [[ "$use_keyring" == 1 ]] && ! security find-generic-password \
+    -s baseten-profile -a "$profile" >/dev/null 2>&1; then
+    fail "Baseten CLI did not create the expected keyring entry"
+fi
 
 cat > "$config_path" <<EOF
 global:
@@ -198,12 +281,12 @@ EOF
 chmod 600 "$config_path"
 
 switch_env=(
-    "HOME=$scratch_dir/home"
+    "HOME=$credential_home"
     "BASETEN_CONFIG_DIR=$baseten_config_dir"
     "BASETEN_REMOTE_URL=https://api.baseten.co"
     "BASETEN_BASE_URL=https://inference.baseten.co"
     "BASETEN_SWITCH_AUTH_FILE="
-    "BASETEN_SWITCH_AUTH_NO_KEYRING=1"
+    "BASETEN_SWITCH_AUTH_NO_KEYRING=$auth_no_keyring"
     "BASETEN_SWITCH_OAUTH_PROFILE=$profile"
     "BASETEN_SWITCH_CONFIG_PATH=$config_path"
     "BASETEN_SWITCH_ENV_FILE=$env_file"
@@ -264,7 +347,7 @@ grep -Eq '"signed_in"[[:space:]]*:[[:space:]]*true' \
 grep -Eq '"auth_type"[[:space:]]*:[[:space:]]*"api_key"' \
     "$output_dir/auth-status.json" \
     || fail "admin auth status did not report API-key authentication"
-grep -Eq '"profile"[[:space:]]*:[[:space:]]*"switch-api-key-test"' \
+grep -Eq '"profile"[[:space:]]*:[[:space:]]*"'"$profile"'"' \
     "$output_dir/auth-status.json" \
     || fail "admin auth status did not report the isolated profile"
 grep -Eq '"health"[[:space:]]*:[[:space:]]*"ok"' \


### PR DESCRIPTION
## Summary

- Preserve an active credential when reload encounters unreadable or malformed credential-store data.
- Add typed store diagnostics while retaining legacy `auth.Load` behavior for existing callers.
- Align preflight and doctor with explicit API-key fallback opt-in and the running router auth snapshot.
- Surface `auth_unavailable` fallback through trusted response metadata, local status, lifecycle output, and doctor attribution.
- Add regression coverage for reload preservation, fallback provenance, and diagnostic findings.

## Validation

- `./scripts/check.sh`
- Focused gateway and doctor regression tests with `-count=1`
- Manual Preview QA for routed family requests, explicit Baseten aliases, signed-out native fallback attribution, Requests UI rendering, and channel isolation

## Scope

This keeps the existing explicit environment API-key fallback opt-in. It does not add boot-time or Keychain retry behavior.