### PR TITLE
Route Claude Code Auto checks to Anthropic

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,16 @@ Request content leaves the machine only for the upstream chosen by the active
 routing policy. Baseten credentials go only to Baseten, and native credentials
 go only to their matching native provider.
 
+### Compatibility routing
+
+Switch may route narrowly identified compatibility requests to a harness's
+native provider even when ordinary requests are mapped to Baseten. For example,
+recognized Claude Code Auto permission checks are sent to Anthropic and labeled
+`Auto check` in the Requests view. These checks require credentials accepted
+by Anthropic, and a native failure is returned directly instead of being
+retried through Baseten. Other requests continue to follow the configured
+routing policy.
+
 Local telemetry contains request metadata, not prompts, responses,
 credentials, headers, or request bodies. Disable future records by setting
 `telemetry_enabled: false` in `gateway.yaml`, then reload the configuration.

--- a/gateway/cmd/gateway/admin_requests.go
+++ b/gateway/cmd/gateway/admin_requests.go
@@ -24,21 +24,22 @@ const (
 var adminRequestsNow = time.Now
 
 type adminRequestRow struct {
-	EventID              string                      `json:"event_id"`
-	CompletedAt          time.Time                   `json:"completed_at"`
-	Client               string                      `json:"client"`
-	ConfiguredRoute      string                      `json:"configured_route"`
-	EffectiveProvider    string                      `json:"effective_provider"`
-	RequestedModel       string                      `json:"requested_model"`
-	RequestedModelFamily string                      `json:"requested_model_family"`
-	ServedModel          string                      `json:"served_model"`
-	Status               *int                        `json:"status"`
-	TerminationReason    telemetry.TerminationReason `json:"termination_reason"`
-	DurationMS           int64                       `json:"duration_ms"`
-	TTFTMS               *int64                      `json:"ttft_ms"`
-	Subagent             bool                        `json:"subagent"`
-	Fallback             telemetry.FallbackV1        `json:"fallback"`
-	Primary              *telemetry.PrimaryV1        `json:"primary,omitempty"`
+	EventID               string                             `json:"event_id"`
+	CompletedAt           time.Time                          `json:"completed_at"`
+	Client                string                             `json:"client"`
+	ConfiguredRoute       string                             `json:"configured_route"`
+	EffectiveProvider     string                             `json:"effective_provider"`
+	RequestedModel        string                             `json:"requested_model"`
+	RequestedModelFamily  string                             `json:"requested_model_family"`
+	ServedModel           string                             `json:"served_model"`
+	Status                *int                               `json:"status"`
+	TerminationReason     telemetry.TerminationReason        `json:"termination_reason"`
+	DurationMS            int64                              `json:"duration_ms"`
+	TTFTMS                *int64                             `json:"ttft_ms"`
+	Subagent              bool                               `json:"subagent"`
+	Fallback              telemetry.FallbackV1               `json:"fallback"`
+	Primary               *telemetry.PrimaryV1               `json:"primary,omitempty"`
+	RequestClassification *telemetry.RequestClassificationV1 `json:"request_classification,omitempty"`
 }
 
 type adminRequestsCoverage struct {
@@ -184,6 +185,9 @@ func projectAdminRequest(event telemetry.EventV1) adminRequestRow {
 		Subagent:             event.Subagent,
 		Fallback:             event.Fallback,
 		Primary:              clonePrimaryV1(event.Primary),
+		RequestClassification: cloneRequestClassificationV1(
+			event.RequestClassification,
+		),
 	}
 }
 

--- a/gateway/cmd/gateway/admin_requests_test.go
+++ b/gateway/cmd/gateway/admin_requests_test.go
@@ -202,6 +202,67 @@ func TestAdminRequestsProjectsFallbackAndNullableFields(t *testing.T) {
 	}
 }
 
+func TestAdminRequestsProjectsAutoClassification(t *testing.T) {
+	now := time.Date(2026, time.August, 26, 12, 0, 0, 0, time.UTC)
+	setAdminRequestsNow(t, now)
+	gateway, dir := newAdminRequestsGateway(t, analytics.IndexOptions{})
+	event := adminRequestsEvent(1, now.Add(-time.Second))
+	event.EffectiveProvider = "anthropic"
+	event.ServedModel = "claude-sonnet-5"
+	event.RequestClassification = &telemetry.RequestClassificationV1{
+		Kind:          telemetry.RequestClassificationKindClaudeAutoPermissionCheck,
+		Detector:      telemetry.RequestClassificationDetectorClaudeAutoV1,
+		RoutingAction: telemetry.RequestClassificationRoutingActionNativeAnthropic,
+	}
+	writeAdminRequestEvents(t, dir, event)
+
+	recorder, response := requestAdminRequests(
+		t,
+		gateway,
+		"/v1/admin/requests",
+		http.MethodGet,
+	)
+	if recorder.Code != http.StatusOK || len(response.Items) != 1 {
+		t.Fatalf("response status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	classification := response.Items[0].RequestClassification
+	if classification == nil ||
+		classification.Kind != telemetry.RequestClassificationKindClaudeAutoPermissionCheck ||
+		classification.Detector != telemetry.RequestClassificationDetectorClaudeAutoV1 ||
+		classification.RoutingAction != telemetry.RequestClassificationRoutingActionNativeAnthropic {
+		t.Fatalf("row classification = %+v", classification)
+	}
+	if !strings.Contains(
+		recorder.Body.String(),
+		`"request_classification":{"kind":"claude_auto_permission_check","detector":"claude_auto_v1","routing_action":"native_anthropic"}`,
+	) {
+		t.Fatalf("classification missing from response: %s", recorder.Body.String())
+	}
+}
+
+func TestAdminRequestsOmitsClassificationForOrdinaryRows(t *testing.T) {
+	now := time.Date(2026, time.August, 26, 12, 0, 0, 0, time.UTC)
+	setAdminRequestsNow(t, now)
+	gateway, dir := newAdminRequestsGateway(t, analytics.IndexOptions{})
+	writeAdminRequestEvents(t, dir, adminRequestsEvent(1, now.Add(-time.Second)))
+
+	recorder, response := requestAdminRequests(
+		t,
+		gateway,
+		"/v1/admin/requests",
+		http.MethodGet,
+	)
+	if recorder.Code != http.StatusOK || len(response.Items) != 1 {
+		t.Fatalf("response status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if response.Items[0].RequestClassification != nil {
+		t.Fatalf("ordinary row classification = %+v", response.Items[0].RequestClassification)
+	}
+	if strings.Contains(recorder.Body.String(), `"request_classification"`) {
+		t.Fatalf("ordinary row emitted request classification: %s", recorder.Body.String())
+	}
+}
+
 func TestAdminRequestsFilters(t *testing.T) {
 	now := time.Date(2026, time.July, 26, 12, 0, 0, 0, time.UTC)
 	setAdminRequestsNow(t, now)

--- a/gateway/cmd/gateway/auto_mode_routing_test.go
+++ b/gateway/cmd/gateway/auto_mode_routing_test.go
@@ -1,0 +1,597 @@
+package gateway
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/basetenlabs/baseten-switch/gateway/internal/pricing"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/requestclassification"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/telemetry"
+)
+
+func TestAutoPermissionCheckRoutesOnceToAnthropicUnchanged(t *testing.T) {
+	var basetenHits atomic.Int32
+	baseten := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		basetenHits.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer baseten.Close()
+
+	gotBody := make(chan []byte, 1)
+	anthropic := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody <- body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_auto","type":"message","role":"assistant","content":[{"type":"text","text":"allow"}],"model":"claude-example-model","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer anthropic.Close()
+
+	cfg := testConfig(t, baseten.URL, anthropic.URL)
+	rc := resolvedAnthropicBaseten(t)
+	rc.SanitizeHistory = true
+	rc.FallbackRoute = "anthropic"
+	rc.ModelAliases = map[string]string{
+		"claude-baseten-example": "example/model",
+		"claude-baseten-worker":  "example/worker",
+	}
+	rc.ModelRoutes = map[string]string{"sonnet": "claude-baseten-example"}
+	rc.SubagentModel = "claude-baseten-worker"
+	g, adminL, _ := newGateway(t, cfg, rc)
+	defer adminL.Close()
+	stop := start(t, g)
+	defer stop()
+
+	original := syntheticAutoPermissionBody("claude-baseten-example")
+	req, err := http.NewRequest(
+		http.MethodPost,
+		clientURL(g, "claude-code", "/v1/messages?beta=true"),
+		bytes.NewReader(original),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(subagentAgentIDHeader, "synthetic-agent")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	responseBody, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, responseBody)
+	}
+	if got := basetenHits.Load(); got != 0 {
+		t.Fatalf("Baseten hits = %d, want 0", got)
+	}
+	select {
+	case got := <-gotBody:
+		if !bytes.Equal(got, original) {
+			t.Fatalf("native body changed\ngot:  %s\nwant: %s", got, original)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Anthropic did not receive the request")
+	}
+
+	rows := waitForRows(t, cfg.TelemetryDir, 1, 2*time.Second)
+	if rows[0].EffectiveProvider != "anthropic" {
+		t.Fatalf("effective_provider = %q, want anthropic", rows[0].EffectiveProvider)
+	}
+	if rows[0].RequestedModel != "claude-baseten-example" ||
+		rows[0].ServedModel != "claude-baseten-example" {
+		t.Fatalf(
+			"models = requested %q served %q, want preserved alias",
+			rows[0].RequestedModel,
+			rows[0].ServedModel,
+		)
+	}
+	if rows[0].Sanitized {
+		t.Fatal("sanitized = true, want false")
+	}
+	if rows[0].Fallback.Attempted || rows[0].Fallback.Count != 0 {
+		t.Fatalf("fallback = %+v, want no fallback", rows[0].Fallback)
+	}
+	classification := rows[0].RequestClassification
+	if classification == nil ||
+		classification.Kind != requestclassification.KindClaudeAutoPermissionCheck ||
+		classification.Detector != requestclassification.DetectorClaudeAutoV1 ||
+		classification.RoutingAction != requestclassification.RoutingActionNativeAnthropic {
+		t.Fatalf("request_classification = %+v", classification)
+	}
+}
+
+func TestAutoPermissionCheckFailureIsTerminalAndDoesNotTripCooldown(t *testing.T) {
+	var basetenHits atomic.Int32
+	baseten := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		basetenHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_normal","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"example/model","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer baseten.Close()
+
+	var anthropicHits atomic.Int32
+	anthropic := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		anthropicHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"overloaded_error","message":"retry later"}}`))
+	}))
+	defer anthropic.Close()
+
+	cfg := testConfig(t, baseten.URL, anthropic.URL)
+	rc := resolvedAnthropicBaseten(t)
+	rc.FallbackRoute = "anthropic"
+	g, adminL, _ := newGateway(t, cfg, rc)
+	defer adminL.Close()
+	stop := start(t, g)
+	defer stop()
+
+	resp, body := postMessagesBody(t, g, syntheticAutoPermissionBody("claude-example-model"))
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("Auto status = %d, body = %s", resp.StatusCode, body)
+	}
+	if got := anthropicHits.Load(); got != 1 {
+		t.Fatalf("Anthropic hits = %d, want 1", got)
+	}
+	if got := basetenHits.Load(); got != 0 {
+		t.Fatalf("Baseten hits after Auto failure = %d, want 0", got)
+	}
+	if _, active := g.fallbackDeadline("claude-code"); active {
+		t.Fatal("Auto failure activated fallback cooldown")
+	}
+
+	normal := []byte(`{"model":"claude-example-model","stream":false,"system":[{"type":"text","text":"You are a coding assistant."}],"messages":[{"role":"user","content":"hello"}]}`)
+	resp, body = postMessagesBody(t, g, normal)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("ordinary status = %d, body = %s", resp.StatusCode, body)
+	}
+	if got := basetenHits.Load(); got != 1 {
+		t.Fatalf("Baseten hits after ordinary request = %d, want 1", got)
+	}
+	if got := anthropicHits.Load(); got != 1 {
+		t.Fatalf("Anthropic hits after ordinary request = %d, want 1", got)
+	}
+}
+
+func TestAutoPermissionCheckHTTPFailuresNeverReachBaseten(t *testing.T) {
+	for _, status := range []int{
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+	} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			var basetenHits atomic.Int32
+			baseten := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				basetenHits.Add(1)
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer baseten.Close()
+
+			var anthropicHits atomic.Int32
+			anthropic := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				anthropicHits.Add(1)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(`{"type":"error","error":{"type":"synthetic_error","message":"request failed"}}`))
+			}))
+			defer anthropic.Close()
+
+			cfg := testConfig(t, baseten.URL, anthropic.URL)
+			rc := resolvedAnthropicBaseten(t)
+			rc.FallbackRoute = "anthropic"
+			g, adminL, _ := newGateway(t, cfg, rc)
+			defer adminL.Close()
+			stop := start(t, g)
+			defer stop()
+
+			resp, body := postMessagesBody(t, g, syntheticAutoPermissionBody("claude-example-model"))
+			if resp.StatusCode != status {
+				t.Fatalf("status = %d, want %d, body = %s", resp.StatusCode, status, body)
+			}
+			if got := anthropicHits.Load(); got != 1 {
+				t.Fatalf("Anthropic hits = %d, want 1", got)
+			}
+			if got := basetenHits.Load(); got != 0 {
+				t.Fatalf("Baseten hits = %d, want 0", got)
+			}
+			if _, active := g.fallbackDeadline("claude-code"); active {
+				t.Fatal("Auto HTTP failure activated fallback cooldown")
+			}
+			rows := waitForRows(t, cfg.TelemetryDir, 1, 2*time.Second)
+			row := rows[0]
+			if row.StatusCode() != status {
+				t.Fatalf("telemetry status = %d, want %d", row.StatusCode(), status)
+			}
+			if row.Fallback.Attempted || row.Fallback.Count != 0 || row.Fallback.Trigger != nil {
+				t.Fatalf("fallback = %+v, want empty", row.Fallback)
+			}
+			assertAutoClassification(t, row.RequestClassification)
+		})
+	}
+}
+
+func TestAutoPermissionCheckForwardsNativeAnthropicAuthentication(t *testing.T) {
+	tests := []struct {
+		name        string
+		header      string
+		value       string
+		otherHeader string
+	}{
+		{
+			name:        "OAuth-style bearer",
+			header:      "Authorization",
+			value:       "Bearer synthetic-claude-oauth-token",
+			otherHeader: "X-Api-Key",
+		},
+		{
+			name:        "native API key",
+			header:      "X-Api-Key",
+			value:       "synthetic-anthropic-api-key",
+			otherHeader: "Authorization",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var basetenHits atomic.Int32
+			baseten := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				basetenHits.Add(1)
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+			defer baseten.Close()
+
+			anthropic := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.Header.Get(tc.header); got != tc.value {
+					t.Errorf("%s = %q, want %q", tc.header, got, tc.value)
+				}
+				if got := r.Header.Get(tc.otherHeader); got != "" {
+					t.Errorf("unexpected %s = %q", tc.otherHeader, got)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"id":"msg_auto","type":"message","role":"assistant","content":[{"type":"text","text":"allow"}],"model":"claude-example-model","usage":{"input_tokens":1,"output_tokens":1}}`))
+			}))
+			defer anthropic.Close()
+
+			cfg := testConfig(t, baseten.URL, anthropic.URL)
+			rc := resolvedAnthropicBaseten(t)
+			g, adminL, _ := newGateway(t, cfg, rc)
+			defer adminL.Close()
+			stop := start(t, g)
+			defer stop()
+
+			req, err := http.NewRequest(
+				http.MethodPost,
+				clientURL(g, "claude-code", "/v1/messages"),
+				bytes.NewReader(syntheticAutoPermissionBody("claude-example-model")),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set(tc.header, tc.value)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+			}
+			if got := basetenHits.Load(); got != 0 {
+				t.Fatalf("Baseten hits = %d, want 0", got)
+			}
+		})
+	}
+}
+
+// A gateway-only bearer is wire-indistinguishable from a native bearer, so
+// Switch cannot identify it before Anthropic rejects it. The rejection must
+// remain a classified terminal response with no Baseten fallback.
+func TestAutoPermissionCheckGatewayOnlyBearerCannotBePreidentified(t *testing.T) {
+	const bearer = "Bearer synthetic-gateway-only-token"
+	var basetenHits atomic.Int32
+	baseten := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		basetenHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer baseten.Close()
+
+	var anthropicHits atomic.Int32
+	anthropic := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		anthropicHits.Add(1)
+		if got := r.Header.Get("Authorization"); got != bearer {
+			t.Errorf("Authorization = %q, want exact gateway-only bearer", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"authentication_error","message":"invalid credential"}}`))
+	}))
+	defer anthropic.Close()
+
+	cfg := testConfig(t, baseten.URL, anthropic.URL)
+	rc := resolvedAnthropicBaseten(t)
+	rc.FallbackRoute = "anthropic"
+	g, adminL, _ := newGateway(t, cfg, rc)
+	defer adminL.Close()
+	stop := start(t, g)
+	defer stop()
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		clientURL(g, "claude-code", "/v1/messages"),
+		bytes.NewReader(syntheticAutoPermissionBody("claude-example-model")),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", bearer)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	if got := anthropicHits.Load(); got != 1 {
+		t.Fatalf("Anthropic hits = %d, want 1", got)
+	}
+	if got := basetenHits.Load(); got != 0 {
+		t.Fatalf("Baseten hits = %d, want 0", got)
+	}
+	if _, active := g.fallbackDeadline("claude-code"); active {
+		t.Fatal("gateway-only bearer rejection activated fallback cooldown")
+	}
+	rows := waitForRows(t, cfg.TelemetryDir, 1, 2*time.Second)
+	row := rows[0]
+	if row.StatusCode() != http.StatusUnauthorized {
+		t.Fatalf("telemetry status = %d, want 401", row.StatusCode())
+	}
+	if row.Fallback.Attempted || row.Fallback.Count != 0 || row.Fallback.Trigger != nil {
+		t.Fatalf("fallback = %+v, want empty", row.Fallback)
+	}
+	assertAutoClassification(t, row.RequestClassification)
+}
+
+func TestAutoPermissionCheckMonitorStaysLocal(t *testing.T) {
+	var upstreamHits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer upstream.Close()
+
+	cfg := testConfig(t, upstream.URL, upstream.URL)
+	rc := resolvedAnthropicBaseten(t)
+	rc.Route = "monitor"
+	g, adminL, _ := newGateway(t, cfg, rc)
+	defer adminL.Close()
+	stop := start(t, g)
+	defer stop()
+
+	resp, body := postMessagesBody(t, g, syntheticAutoPermissionBody("claude-example-model"))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("monitor status = %d, body = %s", resp.StatusCode, body)
+	}
+	if got := upstreamHits.Load(); got != 0 {
+		t.Fatalf("upstream hits = %d, want 0", got)
+	}
+}
+
+func TestAutoPermissionCheckTTFTIsTerminalWithoutFallbackMetadata(t *testing.T) {
+	var anthropicHits atomic.Int32
+	anthropic := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		anthropicHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-r.Context().Done()
+	}))
+	defer anthropic.Close()
+
+	cfg := testConfig(t, anthropic.URL, anthropic.URL)
+	rc := resolvedAnthropicBaseten(t)
+	rc.FallbackRoute = "anthropic"
+	rc.TTFTTimeout = 40 * time.Millisecond
+	g, adminL, _ := newGateway(t, cfg, rc)
+	defer adminL.Close()
+	stop := start(t, g)
+	defer stop()
+
+	resp, body := postMessagesBody(t, g, syntheticAutoPermissionBody("claude-example-model"))
+	if resp.StatusCode != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	if got := anthropicHits.Load(); got != 1 {
+		t.Fatalf("Anthropic hits = %d, want 1", got)
+	}
+	if _, active := g.fallbackDeadline("claude-code"); active {
+		t.Fatal("Auto TTFT activated fallback cooldown")
+	}
+	rows := waitForRows(t, cfg.TelemetryDir, 1, 2*time.Second)
+	row := rows[0]
+	if row.StatusCode() != http.StatusGatewayTimeout || !row.IsHTTPError() {
+		t.Fatalf("telemetry status/error = %d/%v", row.StatusCode(), row.IsHTTPError())
+	}
+	if row.Fallback.Attempted || row.Fallback.Count != 0 || row.Fallback.Trigger != nil {
+		t.Fatalf("fallback = %+v, want empty", row.Fallback)
+	}
+	assertAutoClassification(t, row.RequestClassification)
+}
+
+func TestAutoPermissionCheckTransportFailureRetainsClassification(t *testing.T) {
+	closed := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	closedURL := closed.URL
+	closed.Close()
+
+	baseten := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("classified request reached Baseten")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer baseten.Close()
+
+	cfg := testConfig(t, baseten.URL, closedURL)
+	rc := resolvedAnthropicBaseten(t)
+	rc.FallbackRoute = "baseten"
+	g, adminL, _ := newGateway(t, cfg, rc)
+	defer adminL.Close()
+	stop := start(t, g)
+	defer stop()
+
+	resp, body := postMessagesBody(t, g, syntheticAutoPermissionBody("claude-example-model"))
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	if _, active := g.fallbackDeadline("claude-code"); active {
+		t.Fatal("Auto transport failure activated fallback cooldown")
+	}
+	rows := waitForRows(t, cfg.TelemetryDir, 1, 2*time.Second)
+	row := rows[0]
+	if row.Fallback.Attempted || row.Fallback.Count != 0 || row.Fallback.Trigger != nil {
+		t.Fatalf("fallback = %+v, want empty", row.Fallback)
+	}
+	assertAutoClassification(t, row.RequestClassification)
+}
+
+func TestResolveAutoPermissionCheckBypassesRoutingLadder(t *testing.T) {
+	g := &Gateway{
+		cfg: Config{
+			AnthropicURL: "https://anthropic.example.invalid",
+			BasetenURL:   "https://baseten.example.invalid",
+		},
+		client:  http.DefaultClient,
+		pricing: pricing.New(),
+	}
+	rc := resolvedClientConfig{
+		Name:                 "claude-code",
+		ProtocolShape:        "anthropic",
+		Route:                "baseten",
+		HasGlobalRoutingGate: true,
+		GlobalRoutingEnabled: true,
+		DefaultModel:         "example/default",
+		ModelAliases:         map[string]string{"claude-baseten-example": "example/alias"},
+		ModelRoutes:          map[string]string{"sonnet": "claude-baseten-example"},
+		SubagentModel:        "example/worker",
+		FallbackRoute:        "openai",
+	}
+	cl := &clientListener{cfg: rc}
+	classification := &requestclassification.Classification{
+		Kind:          requestclassification.KindClaudeAutoPermissionCheck,
+		Detector:      requestclassification.DetectorClaudeAutoV1,
+		RoutingAction: requestclassification.RoutingActionNativeAnthropic,
+	}
+
+	for _, model := range []string{
+		"claude-sonnet-example",
+		"claude-baseten-example",
+		"example/raw-slug",
+	} {
+		t.Run(model, func(t *testing.T) {
+			body := syntheticAutoPermissionBody(model)
+			req := httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+			req.Header.Set(subagentAgentIDHeader, "synthetic-agent")
+			requested, observed := inspectRequestedReasoning("messages", body)
+			attempts, err := g.resolveAttemptsWithRequestedReasoning(
+				cl,
+				req,
+				body,
+				"messages",
+				requested,
+				observed,
+				classification,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(attempts) != 1 {
+				t.Fatalf("attempt count = %d, want 1", len(attempts))
+			}
+			at := attempts[0]
+			if at.route != "anthropic" || at.res.RequestedModel != model || at.res.UpstreamModel != model {
+				t.Fatalf("attempt route/models = %q/%q/%q", at.route, at.res.RequestedModel, at.res.UpstreamModel)
+			}
+			if !bytes.Equal(at.res.NewBody, body) {
+				t.Fatalf("attempt body changed\ngot:  %s\nwant: %s", at.res.NewBody, body)
+			}
+			if at.fallbackCount != 0 || at.fallbackTrigger != "" || at.primary != nil {
+				t.Fatalf("attempt has fallback state: %+v", at)
+			}
+			if at.requestClassification != classification {
+				t.Fatal("classification was not carried on the native attempt")
+			}
+		})
+	}
+
+	t.Run("global routing off", func(t *testing.T) {
+		cl.cfg.GlobalRoutingEnabled = false
+		body := syntheticAutoPermissionBody("claude-example-model")
+		req := httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+		requested, observed := inspectRequestedReasoning("messages", body)
+		attempts, err := g.resolveAttemptsWithRequestedReasoning(
+			cl,
+			req,
+			body,
+			"messages",
+			requested,
+			observed,
+			classification,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(attempts) != 1 || attempts[0].route != "anthropic" {
+			t.Fatalf("attempts = %+v, want one Anthropic attempt", attempts)
+		}
+	})
+}
+
+func syntheticAutoPermissionBody(model string) []byte {
+	return []byte(`{"model":"` + model + `", "system":[{"type":"text","text":"In Auto mode, classify whether a proposed tool call has permission to run safely."}], "messages":[{"role":"assistant","content":[{"type":"text","text":""},{"type":"tool_use","id":"tools.Example:0","name":"Example","input":{}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"tools.Example:0","content":"ok"}]}]}`)
+}
+
+func postMessagesBody(t *testing.T, g *Gateway, body []byte) (*http.Response, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(
+		http.MethodPost,
+		clientURL(g, "claude-code", "/v1/messages"),
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	responseBody, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp, responseBody
+}
+
+func assertAutoClassification(
+	t *testing.T,
+	classification *telemetry.RequestClassificationV1,
+) {
+	t.Helper()
+	if classification == nil ||
+		classification.Kind != requestclassification.KindClaudeAutoPermissionCheck ||
+		classification.Detector != requestclassification.DetectorClaudeAutoV1 ||
+		classification.RoutingAction != requestclassification.RoutingActionNativeAnthropic {
+		t.Fatalf("request_classification = %+v", classification)
+	}
+}

--- a/gateway/cmd/gateway/gateway.go
+++ b/gateway/cmd/gateway/gateway.go
@@ -32,6 +32,7 @@ import (
 	"github.com/basetenlabs/baseten-switch/gateway/internal/pricing"
 	"github.com/basetenlabs/baseten-switch/gateway/internal/proxy"
 	"github.com/basetenlabs/baseten-switch/gateway/internal/reasoning"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/requestclassification"
 	"github.com/basetenlabs/baseten-switch/gateway/internal/requestprofile"
 	"github.com/basetenlabs/baseten-switch/gateway/internal/responsescompat"
 	"github.com/basetenlabs/baseten-switch/gateway/internal/sanitize"
@@ -1913,6 +1914,14 @@ func (g *Gateway) forwardMessages(cl *clientListener, w http.ResponseWriter, r *
 		g.monitorStubAnthropic(cl, w, body, nil, start)
 		return
 	}
+	classification := requestclassification.ClassifyClaudeMessages(
+		requestclassification.RequestContext{
+			ClaudeListener: cl.cfg.Name == "claude-code",
+			Method:         r.Method,
+			Path:           r.URL.Path,
+		},
+		body,
+	)
 	trace := g.beginTraceCaptureAtGeneration(
 		cl,
 		r,
@@ -1928,9 +1937,10 @@ func (g *Gateway) forwardMessages(cl *clientListener, w http.ResponseWriter, r *
 	requestedReasoning := reasoning.InspectAnthropicMessages(body)
 	// History repair for anthropic-shape upstreams: harnesses replay
 	// prior turns containing empty text blocks and (after a route flip
-	// through an openai-shape provider) tool ids Anthropic rejects.
+	// through an openai-shape provider) tool ids Anthropic rejects. Auto
+	// permission checks must retain their original admitted body.
 	sanitized := false
-	if cl.cfg.SanitizeHistory {
+	if classification == nil && cl.cfg.SanitizeHistory {
 		body, sanitized = sanitize.AnthropicBody(body)
 	}
 	attempts, err := g.resolveAttemptsWithRequestedReasoning(
@@ -1940,6 +1950,7 @@ func (g *Gateway) forwardMessages(cl *clientListener, w http.ResponseWriter, r *
 		"messages",
 		requestedReasoning,
 		true,
+		classification,
 	)
 	if err != nil {
 		if errors.Is(err, errNeedsLogin) {
@@ -2142,6 +2153,9 @@ type upstreamAttempt struct {
 	// stream repair counts, and the telemetry summary. It is present only
 	// for Baseten /v1/responses attempts with configured compatibility work.
 	responsesCompatibility *responsesCompatibilityRequest
+	// requestClassification is set only when gateway-owned compatibility
+	// routing selected this attempt. It contains no request-derived content.
+	requestClassification *requestclassification.Classification
 }
 
 // telRequestedModel returns the model to record as requested_model in
@@ -2669,6 +2683,7 @@ func (g *Gateway) resolveAttempts(cl *clientListener, r *http.Request, body []by
 		kind,
 		requested,
 		observed,
+		nil,
 	)
 }
 
@@ -2679,9 +2694,31 @@ func (g *Gateway) resolveAttemptsWithRequestedReasoning(
 	kind string,
 	requested reasoning.RequestedReasoning,
 	requestedObserved bool,
+	classification *requestclassification.Classification,
 ) ([]upstreamAttempt, error) {
 	snapshot := g.pricing.Capture()
 	profile := requestprofile.Inspect(body)
+	if classification != nil {
+		at, err := g.buildAttemptWithSnapshot(
+			snapshot,
+			requested,
+			requestedObserved,
+			cl,
+			r,
+			body,
+			"anthropic",
+			kind,
+		)
+		if err != nil {
+			return nil, err
+		}
+		at.requestedReasoning = requested
+		at.requestedReasoningObserved = requestedObserved
+		at.requestProfile = profile
+		at.subagent = r.Header.Get(subagentAgentIDHeader) != ""
+		at.requestClassification = classification
+		return []upstreamAttempt{at}, nil
+	}
 	isSubagent := false
 	origRequested := ""
 	subagentModel := ""
@@ -3204,6 +3241,13 @@ func (g *Gateway) streamForward(
 		requestCapture.requestedReasoningObserved =
 			attempts[0].requestedReasoningObserved
 		requestCapture.primaryReasoning = attempts[0].telemetryAttempt.reasoning
+		if classification := attempts[0].requestClassification; classification != nil {
+			requestCapture.setRequestClassificationV1(
+				classification.Kind,
+				classification.Detector,
+				classification.RoutingAction,
+			)
+		}
 		for i := range attempts {
 			attempts[i].telemetryRequest = &requestCapture
 			attempts[i].traceCapture = trace
@@ -3496,15 +3540,21 @@ attemptLoop:
 				cl.cfg.Name, at.route, at.modelForCost, cl.cfg.TTFTTimeout, time.Since(start))
 			g.reject(w, 504, fmt.Sprintf("upstream timeout: model %s sent no first byte within ttft_timeout %s", at.modelForCost, cl.cfg.TTFTTimeout))
 			status := 504
-			trigger := fallbackTriggerTTFT
-			g.recordTelemetryV1(cl, at, telemetryCompletionV1{
-				completedAt:     time.Now(),
-				status:          &status,
-				isStream:        isStream,
-				gatewayFailure:  true,
-				fallbackTrigger: &trigger,
-				requestBytes:    len(res.NewBody),
-			})
+			completion := telemetryCompletionV1{
+				completedAt:    time.Now(),
+				status:         &status,
+				isStream:       isStream,
+				gatewayFailure: true,
+				requestBytes:   len(res.NewBody),
+			}
+			// A terminal timeout is only a fallback trigger for ordinary
+			// routes. A classified Auto request has one mandatory native
+			// attempt and never participates in fallback or cooldown state.
+			if at.requestClassification == nil {
+				trigger := fallbackTriggerTTFT
+				completion.fallbackTrigger = &trigger
+			}
+			g.recordTelemetryV1(cl, at, completion)
 			return
 		}
 		break

--- a/gateway/cmd/gateway/telemetry_v1_capture.go
+++ b/gateway/cmd/gateway/telemetry_v1_capture.go
@@ -42,6 +42,7 @@ type telemetryRequestCaptureV1 struct {
 	nativePricingUnsupported bool
 	nativeQuote              pricing.Quote
 	nativeQuoteCapturedAt    time.Time
+	requestClassification    *telemetry.RequestClassificationV1
 }
 
 // telemetryAttemptCaptureV1 is immutable attempt-start state. A fallback
@@ -101,6 +102,24 @@ func (request telemetryRequestCaptureV1) requestedReasoningEffort() *string {
 	}
 	effort := request.requestedReasoning.Effort
 	return &effort
+}
+
+// setRequestClassificationV1 binds the immutable, content-free result from
+// request admission to the logical request's telemetry row. Callers pass only
+// stable classifier metadata, never prompt-derived evidence.
+func (request *telemetryRequestCaptureV1) setRequestClassificationV1(
+	kind string,
+	detector string,
+	routingAction string,
+) {
+	if request == nil {
+		return
+	}
+	request.requestClassification = &telemetry.RequestClassificationV1{
+		Kind:          kind,
+		Detector:      detector,
+		RoutingAction: routingAction,
+	}
 }
 
 func captureTelemetryRequestV1(
@@ -357,6 +376,9 @@ func (request telemetryRequestCaptureV1) event(
 		ResponsesCompatibility: cloneResponsesCompatibilityV1(
 			completion.responsesCompatibility,
 		),
+		RequestClassification: cloneRequestClassificationV1(
+			request.requestClassification,
+		),
 		ToolCalls:    completion.toolCalls,
 		RequestBytes: completion.requestBytes,
 	}
@@ -367,6 +389,16 @@ func (request telemetryRequestCaptureV1) event(
 		return telemetry.EventV1{}, err
 	}
 	return event, nil
+}
+
+func cloneRequestClassificationV1(
+	in *telemetry.RequestClassificationV1,
+) *telemetry.RequestClassificationV1 {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
 }
 
 func clonePrimaryV1(in *telemetry.PrimaryV1) *telemetry.PrimaryV1 {

--- a/gateway/cmd/gateway/telemetry_v1_capture_test.go
+++ b/gateway/cmd/gateway/telemetry_v1_capture_test.go
@@ -249,6 +249,73 @@ func TestTelemetryV1CaptureRetainsRequestAndAttemptPrices(t *testing.T) {
 	}
 }
 
+func TestTelemetryV1CaptureCarriesAutoClassificationToNativeEvent(t *testing.T) {
+	startedAt := time.Date(2026, time.August, 26, 20, 0, 0, 0, time.UTC)
+	prices := telemetryVariantPricing(t, startedAt)
+	request, err := captureTelemetryRequestProfileV1(
+		prices.Capture(),
+		startedAt,
+		"claude-code",
+		pricing.ProviderBaseten,
+		pricing.ProviderAnthropic,
+		"claude-sonnet-5",
+		requestprofile.Profile{RawModel: "claude-sonnet-5"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.eventID = "00112233445566778899aabbccddeeff"
+	request.setRequestClassificationV1(
+		telemetry.RequestClassificationKindClaudeAutoPermissionCheck,
+		telemetry.RequestClassificationDetectorClaudeAutoV1,
+		telemetry.RequestClassificationRoutingActionNativeAnthropic,
+	)
+	attempt := captureTelemetryAttemptV1(
+		prices.Capture(),
+		startedAt,
+		pricing.ProviderAnthropic,
+		"claude-sonnet-5",
+	)
+	status := http.StatusOK
+	event, err := request.event(attempt, telemetryCompletionV1{
+		completedAt:      startedAt.Add(time.Second),
+		status:           &status,
+		responseComplete: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.ConfiguredRoute != pricing.ProviderBaseten ||
+		event.EffectiveProvider != pricing.ProviderAnthropic ||
+		event.Fallback.Attempted || event.Fallback.Count != 0 ||
+		event.Primary != nil || event.NativeCounterfactualCost != nil ||
+		event.RequestClassification == nil ||
+		event.RequestClassification.Kind != telemetry.RequestClassificationKindClaudeAutoPermissionCheck ||
+		event.RequestClassification.Detector != telemetry.RequestClassificationDetectorClaudeAutoV1 ||
+		event.RequestClassification.RoutingAction != telemetry.RequestClassificationRoutingActionNativeAnthropic {
+		t.Fatalf("classified native event = %+v", event)
+	}
+	failureStatus := http.StatusUnauthorized
+	failedEvent, err := request.event(attempt, telemetryCompletionV1{
+		completedAt:      startedAt.Add(2 * time.Second),
+		status:           &failureStatus,
+		responseComplete: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failedEvent.TerminationReason != telemetry.TerminationUpstreamHTTPError ||
+		failedEvent.Status == nil || *failedEvent.Status != http.StatusUnauthorized ||
+		failedEvent.RequestClassification == nil ||
+		failedEvent.RequestClassification.Kind != telemetry.RequestClassificationKindClaudeAutoPermissionCheck {
+		t.Fatalf("classified terminal event = %+v", failedEvent)
+	}
+	request.requestClassification.Kind = "changed"
+	if event.RequestClassification.Kind != telemetry.RequestClassificationKindClaudeAutoPermissionCheck {
+		t.Fatalf("event retained mutable classification: %+v", event.RequestClassification)
+	}
+}
+
 func TestTelemetryV1AnthropicActualPriceRequiresConfirmedFastSpeed(t *testing.T) {
 	startedAt := time.Date(2026, time.July, 25, 20, 0, 0, 0, time.UTC)
 	prices := telemetryVariantPricing(t, startedAt)

--- a/gateway/internal/requestclassification/classification.go
+++ b/gateway/internal/requestclassification/classification.go
@@ -1,0 +1,134 @@
+// Package requestclassification identifies request purposes that require
+// gateway-owned compatibility routing. It returns only content-free metadata.
+package requestclassification
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"unicode"
+)
+
+const (
+	KindClaudeAutoPermissionCheck = "claude_auto_permission_check"
+	DetectorClaudeAutoV1          = "claude_auto_v1"
+	RoutingActionNativeAnthropic  = "native_anthropic"
+
+	maxSystemTextBytes = 128 << 10
+)
+
+// RequestContext contains the request facts that are safe and necessary for
+// classification. Path excludes the query string.
+type RequestContext struct {
+	ClaudeListener bool
+	Method         string
+	Path           string
+}
+
+// Classification is the complete binary result retained by the gateway. It
+// deliberately excludes matched text, excerpts, hashes, and confidence.
+type Classification struct {
+	Kind          string `json:"kind"`
+	Detector      string `json:"detector"`
+	RoutingAction string `json:"routing_action"`
+}
+
+type messagesEnvelope struct {
+	Stream *bool           `json:"stream"`
+	System json.RawMessage `json:"system"`
+}
+
+// ClassifyClaudeMessages returns a positive result only for the complete v1
+// Auto permission-check signature. Unsupported or uncertain input is left
+// unclassified so it follows the gateway's ordinary routing policy.
+func ClassifyClaudeMessages(ctx RequestContext, body []byte) *Classification {
+	if !ctx.ClaudeListener || ctx.Method != http.MethodPost || ctx.Path != "/v1/messages" {
+		return nil
+	}
+
+	var envelope messagesEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil ||
+		(envelope.Stream != nil && *envelope.Stream) || len(envelope.System) == 0 {
+		return nil
+	}
+
+	systemText, ok := concatenateSystemText(envelope.System)
+	if !ok {
+		return nil
+	}
+	normalized := normalizeSystemText(systemText)
+	if !containsAllConcepts(normalized) {
+		return nil
+	}
+
+	return &Classification{
+		Kind:          KindClaudeAutoPermissionCheck,
+		Detector:      DetectorClaudeAutoV1,
+		RoutingAction: RoutingActionNativeAnthropic,
+	}
+}
+
+func concatenateSystemText(raw json.RawMessage) (string, bool) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || trimmed[0] != '[' {
+		return "", false
+	}
+	var blocks []json.RawMessage
+	if err := json.Unmarshal(trimmed, &blocks); err != nil || len(blocks) == 0 {
+		return "", false
+	}
+
+	var text strings.Builder
+	textBlocks := 0
+	for _, rawBlock := range blocks {
+		var header struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(rawBlock, &header); err != nil || header.Type != "text" {
+			continue
+		}
+		var block struct {
+			Text *string `json:"text"`
+		}
+		if err := json.Unmarshal(rawBlock, &block); err != nil || block.Text == nil {
+			return "", false
+		}
+		additional := len(*block.Text)
+		if textBlocks > 0 {
+			additional++
+		}
+		if text.Len()+additional > maxSystemTextBytes {
+			return "", false
+		}
+		if textBlocks > 0 {
+			text.WriteByte('\n')
+		}
+		text.WriteString(*block.Text)
+		textBlocks++
+	}
+	if textBlocks == 0 {
+		return "", false
+	}
+	return text.String(), true
+}
+
+func normalizeSystemText(text string) string {
+	return strings.Join(strings.FieldsFunc(strings.ToLower(text), unicode.IsSpace), " ")
+}
+
+func containsAllConcepts(text string) bool {
+	return strings.Contains(text, "auto mode") &&
+		containsAny(text, "permission", "safe", "safety") &&
+		containsAny(text, "classify", "classifier", "classification") &&
+		containsAny(text, "tool call", "tool use", "tool invocation", "action")
+}
+
+func containsAny(text string, terms ...string) bool {
+	for _, term := range terms {
+		if strings.Contains(text, term) {
+			return true
+		}
+	}
+	return false
+}

--- a/gateway/internal/requestclassification/classification_test.go
+++ b/gateway/internal/requestclassification/classification_test.go
@@ -1,0 +1,269 @@
+package requestclassification
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestClassifyClaudeMessagesPositive(t *testing.T) {
+	tests := []struct {
+		name   string
+		system any
+	}{
+		{
+			name: "single text block",
+			system: []any{map[string]any{
+				"type": "text",
+				"text": "In Auto mode, classify whether the proposed tool call has permission to run safely.",
+			}},
+		},
+		{
+			name: "concepts span text blocks",
+			system: []any{
+				map[string]any{"type": "text", "text": "AUTO\u2003MODE permission"},
+				map[string]any{"type": "metadata", "text": 42},
+				map[string]any{"type": "text", "text": "classification of an action"},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := messageBody(t, false, tc.system, "ordinary user text")
+			got := ClassifyClaudeMessages(validContext(), body)
+			if got == nil {
+				t.Fatal("classification = nil, want positive")
+			}
+			want := Classification{
+				Kind:          KindClaudeAutoPermissionCheck,
+				Detector:      DetectorClaudeAutoV1,
+				RoutingAction: RoutingActionNativeAnthropic,
+			}
+			if *got != want {
+				t.Fatalf("classification = %+v, want %+v", *got, want)
+			}
+		})
+	}
+
+	withoutStream := messageBodyWithoutStream(
+		t,
+		textSystem("Auto mode permission classifier for a proposed tool use."),
+		"Review the proposed operation.",
+	)
+	if got := ClassifyClaudeMessages(validContext(), withoutStream); got == nil {
+		t.Fatal("classification with omitted stream = nil, want positive")
+	}
+}
+
+func TestClassifyClaudeMessagesRequiresFullPredicate(t *testing.T) {
+	matchingSystem := []any{map[string]any{
+		"type": "text",
+		"text": "Auto mode permission classifier for a proposed tool use.",
+	}}
+	streamTrue := true
+	streamFalse := false
+	tests := []struct {
+		name string
+		ctx  RequestContext
+		body []byte
+	}{
+		{"non Claude listener", RequestContext{Method: http.MethodPost, Path: "/v1/messages"}, messageBody(t, false, matchingSystem, "hello")},
+		{"wrong method", RequestContext{ClaudeListener: true, Method: http.MethodPut, Path: "/v1/messages"}, messageBody(t, false, matchingSystem, "hello")},
+		{"wrong path", RequestContext{ClaudeListener: true, Method: http.MethodPost, Path: "/v1/messages/count_tokens"}, messageBody(t, false, matchingSystem, "hello")},
+		{"invalid JSON", validContext(), []byte(`{"stream":false`)},
+		{"stream true", validContext(), envelopeBody(t, &streamTrue, matchingSystem)},
+		{"system string", validContext(), envelopeBody(t, &streamFalse, "Auto mode permission classifier for a tool call")},
+		{"empty system", validContext(), envelopeBody(t, &streamFalse, []any{})},
+		{"no text blocks", validContext(), envelopeBody(t, &streamFalse, []any{map[string]any{"type": "metadata", "text": "Auto mode permission classifier tool call"}})},
+		{"malformed text block", validContext(), envelopeBody(t, &streamFalse, []any{map[string]any{"type": "text", "text": 42}, map[string]any{"type": "text", "text": "Auto mode permission classifier tool call"}})},
+		{"missing auto mode", validContext(), messageBody(t, false, textSystem("Permission classifier for a tool call."), "hello")},
+		{"missing safety", validContext(), messageBody(t, false, textSystem("Auto mode classifier for a tool call."), "hello")},
+		{"missing classifier", validContext(), messageBody(t, false, textSystem("Auto mode checks permission for a tool call."), "hello")},
+		{"missing action", validContext(), messageBody(t, false, textSystem("Auto mode permission classifier."), "hello")},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClassifyClaudeMessages(tc.ctx, tc.body); got != nil {
+				t.Fatalf("classification = %+v, want nil", *got)
+			}
+		})
+	}
+}
+
+func TestClassifyClaudeMessagesIgnoresUserContent(t *testing.T) {
+	body := messageBody(
+		t,
+		false,
+		textSystem("You are a general coding assistant."),
+		"Auto mode permission classifier for a proposed tool call.",
+	)
+	if got := ClassifyClaudeMessages(validContext(), body); got != nil {
+		t.Fatalf("classification = %+v, want nil", *got)
+	}
+}
+
+func TestClassifyClaudeMessagesNegativeRequestFamilies(t *testing.T) {
+	matchingSystem := textSystem("In Auto mode, classify whether a proposed tool call has permission to run safely.")
+	tests := []struct {
+		name       string
+		ctx        RequestContext
+		stream     bool
+		omitStream bool
+		system     any
+		user       string
+	}{
+		{
+			name:   "ordinary streaming turn",
+			ctx:    validContext(),
+			stream: true,
+			system: textSystem("You are a coding assistant. Help with the requested task."),
+			user:   "Explain this function.",
+		},
+		{
+			name:       "ordinary nonstreaming turn",
+			ctx:        validContext(),
+			omitStream: true,
+			system:     textSystem("You are a coding assistant. Answer concisely."),
+			user:       "Name two testing strategies.",
+		},
+		{
+			name:       "title generation",
+			ctx:        validContext(),
+			omitStream: true,
+			system:     textSystem("Generate a short title for the conversation."),
+			user:       "We discussed improving a command-line interface.",
+		},
+		{
+			name:       "summarization and compaction",
+			ctx:        validContext(),
+			omitStream: true,
+			system:     textSystem("Summarize the conversation into a compact continuation note."),
+			user:       "Keep the decisions and unresolved questions.",
+		},
+		{
+			name:       "tool search",
+			ctx:        validContext(),
+			omitStream: true,
+			system:     textSystem("Find tools relevant to the requested operation."),
+			user:       "Look for a source-code search tool.",
+		},
+		{
+			name:       "subagent turn",
+			ctx:        validContext(),
+			omitStream: true,
+			system:     textSystem("You are a focused subagent investigating one bounded task."),
+			user:       "Review the parser tests.",
+		},
+		{
+			name: "token counting endpoint",
+			ctx: RequestContext{
+				ClaudeListener: true,
+				Method:         http.MethodPost,
+				Path:           "/v1/messages/count_tokens",
+			},
+			system: matchingSystem,
+			user:   "Count these tokens.",
+		},
+		{
+			name:   "classifier-like non-Auto system text",
+			ctx:    validContext(),
+			system: textSystem("Classify whether a tool call has permission to run safely."),
+			user:   "Review the proposed operation.",
+		},
+		{
+			name:   "classifier language only in user content",
+			ctx:    validContext(),
+			system: textSystem("You are a general coding assistant."),
+			user:   "In Auto mode, classify whether a proposed tool call has permission to run safely.",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := messageBody(t, tc.stream, tc.system, tc.user)
+			if tc.omitStream {
+				body = messageBodyWithoutStream(t, tc.system, tc.user)
+			}
+			if got := ClassifyClaudeMessages(tc.ctx, body); got != nil {
+				t.Fatalf("classification = %+v, want nil", *got)
+			}
+		})
+	}
+}
+
+func TestClassifyClaudeMessagesSystemTextLimit(t *testing.T) {
+	matching := "Auto mode permission classifier for a tool call."
+	atLimit := matching + strings.Repeat("x", maxSystemTextBytes-len(matching))
+	if got := ClassifyClaudeMessages(
+		validContext(),
+		messageBody(t, false, textSystem(atLimit), "hello"),
+	); got == nil {
+		t.Fatal("classification at limit = nil, want positive")
+	}
+	overLimit := atLimit + "x"
+	if got := ClassifyClaudeMessages(
+		validContext(),
+		messageBody(t, false, textSystem(overLimit), "hello"),
+	); got != nil {
+		t.Fatalf("classification over limit = %+v, want nil", *got)
+	}
+}
+
+func validContext() RequestContext {
+	return RequestContext{
+		ClaudeListener: true,
+		Method:         http.MethodPost,
+		Path:           "/v1/messages",
+	}
+}
+
+func textSystem(text string) []any {
+	return []any{map[string]any{"type": "text", "text": text}}
+}
+
+func messageBody(t *testing.T, stream bool, system any, user string) []byte {
+	t.Helper()
+	body := map[string]any{
+		"model":  "claude-example-model",
+		"stream": stream,
+		"system": system,
+		"messages": []any{map[string]any{
+			"role": "user", "content": user,
+		}},
+	}
+	b, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func messageBodyWithoutStream(t *testing.T, system any, user string) []byte {
+	t.Helper()
+	body := map[string]any{
+		"model":  "claude-example-model",
+		"system": system,
+		"messages": []any{map[string]any{
+			"role": "user", "content": user,
+		}},
+	}
+	b, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func envelopeBody(t *testing.T, stream *bool, system any) []byte {
+	t.Helper()
+	body := map[string]any{"system": system}
+	if stream != nil {
+		body["stream"] = *stream
+	}
+	b, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}

--- a/gateway/internal/telemetry/event_v1.go
+++ b/gateway/internal/telemetry/event_v1.go
@@ -78,6 +78,7 @@ type EventV1 struct {
 	Translated                    bool                      `json:"translated"`
 	StrippedToolTypes             []string                  `json:"stripped_tool_types"`
 	ResponsesCompatibility        *ResponsesCompatibilityV1 `json:"responses_compatibility,omitempty"`
+	RequestClassification         *RequestClassificationV1  `json:"request_classification,omitempty"`
 	ToolCalls                     int                       `json:"tool_calls"`
 	RequestBytes                  int                       `json:"request_bytes"`
 	requestedReasoningPresentNull bool
@@ -170,6 +171,21 @@ type ResponsesCompatibilityV1 struct {
 	RepairedEvents   int      `json:"repaired_events"`
 	ValidationErrors int      `json:"validation_errors"`
 }
+
+// RequestClassificationV1 records only the gateway-owned, content-free
+// result of a positive request classification. Prompt text, matched terms,
+// excerpts, hashes, and other content-derived signals never belong here.
+type RequestClassificationV1 struct {
+	Kind          string `json:"kind"`
+	Detector      string `json:"detector"`
+	RoutingAction string `json:"routing_action"`
+}
+
+const (
+	RequestClassificationKindClaudeAutoPermissionCheck = "claude_auto_permission_check"
+	RequestClassificationDetectorClaudeAutoV1          = "claude_auto_v1"
+	RequestClassificationRoutingActionNativeAnthropic  = "native_anthropic"
+)
 
 const (
 	ResponsesCompatibilityRuleTextFormatDefault            = "responses.text_format_default"
@@ -314,6 +330,21 @@ func (e EventV1) Validate() error {
 	if err := e.ResponsesCompatibility.validate(); err != nil {
 		return err
 	}
+	if err := e.RequestClassification.validate(); err != nil {
+		return err
+	}
+	if e.RequestClassification != nil {
+		switch {
+		case e.EffectiveProvider != "anthropic":
+			return errors.New("telemetry classified Auto request requires effective_provider=anthropic")
+		case e.Fallback.Attempted || e.Fallback.Count != 0 || e.Fallback.Trigger != nil:
+			return errors.New("telemetry classified Auto request cannot record fallback")
+		case e.Primary != nil:
+			return errors.New("telemetry classified Auto request cannot record a primary attempt")
+		case e.NativeCounterfactualCost != nil:
+			return errors.New("telemetry classified Auto request cannot record native counterfactual cost")
+		}
+	}
 	if err := e.Usage.validate(e.UsageComplete); err != nil {
 		return err
 	}
@@ -327,6 +358,31 @@ func (e EventV1) Validate() error {
 		); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func (classification *RequestClassificationV1) validate() error {
+	if classification == nil {
+		return nil
+	}
+	if classification.Kind != RequestClassificationKindClaudeAutoPermissionCheck {
+		return fmt.Errorf(
+			"telemetry request_classification kind = %q is invalid",
+			classification.Kind,
+		)
+	}
+	if classification.Detector != RequestClassificationDetectorClaudeAutoV1 {
+		return fmt.Errorf(
+			"telemetry request_classification detector = %q is invalid",
+			classification.Detector,
+		)
+	}
+	if classification.RoutingAction != RequestClassificationRoutingActionNativeAnthropic {
+		return fmt.Errorf(
+			"telemetry request_classification routing_action = %q is invalid",
+			classification.RoutingAction,
+		)
 	}
 	return nil
 }

--- a/gateway/internal/telemetry/event_v1_test.go
+++ b/gateway/internal/telemetry/event_v1_test.go
@@ -103,6 +103,143 @@ func TestEventV1PrimarySummaryRoundTrip(t *testing.T) {
 	}
 }
 
+func TestEventV1RequestClassificationRoundTrip(t *testing.T) {
+	now := time.Date(2026, time.August, 26, 12, 0, 0, 0, time.UTC)
+	event := validEventV1(now)
+	event.EffectiveProvider = "anthropic"
+	event.ServedModel = "claude-sonnet-5"
+	event.RequestClassification = &RequestClassificationV1{
+		Kind:          RequestClassificationKindClaudeAutoPermissionCheck,
+		Detector:      RequestClassificationDetectorClaudeAutoV1,
+		RoutingAction: RequestClassificationRoutingActionNativeAnthropic,
+	}
+	if err := event.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "auto mode") ||
+		strings.Contains(string(raw), "tool call") {
+		t.Fatalf("classification telemetry contains prompt-derived data: %s", raw)
+	}
+	var decoded EventV1
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.RequestClassification == nil ||
+		decoded.RequestClassification.Kind != RequestClassificationKindClaudeAutoPermissionCheck ||
+		decoded.RequestClassification.Detector != RequestClassificationDetectorClaudeAutoV1 ||
+		decoded.RequestClassification.RoutingAction != RequestClassificationRoutingActionNativeAnthropic {
+		t.Fatalf("request classification round trip = %+v", decoded.RequestClassification)
+	}
+
+	unclassified := validEventV1(now)
+	raw, err = json.Marshal(unclassified)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), `"request_classification"`) {
+		t.Fatalf("unclassified event emitted request_classification: %s", raw)
+	}
+}
+
+func TestRequestClassificationV1Validation(t *testing.T) {
+	now := time.Date(2026, time.August, 26, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name    string
+		value   RequestClassificationV1
+		wantErr string
+	}{
+		{
+			name: "unknown kind",
+			value: RequestClassificationV1{
+				Kind:          "other",
+				Detector:      RequestClassificationDetectorClaudeAutoV1,
+				RoutingAction: RequestClassificationRoutingActionNativeAnthropic,
+			},
+			wantErr: "kind",
+		},
+		{
+			name: "unknown detector",
+			value: RequestClassificationV1{
+				Kind:          RequestClassificationKindClaudeAutoPermissionCheck,
+				Detector:      "other",
+				RoutingAction: RequestClassificationRoutingActionNativeAnthropic,
+			},
+			wantErr: "detector",
+		},
+		{
+			name: "unknown routing action",
+			value: RequestClassificationV1{
+				Kind:          RequestClassificationKindClaudeAutoPermissionCheck,
+				Detector:      RequestClassificationDetectorClaudeAutoV1,
+				RoutingAction: "other",
+			},
+			wantErr: "routing_action",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			event := validEventV1(now)
+			event.RequestClassification = &test.value
+			err := event.Validate()
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("Validate() error = %v, want %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestRequestClassificationV1RequiresNativeTerminalRouting(t *testing.T) {
+	now := time.Date(2026, time.August, 26, 12, 0, 0, 0, time.UTC)
+	classification := &RequestClassificationV1{
+		Kind:          RequestClassificationKindClaudeAutoPermissionCheck,
+		Detector:      RequestClassificationDetectorClaudeAutoV1,
+		RoutingAction: RequestClassificationRoutingActionNativeAnthropic,
+	}
+	tests := []struct {
+		name    string
+		mutate  func(*EventV1)
+		wantErr string
+	}{
+		{
+			name: "non-Anthropic provider",
+			mutate: func(event *EventV1) {
+				event.EffectiveProvider = "baseten"
+			},
+			wantErr: "effective_provider=anthropic",
+		},
+		{
+			name: "fallback",
+			mutate: func(event *EventV1) {
+				event.Fallback = FallbackV1{Attempted: true, Count: 1}
+			},
+			wantErr: "cannot record fallback",
+		},
+		{
+			name: "native counterfactual",
+			mutate: func(event *EventV1) {
+				event.NativeCounterfactualCost = &CostSnapshotV1{}
+			},
+			wantErr: "cannot record native counterfactual",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			event := validEventV1(now)
+			event.EffectiveProvider = "anthropic"
+			event.RequestClassification = classification
+			test.mutate(&event)
+			err := event.Validate()
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("Validate() error = %v, want %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
 func TestPrimaryV1Validation(t *testing.T) {
 	status := func(value int) *int { return &value }
 	tests := []struct {

--- a/gateway/internal/tracecapture/writer_test.go
+++ b/gateway/internal/tracecapture/writer_test.go
@@ -154,7 +154,11 @@ func TestWriterRecoversPartialFinalLine(t *testing.T) {
 	if err := os.WriteFile(path, content, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	w, err := NewWriter(Config{Dir: dir, RetentionDays: 7})
+	w, err := newWriter(
+		Config{Dir: dir, RetentionDays: 7},
+		defaultWriterLimits(),
+		func() time.Time { return now },
+	)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/gateway/internal/tracepackage/create.go
+++ b/gateway/internal/tracepackage/create.go
@@ -538,8 +538,9 @@ func stageTelemetry(
 	}
 	included := make(map[string]struct{}, len(eventIDs))
 	err = readSnapshotLines(ctx, snapshot, MaxTelemetryLineBytes, func(line []byte) error {
+		// Telemetry schema v1 permits additive optional metadata. Decode known
+		// fields for join validation while preserving the original row bytes.
 		decoder := json.NewDecoder(bytes.NewReader(line))
-		decoder.DisallowUnknownFields()
 		var event telemetry.EventV1
 		if err := decoder.Decode(&event); err != nil {
 			return fmt.Errorf("read telemetry row: %w", err)

--- a/gateway/internal/tracepackage/decode.go
+++ b/gateway/internal/tracepackage/decode.go
@@ -766,8 +766,9 @@ func validateTraceRows(member extractedMember) (map[string]string, error) {
 func validateTelemetryRows(member extractedMember, events map[string]string) (int, error) {
 	seen := make(map[string]struct{})
 	return forEachJSONLine(member, MaxTelemetryLineBytes, func(line []byte) error {
+		// Telemetry schema v1 permits additive optional metadata. Validate the
+		// known contract without rejecting fields added by newer gateways.
 		decoder := json.NewDecoder(bytes.NewReader(line))
-		decoder.DisallowUnknownFields()
 		var event telemetry.EventV1
 		if err := decoder.Decode(&event); err != nil || event.Validate() != nil || event.SchemaVersion != telemetry.SchemaVersionV1 || event.Event != telemetry.EventRequest {
 			return errors.New("trace package decode: invalid telemetry row")

--- a/gateway/internal/tracepackage/decode_test.go
+++ b/gateway/internal/tracepackage/decode_test.go
@@ -91,6 +91,59 @@ func TestDecodeProducesVersionedContentFreeOutput(t *testing.T) {
 	}
 }
 
+func TestCreateAndDecodeAcceptForwardCompatibleTelemetryFields(t *testing.T) {
+	base := time.Date(2026, time.August, 26, 12, 0, 0, 0, time.UTC)
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	telemetryRow := telemetryJSON(t, selectedEventID, base.Add(time.Hour))
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(telemetryRow, &fields); err != nil {
+		t.Fatal(err)
+	}
+	fields["future_optional_metadata"] = json.RawMessage(`{"version":2}`)
+	telemetryRow, err = json.Marshal(fields)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	source := filepath.Join(root, "source.zip")
+	options := basicOptions(
+		source,
+		base,
+		jsonl(traceJSON(t, selectedEventID, "claude-code", base.Add(time.Hour))),
+	)
+	options.Sources.Telemetry = func(
+		context.Context,
+		Selection,
+		[]string,
+	) (Snapshot, error) {
+		return bytesSnapshot(jsonl(telemetryRow), nil), nil
+	}
+	if _, err := Create(context.Background(), options); err != nil {
+		t.Fatalf("Create() rejected additive telemetry field: %v", err)
+	}
+
+	output := filepath.Join(root, "decoded")
+	if _, err := Decode(context.Background(), DecodeOptions{
+		PackagePath: source,
+		OutputDir:   output,
+	}); err != nil {
+		t.Fatalf("Decode() rejected additive telemetry field: %v", err)
+	}
+	copied, err := os.ReadFile(filepath.Join(
+		output,
+		filepath.FromSlash(TelemetryMemberName),
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(copied, []byte(`"future_optional_metadata":{"version":2}`)) {
+		t.Fatalf("additive telemetry field was not preserved: %s", copied)
+	}
+}
+
 func TestInspectDecodeIsAuthoritativeAndPlanIsSingleUse(t *testing.T) {
 	source := createDecodeFixture(t)
 	plan, err := InspectDecode(context.Background(), source)

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/RequestsModels.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/RequestsModels.swift
@@ -103,6 +103,23 @@ struct RequestPrimaryAttempt: Decodable, Equatable, Sendable {
     }
 }
 
+struct RequestClassification: Decodable, Equatable, Sendable {
+    var kind: String
+    var detector: String
+    var routingAction: String
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case detector
+        case routingAction = "routing_action"
+    }
+
+    var isClaudeAutoPermissionCheck: Bool {
+        kind == "claude_auto_permission_check"
+            && routingAction == "native_anthropic"
+    }
+}
+
 struct RequestItem: Decodable, Equatable, Identifiable, Sendable {
     var eventID: String
     var completedAt: Date
@@ -117,6 +134,7 @@ struct RequestItem: Decodable, Equatable, Identifiable, Sendable {
     var subagent: Bool
     var fallback: RequestFallback?
     var primary: RequestPrimaryAttempt?
+    var requestClassification: RequestClassification?
 
     var id: String { eventID }
 
@@ -151,6 +169,7 @@ struct RequestItem: Decodable, Equatable, Identifiable, Sendable {
         case subagent
         case fallback
         case primary
+        case requestClassification = "request_classification"
     }
 
     init(
@@ -166,7 +185,8 @@ struct RequestItem: Decodable, Equatable, Identifiable, Sendable {
         terminationReason: String?,
         subagent: Bool,
         fallback: RequestFallback?,
-        primary: RequestPrimaryAttempt? = nil
+        primary: RequestPrimaryAttempt? = nil,
+        requestClassification: RequestClassification? = nil
     ) {
         self.eventID = eventID
         self.completedAt = completedAt
@@ -181,6 +201,7 @@ struct RequestItem: Decodable, Equatable, Identifiable, Sendable {
         self.subagent = subagent
         self.fallback = fallback
         self.primary = primary
+        self.requestClassification = requestClassification
     }
 
     init(from decoder: Decoder) throws {
@@ -214,6 +235,9 @@ struct RequestItem: Decodable, Equatable, Identifiable, Sendable {
         primary = try values.decodeIfPresent(
             RequestPrimaryAttempt.self,
             forKey: .primary)
+        requestClassification = try? values.decode(
+            RequestClassification.self,
+            forKey: .requestClassification)
     }
 }
 

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/RequestsView.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/RequestsView.swift
@@ -202,12 +202,13 @@ struct RequestsView: View {
 private enum RequestTableMetrics {
     static let time: CGFloat = 128
     static let harness: CGFloat = 132
+    static let type: CGFloat = 100
     static let requested: CGFloat = 190
     static let routing: CGFloat = 330
     static let result: CGFloat = 120
     static let duration: CGFloat = 86
     static let fallback: CGFloat = 270
-    static let totalWidth = time + harness + requested + routing
+    static let totalWidth = time + harness + type + requested + routing
         + result + duration + fallback
 }
 
@@ -216,6 +217,7 @@ private struct RequestTableHeader: View {
         HStack(spacing: 0) {
             headerCell("Time", width: RequestTableMetrics.time)
             headerCell("Harness", width: RequestTableMetrics.harness)
+            headerCell("Type", width: RequestTableMetrics.type)
             headerCell("Requested", width: RequestTableMetrics.requested)
             headerCell("Routing", width: RequestTableMetrics.routing)
             headerCell("Result", width: RequestTableMetrics.result)
@@ -269,6 +271,9 @@ private struct RequestTableRow: View {
             }
             .requestTableCell(width: RequestTableMetrics.harness)
 
+            RequestTypeCell(item: item)
+                .requestTableCell(width: RequestTableMetrics.type)
+
             Text(item.requestedModel.isEmpty ? "Unknown model" : item.requestedModel)
                 .lineLimit(1)
                 .truncationMode(.middle)
@@ -316,6 +321,27 @@ private struct RequestTableRow: View {
         .background(shaded ? Color.secondary.opacity(0.04) : Color.clear)
         .overlay(alignment: .bottom) {
             Divider()
+        }
+    }
+}
+
+private struct RequestTypeCell: View {
+    let item: RequestItem
+
+    var body: some View {
+        if let label = requestTypeLabel(item),
+           let description = requestTypeDescription(item) {
+            Text(label)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .help(description)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(description)
+                .accessibilityIdentifier("request-type-auto-check")
+        } else {
+            Text("")
+                .accessibilityHidden(true)
         }
     }
 }
@@ -374,6 +400,30 @@ private extension View {
             .frame(width: width, alignment: .leading)
             .contentShape(Rectangle())
     }
+}
+
+func requestTypeLabel(_ item: RequestItem) -> String? {
+    item.requestClassification?.isClaudeAutoPermissionCheck == true
+        ? "Auto check"
+        : nil
+}
+
+func requestTypeDescription(_ item: RequestItem) -> String? {
+    guard requestTypeLabel(item) != nil else { return nil }
+    if item.status == 401 {
+        return "Switch identified this as a Claude Code Auto permission check "
+            + "and routed it to Anthropic. Anthropic rejected the request "
+            + "credentials. Auto checks require a Claude login or Anthropic "
+            + "API key accepted by Anthropic."
+    }
+    if item.status == 403 {
+        return "Switch identified this as a Claude Code Auto permission check "
+            + "and routed it to Anthropic. Anthropic denied access to the "
+            + "request. Check the Claude login or Anthropic API key, plus the "
+            + "account and model permissions."
+    }
+    return "Switch identified this as a Claude Code Auto permission check "
+        + "and routed it to Anthropic."
 }
 
 func requestServedProviderLabel(_ item: RequestItem) -> String {

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/RequestPresentationTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/RequestPresentationTests.swift
@@ -94,6 +94,59 @@ final class RequestPresentationTests: XCTestCase {
             "Requests that end in an error will appear here.")
     }
 
+    func testAutoCheckTypeUsesServerKindAndRoutingAction() {
+        var item = requestItem()
+        XCTAssertNil(requestTypeLabel(item))
+        XCTAssertNil(requestTypeDescription(item))
+
+        item.requestClassification = RequestClassification(
+            kind: "claude_auto_permission_check",
+            detector: "claude_auto_v1",
+            routingAction: "native_anthropic")
+
+        XCTAssertEqual(requestTypeLabel(item), "Auto check")
+        XCTAssertEqual(
+            requestTypeDescription(item),
+            "Switch identified this as a Claude Code Auto permission check "
+                + "and routed it to Anthropic.")
+
+        item.requestClassification?.detector = "future_detector"
+        XCTAssertEqual(requestTypeLabel(item), "Auto check")
+        XCTAssertNotNil(requestTypeDescription(item))
+
+        item.requestClassification?.routingAction = "future_action"
+        XCTAssertNil(requestTypeLabel(item))
+        XCTAssertNil(requestTypeDescription(item))
+    }
+
+    func testAutoCheckTypeExplainsAnthropicAuthFailures() {
+        var item = requestItem()
+        item.requestClassification = RequestClassification(
+            kind: "claude_auto_permission_check",
+            detector: "claude_auto_v1",
+            routingAction: "native_anthropic")
+        let unauthorized = "Switch identified this as a Claude Code Auto "
+            + "permission check and routed it to Anthropic. Anthropic "
+            + "rejected the request credentials. Auto checks require a "
+            + "Claude login or Anthropic API key accepted by Anthropic."
+        let forbidden = "Switch identified this as a Claude Code Auto "
+            + "permission check and routed it to Anthropic. Anthropic denied "
+            + "access to the request. Check the Claude login or Anthropic API "
+            + "key, plus the account and model permissions."
+
+        item.status = 401
+        XCTAssertEqual(requestTypeDescription(item), unauthorized)
+
+        item.status = 403
+        XCTAssertEqual(requestTypeDescription(item), forbidden)
+
+        item.status = 429
+        XCTAssertEqual(
+            requestTypeDescription(item),
+            "Switch identified this as a Claude Code Auto permission check "
+                + "and routed it to Anthropic.")
+    }
+
     private func requestItem() -> RequestItem {
         RequestItem(
             eventID: "0123456789abcdef0123456789abcdef",

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/RequestsTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/RequestsTests.swift
@@ -97,6 +97,8 @@ final class RequestsTests: XCTestCase {
 
         XCTAssertEqual(snapshot.items.map(\.eventID), [
             "request-newest",
+            "request-auto-success",
+            "request-auto-failed",
             "request-older",
         ])
         XCTAssertEqual(snapshot.nextCursor, "older-page-token")
@@ -117,9 +119,55 @@ final class RequestsTests: XCTestCase {
         XCTAssertEqual(primary.outcome, "image_input_unsupported")
         XCTAssertEqual(primary.status, 400)
         XCTAssertTrue(snapshot.items[0].isFallback)
-        XCTAssertNil(snapshot.items[1].primary)
-        XCTAssertNil(snapshot.items[1].status)
-        XCTAssertTrue(snapshot.items[1].isError)
+        XCTAssertNil(snapshot.items[0].requestClassification)
+        XCTAssertEqual(snapshot.items[1].status, 200)
+        XCTAssertTrue(
+            snapshot.items[1].requestClassification?
+                .isClaudeAutoPermissionCheck == true)
+        XCTAssertFalse(snapshot.items[1].isFallback)
+        XCTAssertEqual(snapshot.items[2].status, 401)
+        XCTAssertTrue(
+            snapshot.items[2].requestClassification?
+                .isClaudeAutoPermissionCheck == true)
+        XCTAssertFalse(snapshot.items[2].isFallback)
+        XCTAssertNil(snapshot.items[3].primary)
+        XCTAssertNil(snapshot.items[3].status)
+        XCTAssertTrue(snapshot.items[3].isError)
+        XCTAssertFalse(
+            snapshot.items[3].requestClassification?
+                .isClaudeAutoPermissionCheck == true)
+    }
+
+    func testClassificationDecodeIsTolerant() throws {
+        let malformed = Data(
+            """
+            {
+              "event_id": "malformed-classification",
+              "completed_at": 1785088860.25,
+              "request_classification": "unexpected"
+            }
+            """.utf8)
+        let incomplete = Data(
+            """
+            {
+              "event_id": "incomplete-classification",
+              "completed_at": 1785088860.25,
+              "request_classification": {
+                "kind": "claude_auto_permission_check",
+                "detector": "claude_auto_v1"
+              }
+            }
+            """.utf8)
+
+        let malformedItem = try JSONDecoder().decode(
+            RequestItem.self,
+            from: malformed)
+        let incompleteItem = try JSONDecoder().decode(
+            RequestItem.self,
+            from: incomplete)
+
+        XCTAssertNil(malformedItem.requestClassification)
+        XCTAssertNil(incompleteItem.requestClassification)
     }
 
     func testFallbackReasonLabelsMakeImageFallbackProminent() {

--- a/mac/BasetenSwitch/Tests/Fixtures/native-requests-mock.json
+++ b/mac/BasetenSwitch/Tests/Fixtures/native-requests-mock.json
@@ -26,6 +26,52 @@
       }
     },
     {
+      "event_id": "request-auto-success",
+      "completed_at": "2026-07-26T18:01:45Z",
+      "client": "claude-code",
+      "configured_route": "baseten",
+      "effective_provider": "anthropic",
+      "requested_model": "claude-sonnet-4-5",
+      "served_model": "claude-sonnet-4-5",
+      "status": 200,
+      "duration_ms": 387,
+      "termination_reason": "completed",
+      "subagent": false,
+      "request_classification": {
+        "kind": "claude_auto_permission_check",
+        "detector": "claude_auto_v1",
+        "routing_action": "native_anthropic"
+      },
+      "fallback": {
+        "attempted": false,
+        "count": 0,
+        "trigger": null
+      }
+    },
+    {
+      "event_id": "request-auto-failed",
+      "completed_at": "2026-07-26T18:01:30Z",
+      "client": "claude-code",
+      "configured_route": "baseten",
+      "effective_provider": "anthropic",
+      "requested_model": "claude-sonnet-4-5",
+      "served_model": "claude-sonnet-4-5",
+      "status": 401,
+      "duration_ms": 213,
+      "termination_reason": "upstream_http_error",
+      "subagent": false,
+      "request_classification": {
+        "kind": "claude_auto_permission_check",
+        "detector": "claude_auto_v1",
+        "routing_action": "native_anthropic"
+      },
+      "fallback": {
+        "attempted": false,
+        "count": 0,
+        "trigger": null
+      }
+    },
+    {
       "event_id": "request-older",
       "completed_at": "2026-07-26T18:01:00Z",
       "client": "codex",
@@ -37,6 +83,11 @@
       "duration_ms": 721,
       "termination_reason": "client_cancelled",
       "subagent": true,
+      "request_classification": {
+        "kind": "future_request_kind",
+        "detector": "future_detector",
+        "routing_action": "future_action"
+      },
       "fallback": {
         "attempted": false,
         "count": 0,


### PR DESCRIPTION
## What

- Detect high-confidence Claude Code Auto permission checks before request rewriting and route each match as one unchanged Anthropic attempt.
- Keep matched failures terminal, without Baseten fallback or cooldown changes, while leaving uncertain and ordinary requests on their existing routing path.
- Record an optional, versioned request classification in telemetry and the admin Requests API, and show matched requests as `Auto check` in the macOS Requests view.
- Preserve additive telemetry fields when decoding trace packages, and make the partial-line trace recovery test independent of wall-clock time.

<img width="1392" height="768" alt="image" src="https://github.com/user-attachments/assets/9f1f5cc5-0155-477b-871d-e24bb202f5a6" />

## Why

Claude Code Auto permission checks should not inherit model substitutions intended for ordinary agent turns. Keeping recognized checks on Anthropic preserves their native request semantics while allowing the rest of the session to follow the configured Switch route.

The Requests view also needs to show when this compatibility route was selected so authentication and routing failures are distinguishable from ordinary model traffic.

## Testing

- `scripts/check.sh`
- Full Go build, vet, and package tests
- Swift build and 269 tests
- Candidate source secret scan and scratch gateway, door, and lifecycle smoke checks
- Manual Claude Code validation through an isolated scratch gateway, including ordinary routing controls and classified native Anthropic checks with no fallback
- Regression coverage for positive and negative classification, body and authentication passthrough, routing-ladder bypass, terminal HTTP, transport, and TTFT failures, telemetry validation, admin projection, trace-package forward compatibility, and macOS presentation

## Security and privacy

Classification performs bounded, transient inspection of Claude Code system text. Routine telemetry stores only the classification kind, detector version, and routing action. It does not retain prompt content, excerpts, matched text, hashes, user actions, or header values. Existing opt-in trace capture behavior is unchanged.

Recognized Auto checks use the existing Anthropic upstream and require credentials accepted by Anthropic. Failures are returned directly and are not retried through Baseten. This change adds no dependencies, localhost APIs, release artifacts, or network destinations.
