### PR TITLE
Add Switch product headers to Baseten requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,11 @@ Request content leaves the machine only for the upstream chosen by the active
 routing policy. Baseten credentials go only to Baseten, and native credentials
 go only to their matching native provider.
 
+Baseten-routed inference requests identify Switch and its version in the
+standard `User-Agent` header and `X-Baseten-Switch-Version`. Switch does not
+add a user or installation identifier. Switch does not add these markers to
+native-provider requests.
+
 ### Compatibility routing
 
 Switch may route narrowly identified compatibility requests to a harness's

--- a/gateway/cmd/gateway/gateway.go
+++ b/gateway/cmd/gateway/gateway.go
@@ -2497,6 +2497,7 @@ func (g *Gateway) buildAttemptTargetWithSnapshot(
 	if projectFastProfile {
 		_, headers, _ = requestprofile.RemoveUnsupportedFastProfile(nil, headers)
 	}
+	applyBasetenUsageHeaders(headers, rt)
 	telemetryAttempt := captureTelemetryAttemptV1(
 		snapshot,
 		time.Now(),

--- a/gateway/cmd/gateway/gateway_test.go
+++ b/gateway/cmd/gateway/gateway_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
 	"github.com/basetenlabs/baseten-switch/gateway/internal/pricing"
 	"github.com/basetenlabs/baseten-switch/gateway/internal/telemetry"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/version"
 )
 
 func testConfig(t *testing.T, upstreamBaseten, upstreamAnthropic string) Config {
@@ -431,6 +432,12 @@ func TestPostMessagesBasetenForwardsRewrittenModel(t *testing.T) {
 		if r.URL.Path != "/v1/messages" {
 			t.Errorf("unexpected upstream path %q", r.URL.Path)
 		}
+		if got, want := r.Header.Get("User-Agent"), "baseten-switch/"+version.Version+" test-harness/1.0"; got != want {
+			t.Errorf("User-Agent = %q, want %q", got, want)
+		}
+		if got := r.Header.Get(switchVersionHeader); got != version.Version {
+			t.Errorf("%s = %q, want %q", switchVersionHeader, got, version.Version)
+		}
 		if r.Header.Get("Authorization") != "Api-Key bas-key" {
 			t.Errorf("bad upstream auth: %q", r.Header.Get("Authorization"))
 		}
@@ -453,6 +460,8 @@ func TestPostMessagesBasetenForwardsRewrittenModel(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer tok")
 	req.Header.Set("Anthropic-Version", "2023-06-01")
+	req.Header.Set("User-Agent", "test-harness/1.0")
+	req.Header.Set(switchVersionHeader, "forged")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -1025,6 +1034,12 @@ func TestOpenAIShapeBasetenForwardsChatCompletions(t *testing.T) {
 	gotModel := make(chan string, 1)
 	gotPath := make(chan string, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Header.Get("User-Agent"), "baseten-switch/"+version.Version+" test-harness/1.0"; got != want {
+			t.Errorf("User-Agent = %q, want %q", got, want)
+		}
+		if got := r.Header.Get(switchVersionHeader); got != version.Version {
+			t.Errorf("%s = %q, want %q", switchVersionHeader, got, version.Version)
+		}
 		gotPath <- r.URL.Path
 		b, _ := io.ReadAll(r.Body)
 		var m map[string]interface{}
@@ -1046,6 +1061,8 @@ func TestOpenAIShapeBasetenForwardsChatCompletions(t *testing.T) {
 	req, _ := http.NewRequest("POST", clientURL(g, "opencode", "/v1/chat/completions"), bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer tok")
+	req.Header.Set("User-Agent", "test-harness/1.0")
+	req.Header.Set(switchVersionHeader, "forged")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -1546,6 +1563,12 @@ func TestOpenAIShapeResponsesPassthroughForwardsVerbatim(t *testing.T) {
 	gotModel := make(chan string, 1)
 	gotPath := make(chan string, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("User-Agent"); got != "native-harness/1.0" {
+			t.Errorf("native User-Agent = %q, want unchanged", got)
+		}
+		if got := r.Header.Get(switchVersionHeader); got != "native-inbound" {
+			t.Errorf("native %s = %q, want unchanged", switchVersionHeader, got)
+		}
 		gotPath <- r.URL.Path
 		b, _ := io.ReadAll(r.Body)
 		var m map[string]interface{}
@@ -1573,6 +1596,8 @@ func TestOpenAIShapeResponsesPassthroughForwardsVerbatim(t *testing.T) {
 	req, _ := http.NewRequest("POST", clientURL(g, "opencode", "/v1/responses"), bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer tok")
+	req.Header.Set("User-Agent", "native-harness/1.0")
+	req.Header.Set(switchVersionHeader, "native-inbound")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -1678,6 +1703,12 @@ func TestOpenAIShapeResponsesBasetenRewritesModel(t *testing.T) {
 	gotModel := make(chan string, 1)
 	gotPath := make(chan string, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Header.Get("User-Agent"), "baseten-switch/"+version.Version+" test-harness/1.0"; got != want {
+			t.Errorf("User-Agent = %q, want %q", got, want)
+		}
+		if got := r.Header.Get(switchVersionHeader); got != version.Version {
+			t.Errorf("%s = %q, want %q", switchVersionHeader, got, version.Version)
+		}
 		gotPath <- r.URL.Path
 		b, _ := io.ReadAll(r.Body)
 		var m map[string]interface{}
@@ -1699,6 +1730,8 @@ func TestOpenAIShapeResponsesBasetenRewritesModel(t *testing.T) {
 	req, _ := http.NewRequest("POST", clientURL(g, "codex", "/v1/responses"), bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer tok")
+	req.Header.Set("User-Agent", "test-harness/1.0")
+	req.Header.Set(switchVersionHeader, "forged")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)

--- a/gateway/cmd/gateway/model_routes_test.go
+++ b/gateway/cmd/gateway/model_routes_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
 	"github.com/basetenlabs/baseten-switch/gateway/internal/pricing"
 	"github.com/basetenlabs/baseten-switch/gateway/internal/telemetry"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/version"
 )
 
 // modelRoutesClient returns an anthropic-shape resolved client with
@@ -410,15 +411,19 @@ func TestModelRoutePassthroughByteIdentical(t *testing.T) {
 // Anthropic. The fallback is NOT built from the family target.
 func TestModelRouteFallbackOriginalID(t *testing.T) {
 	var fbHits int32
+	gotPrimaryHeaders := make(chan http.Header, 1)
 	basSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPrimaryHeaders <- r.Header.Clone()
 		// Primary (baseten, forced target) returns 503.
 		w.WriteHeader(503)
 		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"overloaded_error","message":"overloaded"}}`))
 	}))
 	defer basSrv.Close()
 	gotFbModel := make(chan string, 1)
+	gotFallbackHeaders := make(chan http.Header, 1)
 	antSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&fbHits, 1)
+		gotFallbackHeaders <- r.Header.Clone()
 		b, _ := io.ReadAll(r.Body)
 		var m map[string]any
 		_ = json.Unmarshal(b, &m)
@@ -437,8 +442,19 @@ func TestModelRouteFallbackOriginalID(t *testing.T) {
 
 	// Request claude-opus-4-8; pin forces baseten with GLM. Primary 503
 	// -> fallback to anthropic with the ORIGINAL id.
-	resp, rb := postModelMessages(t, g, "claude-opus-4-8", "")
-	if resp.StatusCode != 200 || !strings.Contains(rb, "FALLBACK") {
+	body := []byte(`{"model":"claude-opus-4-8","stream":false,"messages":[{"role":"user","content":"ping"}]}`)
+	req, _ := http.NewRequest("POST", clientURL(g, "claude-code", "/v1/messages"), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer tok")
+	req.Header.Set("Anthropic-Version", "2023-06-01")
+	req.Header.Set("User-Agent", "header-isolation-test/1.0")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rb, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != 200 || !strings.Contains(string(rb), "FALLBACK") {
 		t.Fatalf("got %d: %s, want fallback 200", resp.StatusCode, rb)
 	}
 	if n := atomic.LoadInt32(&fbHits); n != 1 {
@@ -452,6 +468,29 @@ func TestModelRouteFallbackOriginalID(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("fallback upstream never received the request")
+	}
+	select {
+	case headers := <-gotPrimaryHeaders:
+		wantUserAgent := "baseten-switch/" + version.Version + " header-isolation-test/1.0"
+		if got := headers.Get("User-Agent"); got != wantUserAgent {
+			t.Errorf("Baseten User-Agent = %q, want %q", got, wantUserAgent)
+		}
+		if got := headers.Get(switchVersionHeader); got != version.Version {
+			t.Errorf("Baseten %s = %q, want %q", switchVersionHeader, got, version.Version)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Baseten primary headers were not captured")
+	}
+	select {
+	case headers := <-gotFallbackHeaders:
+		if got := headers.Get("User-Agent"); got != "header-isolation-test/1.0" {
+			t.Errorf("Anthropic User-Agent = %q, want unchanged", got)
+		}
+		if got := headers.Get(switchVersionHeader); got != "" {
+			t.Errorf("Anthropic %s = %q, want empty", switchVersionHeader, got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Anthropic fallback headers were not captured")
 	}
 	rows := waitForRows(t, cfg.TelemetryDir, 1, 2*time.Second)
 	// The fallback attempt served with route_effective=anthropic (differs

--- a/gateway/cmd/gateway/usage_headers.go
+++ b/gateway/cmd/gateway/usage_headers.go
@@ -1,0 +1,22 @@
+package gateway
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/basetenlabs/baseten-switch/gateway/internal/version"
+)
+
+const switchVersionHeader = "X-Baseten-Switch-Version"
+
+func applyBasetenUsageHeaders(headers http.Header, route string) {
+	if route != "baseten" {
+		return
+	}
+	marker := "baseten-switch/" + version.Version
+	if prior := strings.TrimSpace(headers.Get("User-Agent")); prior != "" {
+		marker += " " + prior
+	}
+	headers.Set("User-Agent", marker)
+	headers.Set(switchVersionHeader, version.Version)
+}

--- a/gateway/cmd/gateway/usage_headers_test.go
+++ b/gateway/cmd/gateway/usage_headers_test.go
@@ -1,0 +1,54 @@
+package gateway
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/basetenlabs/baseten-switch/gateway/internal/version"
+)
+
+func TestApplyBasetenUsageHeaders(t *testing.T) {
+	headers := http.Header{
+		"User-Agent":               {"claude-code/2.1"},
+		"X-Baseten-Switch-Version": {"forged"},
+	}
+
+	applyBasetenUsageHeaders(headers, "baseten")
+
+	if got, want := headers.Get("User-Agent"), "baseten-switch/"+version.Version+" claude-code/2.1"; got != want {
+		t.Fatalf("User-Agent = %q, want %q", got, want)
+	}
+	if got := headers.Get(switchVersionHeader); got != version.Version {
+		t.Fatalf("%s = %q, want %q", switchVersionHeader, got, version.Version)
+	}
+}
+
+func TestApplyBasetenUsageHeadersWithoutInboundUserAgent(t *testing.T) {
+	headers := http.Header{}
+
+	applyBasetenUsageHeaders(headers, "baseten")
+
+	if got, want := headers.Get("User-Agent"), "baseten-switch/"+version.Version; got != want {
+		t.Fatalf("User-Agent = %q, want %q", got, want)
+	}
+}
+
+func TestApplyBasetenUsageHeadersLeavesNativeRoutesUnchanged(t *testing.T) {
+	for _, route := range []string{"anthropic", "openai"} {
+		t.Run(route, func(t *testing.T) {
+			headers := http.Header{
+				"User-Agent":               {"harness/1.0"},
+				"X-Baseten-Switch-Version": {"inbound"},
+			}
+
+			applyBasetenUsageHeaders(headers, route)
+
+			if got := headers.Get("User-Agent"); got != "harness/1.0" {
+				t.Fatalf("User-Agent = %q, want unchanged", got)
+			}
+			if got := headers.Get(switchVersionHeader); got != "inbound" {
+				t.Fatalf("%s = %q, want unchanged", switchVersionHeader, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add a `baseten-switch/<version>` product token to `User-Agent` for Baseten-bound inference requests, while preserving the client user agent.
- Add `X-Baseten-Switch-Version` with the exact Switch build version.
- Apply the headers only to Baseten attempts. Native-provider requests remain unchanged, including after fallback.
- Document the request-header behavior and its privacy boundary.

## Testing

- `scripts/check.sh`
