### PR TITLE
Add configurable fallback and Claude Code model picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ baseten-switch claude route sonnet zai-org/GLM-5.2
 baseten-switch claude route sonnet native
 baseten-switch claude subagents zai-org/GLM-5.2
 baseten-switch claude picker status
-baseten-switch claude picker enable --dry-run --json
+baseten-switch claude picker enable
 baseten-switch claude picker add <baseten-model-slug> --dry-run --json
 baseten-switch claude picker add <baseten-model-slug> --alias <alias>
 baseten-switch claude picker remove <alias>
@@ -128,6 +128,10 @@ baseten-switch claude picker sync
 editable while routing is off. A Claude family can map to `native`, a
 configured alias, or a Baseten model slug. Run
 `baseten-switch claude route <family> default` to remove a family override.
+On an existing installation without picker configuration,
+`claude picker enable` enables an empty picker. Add each Baseten model you
+want to expose with `claude picker add`; enabling the picker does not add
+routing aliases as picker rows.
 Picker add, remove, and reorder operations do not delete routing aliases or
 change a running Claude Code session. Reopen `/model` after a change, and
 restart Claude Code if the picker has not refreshed.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ points new sessions at Baseten Switch, enables deferred tool loading, and
 omits Claude Code's attribution block to improve gateway prompt-cache hit
 rates. Restart Claude Code after enabling or disabling the integration.
 
+New installations also append the configured Baseten rows to Claude Code's
+`/model` picker. Claude continues to own and update its native model choices.
+The picker rows use stable aliases from `model_aliases`, so selection and
+routing refer to the same model identity.
+
 Useful controls:
 
 ```sh
@@ -111,12 +116,21 @@ baseten-switch claude route
 baseten-switch claude route sonnet zai-org/GLM-5.2
 baseten-switch claude route sonnet native
 baseten-switch claude subagents zai-org/GLM-5.2
+baseten-switch claude picker status
+baseten-switch claude picker enable --dry-run --json
+baseten-switch claude picker add <baseten-model-slug> --dry-run --json
+baseten-switch claude picker add <baseten-model-slug> --alias <alias>
+baseten-switch claude picker remove <alias>
+baseten-switch claude picker sync
 ```
 
 `on` and `off` change one global routing switch. Saved model mappings remain
 editable while routing is off. A Claude family can map to `native`, a
 configured alias, or a Baseten model slug. Run
 `baseten-switch claude route <family> default` to remove a family override.
+Picker add, remove, and reorder operations do not delete routing aliases or
+change a running Claude Code session. Reopen `/model` after a change, and
+restart Claude Code if the picker has not refreshed.
 
 To restore the Claude Code setting that existed before setup:
 

--- a/config/gateway.example.yaml
+++ b/config/gateway.example.yaml
@@ -57,6 +57,13 @@ clients:
       claude-baseten-glm-5-2:   zai-org/GLM-5.2
       claude-baseten-kimi-k2-7: moonshotai/Kimi-K2.7-Code
       claude-baseten-nemotron:  nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B
+    # Ordered Baseten rows appended to Claude Code's native /model choices.
+    model_picker:
+      enabled: true
+      models:
+        - alias: claude-baseten-glm-5-2
+        - alias: claude-baseten-kimi-k2-7
+        - alias: claude-baseten-nemotron
     # Route Claude Code subagent (sidechain) traffic to a model; toggle with 'baseten-switch claude subagents'. See the subagent-routing contract.
     # subagent_model: claude-baseten-glm-5-2
     # subagent_routing: on

--- a/config/gateway.example.yaml
+++ b/config/gateway.example.yaml
@@ -7,6 +7,11 @@ global:
   # One global switch. Off is absolute native passthrough; On applies saved routing policy.
   routing_enabled: true
 
+  # Independent status classes that may transition a Baseten attempt to the native provider.
+  fallback_policy:
+    on_baseten_429: true
+    on_baseten_5xx: true
+
   # The selected Baseten CLI profile supplies OAuth or API-key auth automatically.
   # baseten below is only the explicit environment fallback; see schema.md.
   auth:
@@ -67,9 +72,11 @@ clients:
     # Route Claude Code subagent (sidechain) traffic to a model; toggle with 'baseten-switch claude subagents'. See the subagent-routing contract.
     # subagent_model: claude-baseten-glm-5-2
     # subagent_routing: on
-    # Tried when baseten is unreachable, returns 5xx, or ttft_timeout expires (30s cooldown).
-    # Anthropic 429 responses relay to the harness without fallback or cooldown.
+    # Native provider used after an eligible Baseten attempt fails.
     fallback_route: anthropic
+    # Used only when a Claude request starts with a Baseten alias or raw slug.
+    # Native-origin requests retain the exact model Claude requested.
+    native_fallback_model: claude-opus-5
 
   # codex ships parked (enabled: false; no listener bound); 'baseten-switch codex on' offers to
   # enable it, or set enabled: true and SIGHUP the router yourself.

--- a/config/schema.md
+++ b/config/schema.md
@@ -20,6 +20,7 @@ SIGHUP. The native Mac app edits the same file through `baseten-switch`.
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `routing_enabled` | bool | `true` in new configs | The one global routing gate. It must be explicitly present. Off is absolute: native requests use the protocol-native provider, and aliases, raw Baseten slugs, Baseten model mappings, dedicated Baseten subagents, fallback, and Baseten credentials are not consulted by request resolution. Saved policy remains editable and becomes active again when On. |
+| `fallback_policy` | object | both triggers On | Independent controls for automatic native fallback after Baseten HTTP 429 and HTTP 5xx responses. An absent block or absent child resolves On. Explicit `null` is invalid. See below. |
 | `auth` | map[route] -> secret ref | (empty) | Environment fallback credentials per upstream route. The selected Baseten CLI profile supplies its OAuth or API-key credential automatically. `${VAR}` resolves from env or `~/.config/baseten-switch/env`. |
 | `telemetry_dir` | string | `~/.config/baseten-switch/telemetry` | Private directory containing versioned, monthly JSONL request segments. |
 | `telemetry_enabled` | bool | `true` | Toggle per-request telemetry collection. Disabling collection preserves existing history. |
@@ -28,6 +29,27 @@ SIGHUP. The native Mac app edits the same file through `baseten-switch`.
 | `retry_max` | int | `3` | Gateway-level retry count against upstream failures. |
 | `request_timeout` | duration | `600s` | Hard per-request timeout (Go duration syntax). |
 | `ttft_timeout` | duration | (disabled) | Time-to-first-byte deadline per upstream attempt (Go duration syntax; absent or `0` disables). Expiry before a response begins permits the configured fallback; a final attempt or explicit model choice returns 504. The deadline never interrupts an active stream. Telemetry records `fallback_trigger: "ttft_timeout"`. Malformed or negative values refuse the config at load. Start with `30s` and tune for your workload. Per-client `ttft_timeout` overrides this value. |
+
+### `global.fallback_policy`
+
+```yaml
+global:
+  fallback_policy:
+    on_baseten_429: true
+    on_baseten_5xx: true
+```
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `on_baseten_429` | bool | `true` | Permit one configured protocol-native attempt after an eligible Baseten HTTP 429 response. Off relays the Baseten response and preserves `Retry-After`. |
+| `on_baseten_5xx` | bool | `true` | Permit one configured protocol-native attempt after an eligible Baseten status from 500 through 599. |
+
+The controls apply only when request resolution has a valid native target and
+before response bytes reach the harness. They do not create fallback for
+global routing Off, a native primary, an unknown alias, or a client without a
+native `fallback_route`. They do not expand transport, TTFT, authentication,
+request-build, image, or reasoning-policy fallback for explicit Baseten
+identities.
 
 ### `global.trace_capture`
 
@@ -120,7 +142,7 @@ Each client entry maps one harness to one local bind address.
 | `protocol_shape` | enum: `anthropic`,`openai` | `anthropic` | Wire shape the harness sends to the gateway. It selects the listener handler and native provider: `/v1/messages` and Anthropic for `anthropic`, `/v1/chat/completions` and OpenAI for `openai`. An anthropic listener with `upstream_shape: openai` uses cross-shape translation for Baseten traffic. The reverse translation is unsupported. |
 | `auth_token` | object | (empty) | Incoming-auth: what the harness sends to the gateway. |
 | `default_model` | baseten slug | (required for enabled clients) | Baseten target for requests that do not match an explicit `model_routes` family mapping. Must contain `/`. Disabled clients may omit it while parked. |
-| `model_aliases` | map[alias id] -> baseten slug | (empty) | Anthropic-shape clients only. Defines stable picker and request model IDs. The gateway also synthesizes aliases into `GET /v1/models` for compatibility with older Claude Code gateway-discovery clients. Alias ids must begin with `claude` or `anthropic` and must not shadow real Anthropic model names (`claude-opus-*`, `claude-sonnet-*`, `claude-haiku-*`, `claude-instant-*`, `claude-<digit>*`); violations refuse the config at load. While global routing is On, a request naming an alias or raw Baseten slug is an explicit Baseten choice with no fallback. While Off, it fails locally with guidance to select a native model or turn routing On; no Baseten credential or endpoint is accessed. Unknown gateway aliases remain a loud error. |
+| `model_aliases` | map[alias id] -> baseten slug | (empty) | Anthropic-shape clients only. Defines stable picker and request model IDs. The gateway also synthesizes aliases into `GET /v1/models` for compatibility with older Claude Code gateway-discovery clients. Alias ids must begin with `claude` or `anthropic` and must not shadow real Anthropic model names (`claude-opus-*`, `claude-sonnet-*`, `claude-haiku-*`, `claude-instant-*`, `claude-<digit>*`); violations refuse the config at load. While global routing is On, a request naming an alias or raw Baseten slug is an explicit Baseten primary. Eligible 429 and 5xx responses use `native_fallback_model` when configured. While Off, the request fails locally without consulting Baseten. Unknown gateway aliases remain a loud error. |
 | `model_picker` | object | (absent) | Anthropic-shape clients only. Ordered desired projection into Claude Code's user-level `modelPicker`. An absent block means the integration has not been configured; a present disabled or empty block remains explicit saved intent. See `model_picker` below. |
 | `subagent_model` | string | (empty) | Anthropic-shape clients only. Rewrite target for Claude Code subagent requests. When global routing is On, the rewrite runs before the normal explicit-choice, family-mapping, and default-mapping ladder. When Off, saved subagent configuration is inactive and the original native model passes through. |
 | `subagent_routing` | enum: `on`,`off` | (absent) | Anthropic-shape clients only. Live toggle for the `subagent_model` rewrite, so the menubar can flip it without losing the configured model. `on` enables the rewrite; `off` disables it (sidechain traffic passes untouched, exact factory behavior). Absent means `on` when `subagent_model` is set, so the field exists purely as the off switch. Enabled = `subagent_model` non-empty and `subagent_routing` is not `off`. Validation at load: a value other than empty/`on`/`off`, or `subagent_routing` set while `subagent_model` is empty, is a config-load error. The `baseten-switch claude subagents on|off` verb flips this field then SIGHUPs the gateway; live sessions pick it up on their next sidechain request. |
@@ -131,7 +153,15 @@ Each client entry maps one harness to one local bind address.
 | `responses_compatibility` | object | (absent, all rules `off`) | OpenAI-shape clients only. Configures isolated Responses API safeguards for Baseten attempts. A present block receives the per-rule defaults below; omitting the entire block keeps every rule off. Unknown fields and modes refuse the config. Changes replace the resolved policy on SIGHUP and participate in the listener config hash. |
 | `responses_strip_tool_types` | list[string] | (empty) | OpenAI-shape clients only; the field on an Anthropic-shape client refuses the config at load. Tool types listed here are stripped from `tools[]` before a Baseten `/v1/responses` attempt. An object-form `tool_choice` referencing a stripped type is rewritten; string forms like `auto` are untouched. A native fallback keeps the original body byte-for-byte. Telemetry and stderr logs report stripping. Empty entries are invalid, list order is preserved, and a list change respawns the listener on SIGHUP. |
 | `ttft_timeout` | duration | inherit `global.ttft_timeout` | Per-harness override of the first-byte deadline (see `global.ttft_timeout` for semantics). `0` disables it for this harness even when the global value is set. |
-| `fallback_route` | enum: `anthropic`,`openai` | protocol-native in new configs | Accepts only `NativeRoute(protocol_shape)` or an absent value. It is eligible after default or mapped Baseten policy fails, but is inactive for global Off, native mappings, and explicit alias or raw-slug choices. Anthropic-shape 429 responses relay to the harness without fallback or cooldown; OpenAI-shape 429 responses remain fallback-eligible. |
+| `fallback_route` | enum: `anthropic`,`openai` | protocol-native in new configs | Native provider for an eligible fallback attempt. It must equal `NativeRoute(protocol_shape)`. Global routing Off and native primary routes do not use it. |
+| `native_fallback_model` | string | (empty); `claude-opus-5` for Claude Code in new and migrated configs | Anthropic-shape client target used only when a request starts with a configured Baseten alias or raw slug. Native-origin requests preserve their exact ingress model and body. The value requires `fallback_route`, must be a full Anthropic model ID, and must not be a Baseten slug, configured alias, gateway alias, compatibility sentinel, family token, or whitespace-padded value. OpenAI-shape clients reject this field; managed Codex compatibility requests remain terminal. |
+
+Before a new router process activates an existing configuration, the launcher
+adds `native_fallback_model: claude-opus-5` to the `claude-code` client when
+that client has `fallback_route: anthropic` and no explicit target. The
+migration preserves an existing valid target, writes a unique exact-byte
+backup, preserves the active file's permissions and comments, validates the
+result before installation, and is idempotent.
 
 ### `model_picker`
 

--- a/config/schema.md
+++ b/config/schema.md
@@ -191,8 +191,12 @@ row into Claude settings.
 
 The checked-in new-install template enables the picker and includes every
 default alias. Existing configs without `model_picker` are not changed merely
-by loading them. Typed picker edits preserve bytes outside this subtree and
-validate the complete resulting config before replacement.
+by loading them. For an existing config where this block is absent,
+`claude picker enable` creates an enabled picker with an empty `models` list.
+Add each desired row explicitly with `claude picker add`; enabling alone does
+not copy `model_aliases` into the picker. Typed picker edits preserve bytes
+outside this subtree and validate the complete resulting config before
+replacement.
 
 ### `responses_compatibility`
 

--- a/config/schema.md
+++ b/config/schema.md
@@ -120,7 +120,8 @@ Each client entry maps one harness to one local bind address.
 | `protocol_shape` | enum: `anthropic`,`openai` | `anthropic` | Wire shape the harness sends to the gateway. It selects the listener handler and native provider: `/v1/messages` and Anthropic for `anthropic`, `/v1/chat/completions` and OpenAI for `openai`. An anthropic listener with `upstream_shape: openai` uses cross-shape translation for Baseten traffic. The reverse translation is unsupported. |
 | `auth_token` | object | (empty) | Incoming-auth: what the harness sends to the gateway. |
 | `default_model` | baseten slug | (required for enabled clients) | Baseten target for requests that do not match an explicit `model_routes` family mapping. Must contain `/`. Disabled clients may omit it while parked. |
-| `model_aliases` | map[alias id] -> baseten slug | (empty) | Anthropic-shape clients only. Publishes picker-visible Baseten models to Claude Code's gateway model discovery: the gateway synthesizes them into `GET /v1/models` (Anthropic list shape, `?limit` respected), and Claude Code launched with `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` shows them in the `/model` picker. Alias ids must begin with `claude` or `anthropic` (the picker drops everything else before caching) and must not shadow real Anthropic model names (`claude-opus-*`, `claude-sonnet-*`, `claude-haiku-*`, `claude-instant-*`, `claude-<digit>*`); violations refuse the config at load. While global routing is On, a request naming an alias or raw Baseten slug is an explicit Baseten choice with no fallback. While Off, it fails locally with guidance to select a native model or turn routing On; no Baseten credential or endpoint is accessed. Unknown gateway aliases remain a loud error. |
+| `model_aliases` | map[alias id] -> baseten slug | (empty) | Anthropic-shape clients only. Defines stable picker and request model IDs. The gateway also synthesizes aliases into `GET /v1/models` for compatibility with older Claude Code gateway-discovery clients. Alias ids must begin with `claude` or `anthropic` and must not shadow real Anthropic model names (`claude-opus-*`, `claude-sonnet-*`, `claude-haiku-*`, `claude-instant-*`, `claude-<digit>*`); violations refuse the config at load. While global routing is On, a request naming an alias or raw Baseten slug is an explicit Baseten choice with no fallback. While Off, it fails locally with guidance to select a native model or turn routing On; no Baseten credential or endpoint is accessed. Unknown gateway aliases remain a loud error. |
+| `model_picker` | object | (absent) | Anthropic-shape clients only. Ordered desired projection into Claude Code's user-level `modelPicker`. An absent block means the integration has not been configured; a present disabled or empty block remains explicit saved intent. See `model_picker` below. |
 | `subagent_model` | string | (empty) | Anthropic-shape clients only. Rewrite target for Claude Code subagent requests. When global routing is On, the rewrite runs before the normal explicit-choice, family-mapping, and default-mapping ladder. When Off, saved subagent configuration is inactive and the original native model passes through. |
 | `subagent_routing` | enum: `on`,`off` | (absent) | Anthropic-shape clients only. Live toggle for the `subagent_model` rewrite, so the menubar can flip it without losing the configured model. `on` enables the rewrite; `off` disables it (sidechain traffic passes untouched, exact factory behavior). Absent means `on` when `subagent_model` is set, so the field exists purely as the off switch. Enabled = `subagent_model` non-empty and `subagent_routing` is not `off`. Validation at load: a value other than empty/`on`/`off`, or `subagent_routing` set while `subagent_model` is empty, is a config-load error. The `baseten-switch claude subagents on|off` verb flips this field then SIGHUPs the gateway; live sessions pick it up on their next sidechain request. |
 | `model_routes` | map[family]string | GLM-5.2 for fable, opus, sonnet, and haiku in new configs | Anthropic-shape per-family mappings. Keys are exactly `fable`, `opus`, `sonnet`, or `haiku`. `native` selects Anthropic; a configured alias or raw Baseten slug selects Baseten. A missing family uses the client's `default_model`. While global routing is Off, every mapping is dormant but remains editable. Baseten mappings retain the protocol-native fallback; native mappings do not activate fallback. |
@@ -131,6 +132,37 @@ Each client entry maps one harness to one local bind address.
 | `responses_strip_tool_types` | list[string] | (empty) | OpenAI-shape clients only; the field on an Anthropic-shape client refuses the config at load. Tool types listed here are stripped from `tools[]` before a Baseten `/v1/responses` attempt. An object-form `tool_choice` referencing a stripped type is rewritten; string forms like `auto` are untouched. A native fallback keeps the original body byte-for-byte. Telemetry and stderr logs report stripping. Empty entries are invalid, list order is preserved, and a list change respawns the listener on SIGHUP. |
 | `ttft_timeout` | duration | inherit `global.ttft_timeout` | Per-harness override of the first-byte deadline (see `global.ttft_timeout` for semantics). `0` disables it for this harness even when the global value is set. |
 | `fallback_route` | enum: `anthropic`,`openai` | protocol-native in new configs | Accepts only `NativeRoute(protocol_shape)` or an absent value. It is eligible after default or mapped Baseten policy fails, but is inactive for global Off, native mappings, and explicit alias or raw-slug choices. Anthropic-shape 429 responses relay to the harness without fallback or cooldown; OpenAI-shape 429 responses remain fallback-eligible. |
+
+### `model_picker`
+
+`model_picker` curates the Baseten rows that Switch appends to Claude Code's
+native `/model` lineup. It does not replace `model_aliases`, enforce routing,
+or change Claude-owned native rows. Organization-managed Claude settings and
+Claude's `availableModels` policy remain authoritative and may prevent a
+configured row from appearing.
+
+```yaml
+model_picker:
+  enabled: true
+  models:
+    - alias: claude-baseten-glm-5-2
+```
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | bool | `false` | When true, the Claude adapter synchronizes these rows. When false, routing aliases remain configured but Switch-owned picker rows are removed. |
+| `models` | ordered list[object] | `[]` | Saved row order. An empty list is valid. Aliases must be unique. |
+| `models[].alias` | string | (required) | Stable routing identity. It must exist in the same client's `model_aliases`. |
+
+Labels and descriptions are not configurable in v1. Switch resolves the exact
+alias slug through local model metadata, appends ` via Baseten` to the display
+name, and uses the fixed description `Served by Baseten.` when projecting the
+row into Claude settings.
+
+The checked-in new-install template enables the picker and includes every
+default alias. Existing configs without `model_picker` are not changed merely
+by loading them. Typed picker edits preserve bytes outside this subtree and
+validate the complete resulting config before replacement.
 
 ### `responses_compatibility`
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -64,11 +64,13 @@ the Claude client's `model_aliases`. The gateway config owns desired alias
 membership and order. The Claude adapter generates presentation, safely
 projects rows into user settings, and reports policy or runtime visibility
 without weakening managed Claude configuration.
-Use `claude picker enable --dry-run --json` to preview every configured alias,
-including aliases that share a slug. If `add <slug> --dry-run --json` reports
-multiple alias choices, repeat it with `--alias <alias>`. Converting an
-existing Claude picker from replacement mode requires the explicit
-`--convert-replacement-mode` flag on `enable` or `sync`.
+When no picker configuration exists, `claude picker enable` creates an enabled
+picker with no rows. Add models explicitly with `claude picker add <slug>`;
+enable does not copy `model_aliases` into the picker. If
+`add <slug> --dry-run --json` reports multiple alias choices, repeat it with
+`--alias <alias>`.
+Converting an existing Claude picker from replacement mode requires the
+explicit `--convert-replacement-mode` flag on `enable` or `sync`.
 
 ## Module layout
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -49,7 +49,7 @@ API-key profiles and reports the active type through
 up, down, restart, status
 on, off
 config init, config reset
-claude on|off|status|subagents|route|reasoning
+claude on|off|status|subagents|route|reasoning|picker
 codex on|off|status|route|reasoning
 whoami, auth login, doctor, spend
 gateway start|stop|restart|status
@@ -58,6 +58,17 @@ door
 
 Run `baseten-switch <command> --help` for the current flags and environment
 overrides.
+
+`claude picker` manages the ordered `model_picker` projection stored beside
+the Claude client's `model_aliases`. The gateway config owns desired alias
+membership and order. The Claude adapter generates presentation, safely
+projects rows into user settings, and reports policy or runtime visibility
+without weakening managed Claude configuration.
+Use `claude picker enable --dry-run --json` to preview every configured alias,
+including aliases that share a slug. If `add <slug> --dry-run --json` reports
+multiple alias choices, repeat it with `--alias <alias>`. Converting an
+existing Claude picker from replacement mode requires the explicit
+`--convert-replacement-mode` flag on `enable` or `sync`.
 
 ## Module layout
 

--- a/gateway/cmd/baseten-switch/claude_adapter.go
+++ b/gateway/cmd/baseten-switch/claude_adapter.go
@@ -90,7 +90,7 @@ var (
 
 func cmdClaude(args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: baseten-switch claude on|off|status|subagents [<model>|on|inherit]|route [<family> <target|default>]|reasoning baseten <model> off|follow-harness|effort <value>|default  (start/stop are aliases for on/off)")
+		fmt.Fprintln(os.Stderr, "usage: baseten-switch claude on|off|status|picker <status|enable|list|add|remove|move|sync|disable>|subagents [<model>|on|inherit]|route [<family> <target|default>]|reasoning baseten <model> off|follow-harness|effort <value>|default  (start/stop are aliases for on/off)")
 		return 2
 	}
 	if replayed, rc := preflightClaudeTerminalReplay(args); replayed {
@@ -100,14 +100,20 @@ func cmdClaude(args []string) int {
 	if err != nil {
 		if args[0] == "route" ||
 			args[0] == "subagents" ||
-			args[0] == "reasoning" {
+			args[0] == "reasoning" ||
+			args[0] == "picker" {
 			opts, _, parseErr := parseMutationOptions(args[1:])
+			if args[0] == "picker" {
+				opts, _, parseErr = parsePickerOptions(args[1:])
+			}
 			if parseErr == nil && opts.JSON {
 				operation := "set_claude_route"
 				if args[0] == "subagents" {
 					operation = "set_claude_subagents"
 				} else if args[0] == "reasoning" {
 					operation = "set_model_reasoning"
+				} else if args[0] == "picker" {
+					operation = "set_claude_picker"
 				}
 				return failMutation(opts, os.Stdout, mutationResult{
 					Operation: operation,
@@ -121,11 +127,19 @@ func cmdClaude(args []string) int {
 	}
 	switch args[0] {
 	case "on", "start":
-		return a.on()
+		rc := a.on()
+		if rc == 0 && a.modelPickerEnabled() {
+			if err := a.syncModelPicker(true); err != nil {
+				fmt.Fprintf(a.out, "claude on: model picker pending: %v\n", err)
+			}
+		}
+		return rc
 	case "off", "stop":
 		return a.off()
 	case "status":
 		return a.status(os.Stdout)
+	case "picker":
+		return a.picker(args[1:], os.Stdout)
 	case "subagents":
 		return a.subagents(args[1:], os.Stdout)
 	case "route":
@@ -133,7 +147,7 @@ func cmdClaude(args []string) int {
 	case "reasoning":
 		return runClientReasoning(mutationSurfaceClaude, a.clientName, args[1:], os.Stdout)
 	default:
-		fmt.Fprintf(os.Stderr, "unknown claude subcommand: %s (use on|off|status|subagents|route|reasoning)\n", args[0])
+		fmt.Fprintf(os.Stderr, "unknown claude subcommand: %s (use on|off|status|picker|subagents|route|reasoning)\n", args[0])
 		return 2
 	}
 }
@@ -168,6 +182,12 @@ func preflightClaudeTerminalReplay(args []string) (bool, int) {
 			return false, 0
 		}
 		spec.Surface = mutationSurfaceClaude
+	case "picker":
+		opts, spec, err = pickerTerminalReplayRequest(args[1:])
+		if err != nil {
+			return false, 0
+		}
+		spec.Surface = mutationSurfaceClaude
 	default:
 		return false, 0
 	}
@@ -185,7 +205,8 @@ type claudeAdapter struct {
 	desiredPort  string            // door port the anthropic-shape claude-code client rides
 	gatewayPorts map[string]bool   // every local port we consider "ours" (door binds + router listeners)
 	modelAliases map[string]string // the target client's model_aliases (subagent alias validation)
-	out          io.Writer         // human-readable action/warning output
+	modelPicker  *config.ModelPicker
+	out          io.Writer // human-readable action/warning output
 }
 
 // claudeBeforeSettingsMutation is a test seam for changes after the adapter
@@ -248,6 +269,7 @@ func newClaudeAdapterFromEnv() (*claudeAdapter, error) {
 		desiredPort:  port,
 		gatewayPorts: ports,
 		modelAliases: aliases,
+		modelPicker:  claudeConfiguredModelPicker(f, clientName),
 		out:          os.Stderr,
 	}, nil
 }
@@ -545,16 +567,17 @@ func envString(env map[string]any, key string) (string, bool) {
 // `on`; a mismatch at `off` downgrades restore to strip-only-owned, while a
 // changed resolved target is refused.
 type claudeBackup struct {
-	ConfigPath      string             `json:"config_path"`
-	ResolvedPath    string             `json:"resolved_path,omitempty"`
-	WrittenIdentity *safefile.Identity `json:"written_identity,omitempty"`
-	Values          map[string]string  `json:"values"`
-	Missing         []string           `json:"missing"`
-	EnvExisted      bool               `json:"env_existed"`
-	Model           string             `json:"model,omitempty"`
-	ModelMissing    bool               `json:"model_missing"`
-	Existed         bool               `json:"existed"`
-	WrittenHash     string             `json:"written_hash"`
+	ConfigPath      string                   `json:"config_path"`
+	ResolvedPath    string                   `json:"resolved_path,omitempty"`
+	WrittenIdentity *safefile.Identity       `json:"written_identity,omitempty"`
+	Values          map[string]string        `json:"values"`
+	Missing         []string                 `json:"missing"`
+	EnvExisted      bool                     `json:"env_existed"`
+	Model           string                   `json:"model,omitempty"`
+	ModelMissing    bool                     `json:"model_missing"`
+	Existed         bool                     `json:"existed"`
+	WrittenHash     string                   `json:"written_hash"`
+	ModelPicker     *claudeModelPickerBackup `json:"model_picker,omitempty"`
 }
 
 // claudeBackupPath keys the backup file by sha256(settings path) so
@@ -640,6 +663,15 @@ func cloneClaudeBackup(bak *claudeBackup) *claudeBackup {
 	if bak.WrittenIdentity != nil {
 		identity := *bak.WrittenIdentity
 		cloned.WrittenIdentity = &identity
+	}
+	if bak.ModelPicker != nil {
+		picker := *bak.ModelPicker
+		picker.Original = append(json.RawMessage(nil), bak.ModelPicker.Original...)
+		picker.WrittenRows = make([]json.RawMessage, len(bak.ModelPicker.WrittenRows))
+		for i := range bak.ModelPicker.WrittenRows {
+			picker.WrittenRows[i] = append(json.RawMessage(nil), bak.ModelPicker.WrittenRows[i]...)
+		}
+		cloned.ModelPicker = &picker
 	}
 	return &cloned
 }
@@ -1028,8 +1060,11 @@ func (a *claudeAdapter) off() int {
 		}
 	}
 	a.fixModelAlias(root, bak)
+	_, pickerCleanupErr := cleanupModelPicker(root, bak.ModelPicker, true)
 
-	if !bak.Existed && len(root) == 0 {
+	var writtenRaw []byte
+	var committed *safefile.Snapshot
+	if !bak.Existed && len(root) == 0 && pickerCleanupErr == nil {
 		if snap.FinalLinked {
 			fmt.Fprintf(a.out, "claude off: refusing to remove linked settings target %s; backup retained\n", a.settingsPath)
 			return 1
@@ -1040,11 +1075,20 @@ func (a *claudeAdapter) off() int {
 		}
 		fmt.Fprintf(a.out, "claude: off (%s did not exist before 'on'; removed)\n", a.settingsPath)
 	} else {
-		if _, _, err := writeClaudeSettings(snap, root); err != nil {
+		writtenRaw, committed, err = writeClaudeSettings(snap, root)
+		if err != nil {
 			fmt.Fprintf(a.out, "claude off: %v\n", err)
 			return 1
 		}
 		fmt.Fprintf(a.out, "claude: off (restored %s from backup)\n", a.settingsPath)
+	}
+	if pickerCleanupErr != nil {
+		if err := retainPickerOnlyBackup(a.backupPath, bak, writtenRaw, committed); err != nil {
+			fmt.Fprintf(a.out, "claude off: base wiring was removed, but modelPicker needs manual resolution (%v) and its recovery backup could not be retained: %v\n", pickerCleanupErr, err)
+			return 1
+		}
+		fmt.Fprintf(a.out, "claude off: base wiring removed; modelPicker preserved for manual resolution: %v\n", pickerCleanupErr)
+		return 1
 	}
 	if err := os.Remove(a.backupPath); err != nil {
 		fmt.Fprintf(a.out, "claude off: remove backup: %v\n", err)
@@ -1104,8 +1148,20 @@ func (a *claudeAdapter) offStripOnly(root map[string]any, snap *safefile.Snapsho
 	if a.fixModelAlias(root, bak) {
 		changed = true
 	}
+	var pickerCleanupErr error
+	if bak != nil && bak.ModelPicker != nil {
+		pickerChanged, pickerErr := cleanupModelPicker(root, bak.ModelPicker, false)
+		if pickerErr != nil {
+			pickerCleanupErr = pickerErr
+		} else {
+			changed = changed || pickerChanged
+		}
+	}
+	var writtenRaw []byte
+	var committed *safefile.Snapshot
 	if changed {
-		if _, _, err := writeClaudeSettings(snap, root); err != nil {
+		writtenRaw, committed, err = writeClaudeSettings(snap, root)
+		if err != nil {
 			fmt.Fprintf(a.out, "claude off: %v\n", err)
 			return 1
 		}
@@ -1116,6 +1172,18 @@ func (a *claudeAdapter) offStripOnly(root map[string]any, snap *safefile.Snapsho
 				fmt.Fprintf(a.out, "claude off: settings changed before backup cleanup: %v\n", err)
 				return 1
 			}
+		}
+		if pickerCleanupErr != nil {
+			if !changed {
+				writtenRaw = snap.Data
+				committed = snap
+			}
+			if err := retainPickerOnlyBackup(a.backupPath, bak, writtenRaw, committed); err != nil {
+				fmt.Fprintf(a.out, "claude off: base wiring was removed, but modelPicker needs manual resolution (%v) and its recovery backup could not be retained: %v\n", pickerCleanupErr, err)
+				return 1
+			}
+			fmt.Fprintf(a.out, "claude off: base wiring removed; modelPicker preserved for manual resolution: %v\n", pickerCleanupErr)
+			return 1
 		}
 		if err := os.Remove(a.backupPath); err != nil {
 			fmt.Fprintf(a.out, "claude off: remove backup: %v\n", err)
@@ -1131,6 +1199,21 @@ func (a *claudeAdapter) offStripOnly(root map[string]any, snap *safefile.Snapsho
 		fmt.Fprintf(a.out, "claude: off (noop; %s is not gateway-managed)\n", a.settingsPath)
 	}
 	return 0
+}
+
+func retainPickerOnlyBackup(path string, bak *claudeBackup, raw []byte, snap *safefile.Snapshot) error {
+	if bak == nil || bak.ModelPicker == nil || snap == nil {
+		return fmt.Errorf("modelPicker recovery state is incomplete")
+	}
+	bak.Values = map[string]string{}
+	bak.Missing = nil
+	bak.EnvExisted = true
+	bak.Model = ""
+	bak.ModelMissing = false
+	bak.Existed = true
+	bak.WrittenHash = sha256Hex(raw)
+	recordClaudeBackupFile(bak, snap)
+	return saveClaudeBackup(path, bak)
 }
 
 // reportUnrestoredBackupValues explains values that the conservative
@@ -1154,14 +1237,14 @@ func (a *claudeAdapter) reportUnrestoredBackupValues(root map[string]any, bak *c
 // fixModelAlias handles the the model-discovery contract persisted-alias
 // trap: a model picked via the gateway's /v1/models aliases persists
 // in settings.json, and Anthropic rejects it once routing is off. If
-// the current model looks like ours (claude-baseten-*), reset it to the
-// backed-up value or delete it. Reports whether root changed.
+// the current model is in either gateway alias namespace, reset it to a
+// non-gateway backed-up value or delete it. Reports whether root changed.
 func (a *claudeAdapter) fixModelAlias(root map[string]any, bak *claudeBackup) bool {
 	m, ok := root["model"].(string)
-	if !ok || !strings.HasPrefix(m, claudeAliasPrefix) {
+	if !ok || !gateway.InAliasNamespace(m) {
 		return false
 	}
-	if bak != nil && bak.Model != "" && !strings.HasPrefix(bak.Model, claudeAliasPrefix) {
+	if bak != nil && bak.Model != "" && !gateway.InAliasNamespace(bak.Model) {
 		root["model"] = bak.Model
 		fmt.Fprintf(a.out, "note: persisted model %q is a gateway alias; reset to backed-up model %q\n", m, bak.Model)
 		return true

--- a/gateway/cmd/baseten-switch/claude_adapter_test.go
+++ b/gateway/cmd/baseten-switch/claude_adapter_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -510,6 +511,28 @@ func TestClaudeOffResetsPersistedModelAlias(t *testing.T) {
 			t.Errorf("expected alias note, got %q", out.String())
 		}
 	})
+}
+
+func TestClaudeOffCleansBothPersistedAliasNamespaces(t *testing.T) {
+	for _, alias := range []string{
+		"claude-baseten-glm-5-2",
+		"anthropic-baseten-glm-5-2",
+	} {
+		t.Run(alias, func(t *testing.T) {
+			a, out := testAdapter(t)
+			writeSettingsFile(t, a, fmt.Sprintf(`{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:8081"},"model":%q}`, alias))
+			if code := a.off(); code != 0 {
+				t.Fatalf("off = %d", code)
+			}
+			after := readTree(t, a.settingsPath)
+			if _, ok := after["model"]; ok {
+				t.Fatalf("persisted alias was not removed: %v", after["model"])
+			}
+			if !strings.Contains(out.String(), "gateway alias") {
+				t.Fatalf("expected alias cleanup note, got %q", out.String())
+			}
+		})
+	}
 }
 
 func TestClaudeOnPreservesOtherSettingsContent(t *testing.T) {

--- a/gateway/cmd/baseten-switch/claude_picker.go
+++ b/gateway/cmd/baseten-switch/claude_picker.go
@@ -26,6 +26,10 @@ import (
 
 const claudeModelPickerMinVersion = "2.1.243"
 const claudeModelPickerVersionOutputLimit = 4096
+const claudeStandardContextTokens int64 = 200_000
+const claudeOneMillionContextTokens int64 = 1_000_000
+const claudeOneMillionContextSuffix = "[1m]"
+const claudePickerContextMinimumErrorCode = "context_window_below_claude_picker_minimum"
 
 type claudeModelPickerBackup struct {
 	OriginalMissing          bool              `json:"original_missing,omitempty"`
@@ -36,21 +40,22 @@ type claudeModelPickerBackup struct {
 }
 
 type claudePickerStatus struct {
-	Enabled                bool   `json:"enabled"`
-	Configuration          string `json:"configuration"`
-	UserFileSync           string `json:"user_file_sync"`
-	KnownPolicy            string `json:"known_policy"`
-	AllowlistPolicy        string `json:"allowlist_policy"`
-	ManagedPolicy          string `json:"managed_policy"`
-	ReplacementMode        string `json:"replacement_mode"`
-	RuntimeVerification    string `json:"runtime_verification"`
-	ConfiguredRows         int    `json:"configured_rows"`
-	InstalledRows          int    `json:"installed_rows"`
-	SettingsPath           string `json:"settings_path"`
-	LegacyDiscoveryEnabled bool   `json:"legacy_discovery_enabled"`
-	SavedModel             string `json:"saved_model,omitempty"`
-	SavedModelUnconfigured bool   `json:"saved_model_unconfigured,omitempty"`
-	Message                string `json:"message,omitempty"`
+	Enabled                   bool   `json:"enabled"`
+	Configuration             string `json:"configuration"`
+	UserFileSync              string `json:"user_file_sync"`
+	KnownPolicy               string `json:"known_policy"`
+	AllowlistPolicy           string `json:"allowlist_policy"`
+	ManagedPolicy             string `json:"managed_policy"`
+	ReplacementMode           string `json:"replacement_mode"`
+	RuntimeVerification       string `json:"runtime_verification"`
+	ConfiguredRows            int    `json:"configured_rows"`
+	InstalledRows             int    `json:"installed_rows"`
+	SettingsPath              string `json:"settings_path"`
+	LegacyDiscoveryEnabled    bool   `json:"legacy_discovery_enabled"`
+	SavedModel                string `json:"saved_model,omitempty"`
+	SavedModelUnconfigured    bool   `json:"saved_model_unconfigured,omitempty"`
+	SavedModelContextMismatch bool   `json:"saved_model_context_mismatch,omitempty"`
+	Message                   string `json:"message,omitempty"`
 }
 
 type pickerReceiptState struct {
@@ -58,6 +63,11 @@ type pickerReceiptState struct {
 	previousToken string
 	adminBefore   *routingAdminStatus
 	activationErr error
+}
+
+type pickerConfigProjection struct {
+	raw           []byte
+	contextTokens map[string]int64
 }
 
 type claudePickerPreview struct {
@@ -80,6 +90,35 @@ type claudePickerAliasAmbiguity struct {
 
 type pickerManualResolutionError struct{ message string }
 
+type pickerContextMinimumError struct {
+	slug   string
+	tokens int64
+}
+
+func (e *pickerContextMinimumError) Error() string {
+	return fmt.Sprintf(
+		"Baseten model %q has a known context limit of %d tokens, below Claude Code's 200000-token model picker minimum; remove it from model_picker or select a model with at least 200000 tokens",
+		e.slug,
+		e.tokens,
+	)
+}
+
+func isPickerContextMinimum(err error) bool {
+	var target *pickerContextMinimumError
+	return errors.As(err, &target)
+}
+
+type claudePickerCatalogResponse struct {
+	State         string                     `json:"state"`
+	Models        []claudePickerCatalogModel `json:"models"`
+	ContextLimits []claudePickerCatalogModel `json:"context_limits"`
+}
+
+type claudePickerCatalogModel struct {
+	Slug          string `json:"slug"`
+	ContextTokens int64  `json:"context_tokens"`
+}
+
 func (e *pickerManualResolutionError) Error() string { return e.message }
 
 func manualPickerErrorf(format string, args ...any) error {
@@ -95,6 +134,11 @@ var (
 	claudePickerLookPath       = exec.LookPath
 	claudePickerCommand        = boundedClaudePickerCommand
 	claudePickerVersionTimeout = 2 * time.Second
+	fetchClaudePickerCatalog   = func(adminAddr string) (claudePickerCatalogResponse, error) {
+		var response claudePickerCatalogResponse
+		err := getJSON(adminAddr, "/v1/admin/model-catalog", &response)
+		return response, err
+	}
 )
 
 type boundedOutputBuffer struct {
@@ -157,20 +201,187 @@ func (a *claudeAdapter) reloadModelPicker() error {
 	return nil
 }
 
-func claudePickerRows(picker *config.ModelPicker, aliases map[string]string) []any {
+func claudePickerRows(
+	picker *config.ModelPicker,
+	aliases map[string]string,
+	contextTokens map[string]int64,
+	preservedOneMillionAliases map[string]bool,
+) ([]any, error) {
 	if picker == nil || !picker.Enabled {
-		return nil
+		return nil, nil
 	}
 	rows := make([]any, 0, len(picker.Models))
+	seenAliases := make(map[string]struct{}, len(picker.Models))
 	for _, model := range picker.Models {
+		if _, duplicate := seenAliases[model.Alias]; duplicate {
+			return nil, fmt.Errorf(
+				"model picker alias %q is duplicated",
+				model.Alias,
+			)
+		}
+		seenAliases[model.Alias] = struct{}{}
 		slug := aliases[model.Alias]
 		label := modelmeta.ResolveBaseten(slug).DisplayName + " via Baseten"
+		modelID := model.Alias
+		// A non-nil map is an authoritative projection. Missing and zero
+		// exact-model values are conservative. A nil map means the trusted
+		// projection is unavailable, so retain a still-owned prior suffix.
+		knownTokens, known := contextTokens[slug]
+		if contextTokens != nil && known && knownTokens > 0 &&
+			knownTokens < claudeStandardContextTokens {
+			return nil, &pickerContextMinimumError{
+				slug: slug, tokens: knownTokens,
+			}
+		}
+		useOneMillion := contextTokens != nil && known &&
+			knownTokens >= claudeOneMillionContextTokens
+		if contextTokens == nil && preservedOneMillionAliases[model.Alias] {
+			useOneMillion = true
+		}
+		if useOneMillion {
+			modelID += claudeOneMillionContextSuffix
+		}
 		row := map[string]any{
-			"model": model.Alias, "label": label, "description": "Served by Baseten.",
+			"model": modelID, "label": label, "description": "Served by Baseten.",
 		}
 		rows = append(rows, row)
 	}
-	return rows
+	return rows, nil
+}
+
+func copyPickerAliases(aliases map[string]string) map[string]string {
+	copy := make(map[string]string, len(aliases))
+	for alias, slug := range aliases {
+		copy[alias] = slug
+	}
+	return copy
+}
+
+func (a *claudeAdapter) preflightPickerContext(
+	picker *config.ModelPicker,
+	aliases map[string]string,
+) error {
+	response, err := fetchClaudePickerCatalog(
+		envDefault("BASETEN_SWITCH_ADMIN_ADDR", gateway.DefaultAdminAddr),
+	)
+	if err != nil {
+		// Without a trusted local projection, new rows remain in Claude Code's
+		// conservative 200K context bucket. Sync preserves any still-owned
+		// [1m] row separately when the whole projection is unavailable.
+		return nil
+	}
+	models := response.ContextLimits
+	if models == nil {
+		if response.State != "ready" {
+			return nil
+		}
+		// Compatibility with a running gateway that predates the complete
+		// exact-context projection. Its live account rows are still trusted,
+		// but cannot prove anything about configured models absent from them.
+		models = response.Models
+	}
+	contextTokens := make(map[string]int64, len(models))
+	for _, model := range models {
+		if model.Slug != "" {
+			contextTokens[model.Slug] = model.ContextTokens
+		}
+	}
+	_, err = claudePickerRows(picker, aliases, contextTokens, nil)
+	return err
+}
+
+func normalizeClaudePickerModelID(modelID string) (string, bool) {
+	if len(modelID) >= len(claudeOneMillionContextSuffix) &&
+		strings.EqualFold(
+			modelID[len(modelID)-len(claudeOneMillionContextSuffix):],
+			claudeOneMillionContextSuffix,
+		) {
+		return modelID[:len(modelID)-len(claudeOneMillionContextSuffix)], true
+	}
+	return modelID, false
+}
+
+func desiredPickerHasOneMillionAlias(rows []any, alias string) bool {
+	for _, row := range rows {
+		base, oneMillion := normalizeClaudePickerModelID(rowModel(row))
+		if oneMillion && base == alias {
+			return true
+		}
+	}
+	return false
+}
+
+func ownedOneMillionPickerAliases(
+	root map[string]any,
+	backup *claudeModelPickerBackup,
+) map[string]bool {
+	if backup == nil || backup.WrittenPickerFingerprint == "" {
+		return nil
+	}
+	obj, exists, err := modelPickerObject(root)
+	if err != nil || !exists {
+		return nil
+	}
+	rows, err := modelPickerOptions(obj)
+	if err != nil ||
+		!anchoredRowsEqual(rows, backup.WrittenRows, backup.WrittenAnchor) {
+		return nil
+	}
+	preserved := map[string]bool{}
+	for _, raw := range backup.WrittenRows {
+		var row map[string]any
+		if json.Unmarshal(raw, &row) != nil {
+			return nil
+		}
+		modelID, _ := row["model"].(string)
+		if alias, oneMillion := normalizeClaudePickerModelID(modelID); oneMillion {
+			if alias != "" {
+				preserved[alias] = true
+			}
+		}
+	}
+	return preserved
+}
+
+func pickerContextTokensFromAdmin(
+	status routingAdminStatus,
+	clientName string,
+) map[string]int64 {
+	for _, client := range status.Clients {
+		if client.Name != clientName || client.ModelPicker == nil {
+			continue
+		}
+		contextTokens := make(map[string]int64, len(client.ModelPicker.Models))
+		for _, model := range client.ModelPicker.Models {
+			if model.Slug != "" {
+				contextTokens[model.Slug] = model.ContextTokens
+			}
+		}
+		return contextTokens
+	}
+	return nil
+}
+
+func (a *claudeAdapter) activePickerContextTokens() map[string]int64 {
+	if state, _ := classifyPidfile(gatewayPidfilePath()); state != pidfileAlive {
+		return nil
+	}
+	raw, _, err := readExactConfig(a.configPath)
+	if err != nil {
+		return nil
+	}
+	status, err := fetchRoutingAdminStatus(
+		envDefault("BASETEN_SWITCH_ADMIN_ADDR", gateway.DefaultAdminAddr),
+	)
+	if err != nil ||
+		validateMutationAdminStatus(
+			status,
+			a.configPath,
+			exactConfigHash(raw),
+		) != nil {
+		return nil
+	}
+	return pickerContextTokensFromAdmin(status, a.clientName)
 }
 
 func canonicalJSON(v any) (json.RawMessage, error) {
@@ -450,35 +661,50 @@ func restorePickerBackupPreimage(path string, pre pickerBackupPreimage) error {
 }
 
 func (a *claudeAdapter) syncModelPicker(requireVersion bool, allowReplacementConversion ...bool) error {
-	projectionRaw, err := func() ([]byte, error) {
+	projection, err := func() (pickerConfigProjection, error) {
 		configLock, lockErr := acquireConfigMutationLock(a.configPath)
 		if lockErr != nil {
-			return nil, fmt.Errorf("lock picker config projection: %w", lockErr)
+			return pickerConfigProjection{}, fmt.Errorf("lock picker config projection: %w", lockErr)
 		}
 		defer configLock.close()
 		if recoverErr := recoverInterruptedExactConfigCommit(a.configPath); recoverErr != nil {
-			return nil, fmt.Errorf("recover picker config projection: %w", recoverErr)
+			return pickerConfigProjection{}, fmt.Errorf("recover picker config projection: %w", recoverErr)
 		}
 		raw, _, readErr := readExactConfig(a.configPath)
 		if readErr != nil {
-			return nil, readErr
+			return pickerConfigProjection{}, readErr
 		}
 		if reloadErr := a.reloadModelPicker(); reloadErr != nil {
-			return nil, reloadErr
+			return pickerConfigProjection{}, reloadErr
 		}
 		if current, _, readErr := readExactConfig(a.configPath); readErr != nil || !bytes.Equal(current, raw) {
-			return nil, fmt.Errorf("picker config changed while loading its settings projection; retry sync")
+			return pickerConfigProjection{}, fmt.Errorf("picker config changed while loading its settings projection; retry sync")
 		}
-		if state, _ := classifyPidfile(gatewayPidfilePath()); state == pidfileAlive {
-			admin, adminErr := fetchRoutingAdminStatus(envDefault("BASETEN_SWITCH_ADMIN_ADDR", gateway.DefaultAdminAddr))
-			if adminErr != nil {
-				return nil, fmt.Errorf("verify active picker config: %w", adminErr)
+		result := pickerConfigProjection{raw: raw}
+		state, _ := classifyPidfile(gatewayPidfilePath())
+		admin, adminErr := fetchRoutingAdminStatus(
+			envDefault("BASETEN_SWITCH_ADMIN_ADDR", gateway.DefaultAdminAddr),
+		)
+		if adminErr != nil && state == pidfileAlive {
+			return pickerConfigProjection{}, fmt.Errorf("verify active picker config: %w", adminErr)
+		}
+		if adminErr == nil {
+			activeErr := validateMutationAdminStatus(
+				admin,
+				a.configPath,
+				exactConfigHash(raw),
+			)
+			if activeErr != nil && state == pidfileAlive {
+				return pickerConfigProjection{}, fmt.Errorf("picker config is not active: %w", activeErr)
 			}
-			if activeErr := validateMutationAdminStatus(admin, a.configPath, exactConfigHash(raw)); activeErr != nil {
-				return nil, fmt.Errorf("picker config is not active: %w", activeErr)
+			if activeErr == nil {
+				result.contextTokens = pickerContextTokensFromAdmin(
+					admin,
+					a.clientName,
+				)
 			}
 		}
-		return raw, nil
+		return result, nil
 	}()
 	if err != nil {
 		return err
@@ -488,7 +714,7 @@ func (a *claudeAdapter) syncModelPicker(requireVersion bool, allowReplacementCon
 		return err
 	}
 	defer lock.close()
-	if current, _, readErr := readExactConfig(a.configPath); readErr != nil || !bytes.Equal(current, projectionRaw) {
+	if current, _, readErr := readExactConfig(a.configPath); readErr != nil || !bytes.Equal(current, projection.raw) {
 		return fmt.Errorf("picker config changed before settings lock acquisition; retry sync")
 	}
 	if a.modelPickerEnabled() && requireVersion {
@@ -529,7 +755,15 @@ func (a *claudeAdapter) syncModelPicker(requireVersion bool, allowReplacementCon
 		}
 		recordClaudeBackupFile(bak, snap)
 	}
-	desired := claudePickerRows(a.modelPicker, a.modelAliases)
+	desired, err := claudePickerRows(
+		a.modelPicker,
+		a.modelAliases,
+		projection.contextTokens,
+		ownedOneMillionPickerAliases(root, bak.ModelPicker),
+	)
+	if err != nil {
+		return fmt.Errorf("project Claude model picker: %w", err)
+	}
 	allowConversion := len(allowReplacementConversion) > 0 && allowReplacementConversion[0]
 	pickerBackup, changed, err := installModelPickerWithOptions(root, desired, bak.ModelPicker, allowConversion)
 	if err != nil {
@@ -538,7 +772,7 @@ func (a *claudeAdapter) syncModelPicker(requireVersion bool, allowReplacementCon
 	bak.ModelPicker = pickerBackup
 	projectionCurrent := func() bool {
 		current, _, readErr := readExactConfig(a.configPath)
-		return readErr == nil && bytes.Equal(current, projectionRaw)
+		return readErr == nil && bytes.Equal(current, projection.raw)
 	}
 	if !projectionCurrent() {
 		return fmt.Errorf("picker config changed before staging its settings projection; retry sync")
@@ -714,7 +948,8 @@ func (a *claudeAdapter) currentPickerStatus() (claudePickerStatus, error) {
 	}
 	if saved, ok := root["model"].(string); ok {
 		status.SavedModel = saved
-		if _, aliasExists := a.modelAliases[saved]; aliasExists && pickerModelIndex(a.modelPickerModels(), saved) < 0 {
+		savedAlias, _ := normalizeClaudePickerModelID(saved)
+		if _, aliasExists := a.modelAliases[savedAlias]; aliasExists && pickerModelIndex(a.modelPickerModels(), savedAlias) < 0 {
 			status.SavedModelUnconfigured = true
 		}
 	}
@@ -776,7 +1011,27 @@ func (a *claudeAdapter) currentPickerStatus() (claudePickerStatus, error) {
 			return status, nil
 		}
 		if status.Enabled && status.UserFileSync != "blocked" && bak != nil && bak.ModelPicker != nil && bak.ModelPicker.WrittenPickerFingerprint != "" {
-			want, _ := canonicalRows(claudePickerRows(a.modelPicker, a.modelAliases))
+			contextTokens := a.activePickerContextTokens()
+			desired, projectionErr := claudePickerRows(
+				a.modelPicker,
+				a.modelAliases,
+				contextTokens,
+				ownedOneMillionPickerAliases(root, bak.ModelPicker),
+			)
+			if projectionErr != nil {
+				status.UserFileSync = "blocked"
+				status.Message = projectionErr.Error()
+				return status, nil
+			}
+			savedAlias, savedOneMillion := normalizeClaudePickerModelID(
+				status.SavedModel,
+			)
+			if savedOneMillion &&
+				pickerModelIndex(a.modelPickerModels(), savedAlias) >= 0 &&
+				!desiredPickerHasOneMillionAlias(desired, savedAlias) {
+				status.SavedModelContextMismatch = true
+			}
+			want, _ := canonicalRows(desired)
 			if anchoredRowsEqual(rows, want, bak.ModelPicker.WrittenAnchor) && rawRowsEqual(want, bak.ModelPicker.WrittenRows) {
 				status.UserFileSync = "synced"
 			}
@@ -848,8 +1103,11 @@ func (a *claudeAdapter) pickerRemovalWarnings(alias string) []string {
 		return nil
 	}
 	var warnings []string
-	if saved, ok := root["model"].(string); ok && saved == alias {
-		warnings = append(warnings, fmt.Sprintf("saved Claude default model %q still points at the removed alias; select a new default in /model", alias))
+	if saved, ok := root["model"].(string); ok {
+		savedAlias, _ := normalizeClaudePickerModelID(saved)
+		if savedAlias == alias {
+			warnings = append(warnings, fmt.Sprintf("saved Claude default model %q still points at the removed alias; select a new default in /model", alias))
+		}
 	}
 	if effectiveLegacyDiscovery(root) {
 		warnings = append(warnings, fmt.Sprintf("legacy gateway model discovery is enabled, so removing %q from modelPicker may not hide it from /model", alias))
@@ -885,6 +1143,30 @@ func (a *claudeAdapter) mutatePickerConfig(args []string, opts mutationOptions, 
 			fmt.Fprintln(a.out, "claude picker enable --dry-run requires --json")
 			return 2
 		}
+		proposed := p
+		proposed.Enabled = true
+		if pickerWasAbsent {
+			for _, alias := range sortedAliasIDs(a.modelAliases) {
+				proposed.Models = append(
+					proposed.Models,
+					config.ModelPickerModel{Alias: alias},
+				)
+			}
+		}
+		if err := a.preflightPickerContext(
+			&proposed,
+			copyPickerAliases(a.modelAliases),
+		); err != nil {
+			code := "config_validation_failed"
+			if isPickerContextMinimum(err) {
+				code = claudePickerContextMinimumErrorCode
+			}
+			return failMutation(opts, stdout, mutationResult{
+				Operation: operation, Client: a.clientName,
+				Key: "model_picker", ConfigPath: a.configPath,
+				Requested: true,
+			}, code, err.Error(), false, 1)
+		}
 		preview := claudePickerEnablePreview{Models: []claudePickerPreview{}}
 		for _, alias := range sortedAliasIDs(a.modelAliases) {
 			slug := a.modelAliases[alias]
@@ -916,6 +1198,28 @@ func (a *claudeAdapter) mutatePickerConfig(args []string, opts mutationOptions, 
 		if err != nil {
 			fmt.Fprintf(a.out, "claude picker add preview: %v\n", err)
 			return 1
+		}
+		proposed := p
+		proposed.Enabled = true
+		proposed.Models = append(
+			proposed.Models,
+			config.ModelPickerModel{Alias: preview.Alias},
+		)
+		proposedAliases := copyPickerAliases(a.modelAliases)
+		proposedAliases[preview.Alias] = preview.Slug
+		if err := a.preflightPickerContext(
+			&proposed,
+			proposedAliases,
+		); err != nil {
+			code := "config_validation_failed"
+			if isPickerContextMinimum(err) {
+				code = claudePickerContextMinimumErrorCode
+			}
+			return failMutation(opts, stdout, mutationResult{
+				Operation: operation, RequestedTarget: args[1],
+				Client: a.clientName, Key: "model_picker",
+				ConfigPath: a.configPath, Requested: true,
+			}, code, err.Error(), false, 1)
 		}
 		_ = json.NewEncoder(stdout).Encode(preview)
 		return 0
@@ -998,6 +1302,23 @@ func (a *claudeAdapter) mutatePickerConfig(args []string, opts mutationOptions, 
 	}
 	if verb == "add" && opts.PickerAlias != "" {
 		requestedTarget += " via " + opts.PickerAlias
+	}
+	if (verb == "enable" || verb == "add" || verb == "move") && p.Enabled {
+		proposedAliases := copyPickerAliases(a.modelAliases)
+		for alias, slug := range aliasesToAdd {
+			proposedAliases[alias] = slug
+		}
+		if err := a.preflightPickerContext(&p, proposedAliases); err != nil {
+			code := "config_validation_failed"
+			if isPickerContextMinimum(err) {
+				code = claudePickerContextMinimumErrorCode
+			}
+			return failMutation(opts, stdout, mutationResult{
+				Operation: operation, RequestedTarget: requestedTarget,
+				Client: a.clientName, Key: "model_picker",
+				ConfigPath: a.configPath, Requested: true,
+			}, code, err.Error(), false, 1)
+		}
 	}
 
 	lock, err := acquireConfigMutationLock(a.configPath)
@@ -1396,6 +1717,7 @@ func aliasesForSlug(slug string, aliases map[string]string) []string {
 }
 
 func pickerModelIndex(models []config.ModelPickerModel, alias string) int {
+	alias, _ = normalizeClaudePickerModelID(alias)
 	for i := range models {
 		if models[i].Alias == alias {
 			return i
@@ -1455,6 +1777,9 @@ func doctorModelPickerCheck(add addCheck, a *claudeAdapter) {
 	}
 	if status.SavedModelUnconfigured {
 		warnings = append(warnings, fmt.Sprintf("saved default %q is no longer configured in model_picker", status.SavedModel))
+	}
+	if status.SavedModelContextMismatch {
+		warnings = append(warnings, fmt.Sprintf("saved default %q still requests 1M context, but its configured picker row now uses the 200K context bucket", status.SavedModel))
 	}
 	if len(warnings) > 0 {
 		add("claude", "model_picker", docWarn, baseFinding+"; "+strings.Join(warnings, "; "), "review Claude user settings and reopen /model")

--- a/gateway/cmd/baseten-switch/claude_picker.go
+++ b/gateway/cmd/baseten-switch/claude_picker.go
@@ -564,7 +564,8 @@ func installModelPickerWithOptions(root map[string]any, desired []any, prior *cl
 			}
 		}
 	}
-	updated := append([]any(nil), rows[:anchor]...)
+	updated := make([]any, 0, len(rows)+len(desired))
+	updated = append(updated, rows[:anchor]...)
 	updated = append(updated, desired...)
 	updated = append(updated, rows[anchor:]...)
 	rows = updated
@@ -1121,7 +1122,6 @@ func (a *claudeAdapter) mutatePickerConfig(args []string, opts mutationOptions, 
 		return 1
 	}
 	picker := a.modelPicker
-	pickerWasAbsent := picker == nil
 	if picker == nil {
 		picker = &config.ModelPicker{}
 	}
@@ -1145,14 +1145,6 @@ func (a *claudeAdapter) mutatePickerConfig(args []string, opts mutationOptions, 
 		}
 		proposed := p
 		proposed.Enabled = true
-		if pickerWasAbsent {
-			for _, alias := range sortedAliasIDs(a.modelAliases) {
-				proposed.Models = append(
-					proposed.Models,
-					config.ModelPickerModel{Alias: alias},
-				)
-			}
-		}
 		if err := a.preflightPickerContext(
 			&proposed,
 			copyPickerAliases(a.modelAliases),
@@ -1168,9 +1160,12 @@ func (a *claudeAdapter) mutatePickerConfig(args []string, opts mutationOptions, 
 			}, code, err.Error(), false, 1)
 		}
 		preview := claudePickerEnablePreview{Models: []claudePickerPreview{}}
-		for _, alias := range sortedAliasIDs(a.modelAliases) {
-			slug := a.modelAliases[alias]
-			preview.Models = append(preview.Models, pickerPreview(alias, slug))
+		for _, model := range proposed.Models {
+			slug := a.modelAliases[model.Alias]
+			preview.Models = append(
+				preview.Models,
+				pickerPreview(model.Alias, slug),
+			)
 		}
 		_ = json.NewEncoder(stdout).Encode(preview)
 		return 0
@@ -1234,20 +1229,6 @@ func (a *claudeAdapter) mutatePickerConfig(args []string, opts mutationOptions, 
 			return pickerUsage(a.out)
 		}
 		p.Enabled = true
-		if pickerWasAbsent {
-			if len(a.modelAliases) == 0 {
-				fmt.Fprintln(a.out, "claude picker enable: no model_aliases are configured")
-				return 1
-			}
-			aliases := make([]string, 0, len(a.modelAliases))
-			for alias := range a.modelAliases {
-				aliases = append(aliases, alias)
-			}
-			sort.Strings(aliases)
-			for _, alias := range aliases {
-				p.Models = append(p.Models, config.ModelPickerModel{Alias: alias})
-			}
-		}
 	case "disable":
 		if len(args) != 1 {
 			return pickerUsage(a.out)

--- a/gateway/cmd/baseten-switch/claude_picker.go
+++ b/gateway/cmd/baseten-switch/claude_picker.go
@@ -1,0 +1,1469 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/basetenlabs/baseten-switch/gateway/cmd/gateway"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/modelmeta"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/safefile"
+)
+
+const claudeModelPickerMinVersion = "2.1.243"
+const claudeModelPickerVersionOutputLimit = 4096
+
+type claudeModelPickerBackup struct {
+	OriginalMissing          bool              `json:"original_missing,omitempty"`
+	Original                 json.RawMessage   `json:"original,omitempty"`
+	WrittenRows              []json.RawMessage `json:"written_rows,omitempty"`
+	WrittenAnchor            int               `json:"written_anchor,omitempty"`
+	WrittenPickerFingerprint string            `json:"written_picker_fingerprint,omitempty"`
+}
+
+type claudePickerStatus struct {
+	Enabled                bool   `json:"enabled"`
+	Configuration          string `json:"configuration"`
+	UserFileSync           string `json:"user_file_sync"`
+	KnownPolicy            string `json:"known_policy"`
+	AllowlistPolicy        string `json:"allowlist_policy"`
+	ManagedPolicy          string `json:"managed_policy"`
+	ReplacementMode        string `json:"replacement_mode"`
+	RuntimeVerification    string `json:"runtime_verification"`
+	ConfiguredRows         int    `json:"configured_rows"`
+	InstalledRows          int    `json:"installed_rows"`
+	SettingsPath           string `json:"settings_path"`
+	LegacyDiscoveryEnabled bool   `json:"legacy_discovery_enabled"`
+	SavedModel             string `json:"saved_model,omitempty"`
+	SavedModelUnconfigured bool   `json:"saved_model_unconfigured,omitempty"`
+	Message                string `json:"message,omitempty"`
+}
+
+type pickerReceiptState struct {
+	previousHash  string
+	previousToken string
+	adminBefore   *routingAdminStatus
+	activationErr error
+}
+
+type claudePickerPreview struct {
+	Alias       string `json:"alias"`
+	Slug        string `json:"slug"`
+	Label       string `json:"label"`
+	Description string `json:"description"`
+}
+
+type claudePickerEnablePreview struct {
+	Models []claudePickerPreview `json:"models"`
+}
+
+type claudePickerAliasAmbiguity struct {
+	OK           bool                  `json:"ok"`
+	Slug         string                `json:"slug"`
+	AliasChoices []claudePickerPreview `json:"alias_choices"`
+	Error        mutationError         `json:"error"`
+}
+
+type pickerManualResolutionError struct{ message string }
+
+func (e *pickerManualResolutionError) Error() string { return e.message }
+
+func manualPickerErrorf(format string, args ...any) error {
+	return &pickerManualResolutionError{message: fmt.Sprintf(format, args...)}
+}
+
+func isPickerManualResolution(err error) bool {
+	var target *pickerManualResolutionError
+	return errors.As(err, &target)
+}
+
+var (
+	claudePickerLookPath       = exec.LookPath
+	claudePickerCommand        = boundedClaudePickerCommand
+	claudePickerVersionTimeout = 2 * time.Second
+)
+
+type boundedOutputBuffer struct {
+	buf      bytes.Buffer
+	overflow bool
+}
+
+func (b *boundedOutputBuffer) Write(p []byte) (int, error) {
+	remaining := claudeModelPickerVersionOutputLimit + 1 - b.buf.Len()
+	if remaining > 0 {
+		if remaining > len(p) {
+			remaining = len(p)
+		}
+		_, _ = b.buf.Write(p[:remaining])
+	}
+	if b.buf.Len() > claudeModelPickerVersionOutputLimit || remaining < len(p) {
+		b.overflow = true
+	}
+	return len(p), nil
+}
+
+func boundedClaudePickerCommand(ctx context.Context, path string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, path, args...)
+	var out boundedOutputBuffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if out.overflow {
+		return nil, fmt.Errorf("Claude Code version output exceeds %d bytes", claudeModelPickerVersionOutputLimit)
+	}
+	return out.buf.Bytes(), err
+}
+
+func claudeConfiguredModelPicker(f *config.File, clientName string) *config.ModelPicker {
+	for i := range f.Clients {
+		if f.Clients[i].Name == clientName && f.Clients[i].ModelPicker != nil {
+			p := *f.Clients[i].ModelPicker
+			p.Models = append([]config.ModelPickerModel(nil), p.Models...)
+			return &p
+		}
+	}
+	return nil
+}
+
+func (a *claudeAdapter) modelPickerEnabled() bool {
+	return a.modelPicker != nil && a.modelPicker.Enabled
+}
+
+func (a *claudeAdapter) reloadModelPicker() error {
+	f, err := config.Load(a.configPath)
+	if err != nil {
+		return err
+	}
+	a.modelPicker = claudeConfiguredModelPicker(f, a.clientName)
+	_, _, aliases, err := claudeDoorPort(f)
+	if err != nil {
+		return err
+	}
+	a.modelAliases = aliases
+	return nil
+}
+
+func claudePickerRows(picker *config.ModelPicker, aliases map[string]string) []any {
+	if picker == nil || !picker.Enabled {
+		return nil
+	}
+	rows := make([]any, 0, len(picker.Models))
+	for _, model := range picker.Models {
+		slug := aliases[model.Alias]
+		label := modelmeta.ResolveBaseten(slug).DisplayName + " via Baseten"
+		row := map[string]any{
+			"model": model.Alias, "label": label, "description": "Served by Baseten.",
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func canonicalJSON(v any) (json.RawMessage, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(b), nil
+}
+
+func canonicalRows(rows []any) ([]json.RawMessage, error) {
+	out := make([]json.RawMessage, len(rows))
+	for i := range rows {
+		row, err := canonicalJSON(rows[i])
+		if err != nil {
+			return nil, err
+		}
+		out[i] = row
+	}
+	return out, nil
+}
+
+func modelPickerObject(root map[string]any) (map[string]any, bool, error) {
+	v, ok := root["modelPicker"]
+	if !ok {
+		return nil, false, nil
+	}
+	obj, ok := v.(map[string]any)
+	if !ok {
+		return nil, true, manualPickerErrorf("settings modelPicker is not a JSON object; fix it by hand")
+	}
+	return obj, true, nil
+}
+
+func modelPickerOptions(obj map[string]any) ([]any, error) {
+	v, ok := obj["options"]
+	if !ok {
+		return []any{}, nil
+	}
+	rows, ok := v.([]any)
+	if !ok {
+		return nil, manualPickerErrorf("settings modelPicker.options is not an array; fix it by hand")
+	}
+	for i, row := range rows {
+		m, ok := row.(map[string]any)
+		if !ok {
+			return nil, manualPickerErrorf("settings modelPicker.options[%d] is not an object", i)
+		}
+		if _, ok := m["model"].(string); !ok {
+			return nil, manualPickerErrorf("settings modelPicker.options[%d].model is not a string", i)
+		}
+	}
+	return rows, nil
+}
+
+func rawEqual(a json.RawMessage, v any) bool {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return false
+	}
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, a); err != nil {
+		return false
+	}
+	return bytes.Equal(compact.Bytes(), b)
+}
+
+func rawRowsEqual(a, b []json.RawMessage) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		var decoded any
+		dec := json.NewDecoder(bytes.NewReader(b[i]))
+		dec.UseNumber()
+		if err := dec.Decode(&decoded); err != nil || !rawEqual(a[i], decoded) {
+			return false
+		}
+	}
+	return true
+}
+
+func anchoredRowsEqual(rows []any, recorded []json.RawMessage, anchor int) bool {
+	if anchor < 0 || anchor+len(recorded) > len(rows) {
+		return false
+	}
+	for i := range recorded {
+		if !rawEqual(recorded[i], rows[anchor+i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *claudeAdapter) modelPickerModels() []config.ModelPickerModel {
+	if a.modelPicker == nil {
+		return nil
+	}
+	return a.modelPicker.Models
+}
+
+func removeRecordedRowsAtAnchor(rows []any, recorded []json.RawMessage, anchor int) ([]any, error) {
+	if anchor < 0 || anchor+len(recorded) > len(rows) {
+		return nil, manualPickerErrorf("a Switch-managed modelPicker row was moved or removed; resolve settings manually")
+	}
+	for i, want := range recorded {
+		if !rawEqual(want, rows[anchor+i]) {
+			return nil, manualPickerErrorf("a Switch-managed modelPicker row was edited, moved, or removed; resolve settings manually")
+		}
+	}
+	result := append([]any(nil), rows[:anchor]...)
+	result = append(result, rows[anchor+len(recorded):]...)
+	return result, nil
+}
+
+func rowModel(row any) string {
+	m, _ := row.(map[string]any)
+	s, _ := m["model"].(string)
+	return s
+}
+
+func modelPickerFingerprint(obj map[string]any) (string, error) {
+	raw, err := canonicalJSON(obj)
+	if err != nil {
+		return "", err
+	}
+	return sha256Hex(raw), nil
+}
+
+func installModelPicker(root map[string]any, desired []any, prior *claudeModelPickerBackup) (*claudeModelPickerBackup, bool, error) {
+	return installModelPickerWithOptions(root, desired, prior, false)
+}
+
+func installModelPickerWithOptions(root map[string]any, desired []any, prior *claudeModelPickerBackup, allowReplacementConversion bool) (*claudeModelPickerBackup, bool, error) {
+	obj, existed, err := modelPickerObject(root)
+	if err != nil {
+		return nil, false, err
+	}
+	if !existed {
+		obj = map[string]any{}
+	}
+	if replaceRaw, present := obj["replaceBuiltInOptions"]; present {
+		replace, ok := replaceRaw.(bool)
+		if !ok {
+			return nil, false, manualPickerErrorf("settings modelPicker.replaceBuiltInOptions is not a boolean; fix it by hand")
+		}
+		if replace && !allowReplacementConversion {
+			return nil, false, fmt.Errorf("existing modelPicker uses replaceBuiltInOptions=true; rerun with --convert-replacement-mode to confirm conversion to append mode")
+		}
+	}
+	rows, err := modelPickerOptions(obj)
+	if err != nil {
+		return nil, false, err
+	}
+	backup := prior
+	anchor := len(rows)
+	if backup == nil {
+		backup = &claudeModelPickerBackup{OriginalMissing: !existed}
+		if existed {
+			backup.Original, err = canonicalJSON(obj)
+			if err != nil {
+				return nil, false, err
+			}
+		}
+	} else {
+		if backup.WrittenPickerFingerprint == "" {
+			return nil, false, manualPickerErrorf("modelPicker backup predates anchored ownership; resolve settings manually before syncing")
+		}
+		anchor = backup.WrittenAnchor
+		rows, err = removeRecordedRowsAtAnchor(rows, backup.WrittenRows, anchor)
+		if err != nil {
+			return nil, false, err
+		}
+	}
+	for _, want := range desired {
+		id := rowModel(want)
+		for _, external := range rows {
+			if rowModel(external) == id {
+				return nil, false, manualPickerErrorf("modelPicker already has an external row for %q; explicit adoption is required", id)
+			}
+		}
+	}
+	updated := append([]any(nil), rows[:anchor]...)
+	updated = append(updated, desired...)
+	updated = append(updated, rows[anchor:]...)
+	rows = updated
+	obj["options"] = rows
+	obj["replaceBuiltInOptions"] = false
+	root["modelPicker"] = obj
+	written, err := canonicalRows(desired)
+	if err != nil {
+		return nil, false, err
+	}
+	backup.WrittenRows = written
+	backup.WrittenAnchor = anchor
+	backup.WrittenPickerFingerprint, err = modelPickerFingerprint(obj)
+	if err != nil {
+		return nil, false, err
+	}
+	return backup, true, nil
+}
+
+func cleanupModelPicker(root map[string]any, picker *claudeModelPickerBackup, _ bool) (bool, error) {
+	if picker == nil {
+		return false, nil
+	}
+	obj, existed, err := modelPickerObject(root)
+	if err != nil || !existed {
+		return false, err
+	}
+	if picker.WrittenPickerFingerprint == "" {
+		return false, manualPickerErrorf("modelPicker backup predates anchored ownership; resolve settings manually")
+	}
+	currentFingerprint, err := modelPickerFingerprint(obj)
+	if err != nil {
+		return false, err
+	}
+	if currentFingerprint == picker.WrittenPickerFingerprint {
+		if picker.OriginalMissing {
+			delete(root, "modelPicker")
+			return true, nil
+		}
+		var original any
+		dec := json.NewDecoder(bytes.NewReader(picker.Original))
+		dec.UseNumber()
+		if err := dec.Decode(&original); err != nil {
+			return false, fmt.Errorf("parse backed-up modelPicker: %w", err)
+		}
+		root["modelPicker"] = original
+		return true, nil
+	}
+	rows, err := modelPickerOptions(obj)
+	if err != nil {
+		return false, err
+	}
+	rows, err = removeRecordedRowsAtAnchor(rows, picker.WrittenRows, picker.WrittenAnchor)
+	if err != nil {
+		return false, err
+	}
+	if len(rows) == 0 && picker.OriginalMissing && len(obj) == 2 && obj["replaceBuiltInOptions"] == false {
+		delete(root, "modelPicker")
+	} else {
+		obj["options"] = rows
+	}
+	return true, nil
+}
+
+type pickerBackupPreimage struct {
+	existed bool
+	raw     []byte
+	mode    os.FileMode
+}
+
+func capturePickerBackupPreimage(path string) (pickerBackupPreimage, error) {
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return pickerBackupPreimage{}, nil
+	}
+	if err != nil {
+		return pickerBackupPreimage{}, err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return pickerBackupPreimage{}, err
+	}
+	return pickerBackupPreimage{existed: true, raw: raw, mode: info.Mode()}, nil
+}
+
+func restorePickerBackupPreimage(path string, pre pickerBackupPreimage) error {
+	if !pre.existed {
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		return nil
+	}
+	return atomicWriteFile(path, pre.raw, pre.mode)
+}
+
+func (a *claudeAdapter) syncModelPicker(requireVersion bool, allowReplacementConversion ...bool) error {
+	projectionRaw, err := func() ([]byte, error) {
+		configLock, lockErr := acquireConfigMutationLock(a.configPath)
+		if lockErr != nil {
+			return nil, fmt.Errorf("lock picker config projection: %w", lockErr)
+		}
+		defer configLock.close()
+		if recoverErr := recoverInterruptedExactConfigCommit(a.configPath); recoverErr != nil {
+			return nil, fmt.Errorf("recover picker config projection: %w", recoverErr)
+		}
+		raw, _, readErr := readExactConfig(a.configPath)
+		if readErr != nil {
+			return nil, readErr
+		}
+		if reloadErr := a.reloadModelPicker(); reloadErr != nil {
+			return nil, reloadErr
+		}
+		if current, _, readErr := readExactConfig(a.configPath); readErr != nil || !bytes.Equal(current, raw) {
+			return nil, fmt.Errorf("picker config changed while loading its settings projection; retry sync")
+		}
+		if state, _ := classifyPidfile(gatewayPidfilePath()); state == pidfileAlive {
+			admin, adminErr := fetchRoutingAdminStatus(envDefault("BASETEN_SWITCH_ADMIN_ADDR", gateway.DefaultAdminAddr))
+			if adminErr != nil {
+				return nil, fmt.Errorf("verify active picker config: %w", adminErr)
+			}
+			if activeErr := validateMutationAdminStatus(admin, a.configPath, exactConfigHash(raw)); activeErr != nil {
+				return nil, fmt.Errorf("picker config is not active: %w", activeErr)
+			}
+		}
+		return raw, nil
+	}()
+	if err != nil {
+		return err
+	}
+	lock, err := a.acquireSettingsMutationLock()
+	if err != nil {
+		return err
+	}
+	defer lock.close()
+	if current, _, readErr := readExactConfig(a.configPath); readErr != nil || !bytes.Equal(current, projectionRaw) {
+		return fmt.Errorf("picker config changed before settings lock acquisition; retry sync")
+	}
+	if a.modelPickerEnabled() && requireVersion {
+		if err := checkClaudeModelPickerVersion(); err != nil {
+			return err
+		}
+	}
+	root, snap, err := readClaudeSettings(a.settingsPath)
+	if err != nil {
+		return err
+	}
+	if !a.modelPickerEnabled() {
+		return a.removeModelPickerRowsLocked(root, snap)
+	}
+	env, err := settingsEnv(root)
+	if err != nil {
+		return err
+	}
+	baseManaged, _ := a.claudeOnState(env)
+	if !baseManaged {
+		return fmt.Errorf("Claude wiring is off; run 'baseten-switch claude on'")
+	}
+	backupPreimage, err := capturePickerBackupPreimage(a.backupPath)
+	if err != nil {
+		return fmt.Errorf("capture modelPicker backup: %w", err)
+	}
+	bak, err := loadClaudeBackup(a.backupPath)
+	if err != nil {
+		return err
+	}
+	if bak != nil && !claudeBackupTargetSafe(bak, snap) {
+		return fmt.Errorf("settings target changed since backup; refusing modelPicker write")
+	}
+	if bak == nil {
+		bak = &claudeBackup{
+			ConfigPath: a.settingsPath, Values: map[string]string{}, EnvExisted: env != nil,
+			Existed: snap.Exists, WrittenHash: sha256Hex(snap.Data),
+		}
+		recordClaudeBackupFile(bak, snap)
+	}
+	desired := claudePickerRows(a.modelPicker, a.modelAliases)
+	allowConversion := len(allowReplacementConversion) > 0 && allowReplacementConversion[0]
+	pickerBackup, changed, err := installModelPickerWithOptions(root, desired, bak.ModelPicker, allowConversion)
+	if err != nil {
+		return err
+	}
+	bak.ModelPicker = pickerBackup
+	projectionCurrent := func() bool {
+		current, _, readErr := readExactConfig(a.configPath)
+		return readErr == nil && bytes.Equal(current, projectionRaw)
+	}
+	if !projectionCurrent() {
+		return fmt.Errorf("picker config changed before staging its settings projection; retry sync")
+	}
+	if err := saveClaudeBackup(a.backupPath, bak); err != nil {
+		return fmt.Errorf("stage modelPicker backup: %w", err)
+	}
+	if !changed {
+		return nil
+	}
+	if claudeBeforeSettingsMutation != nil {
+		claudeBeforeSettingsMutation()
+	}
+	if !projectionCurrent() {
+		if restoreErr := restorePickerBackupPreimage(a.backupPath, backupPreimage); restoreErr != nil {
+			return fmt.Errorf("picker config changed before settings commit; restore exact prior modelPicker backup: %w", restoreErr)
+		}
+		return fmt.Errorf("picker config changed before settings commit; backup restored, retry sync")
+	}
+	raw, committed, err := writeClaudeSettings(snap, root)
+	if err != nil {
+		if !safefile.CommitApplied(err) {
+			if restoreErr := restorePickerBackupPreimage(a.backupPath, backupPreimage); restoreErr != nil {
+				return fmt.Errorf("write Claude settings: %v; restore exact prior modelPicker backup: %w", err, restoreErr)
+			}
+		}
+		return err
+	}
+	bak.WrittenHash = sha256Hex(raw)
+	recordClaudeBackupFile(bak, committed)
+	if err := saveClaudeBackup(a.backupPath, bak); err != nil {
+		return fmt.Errorf("refresh modelPicker backup: %w", err)
+	}
+	return nil
+}
+
+func checkClaudeModelPickerVersion() error {
+	path, err := claudePickerLookPath("claude")
+	if err != nil {
+		return fmt.Errorf("Claude Code %s+ is required: %w", claudeModelPickerMinVersion, err)
+	}
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("Claude Code version probe resolved a relative executable %q", path)
+	}
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return fmt.Errorf("resolve Claude Code executable %q: %w", path, err)
+	}
+	info, err := os.Stat(resolvedPath)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&0o111 == 0 {
+		return fmt.Errorf("Claude Code executable %q is not an executable regular file", resolvedPath)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), claudePickerVersionTimeout)
+	defer cancel()
+	out, err := claudePickerCommand(ctx, resolvedPath, "--version")
+	if err != nil {
+		return fmt.Errorf("probe Claude Code version: %w", err)
+	}
+	if len(out) > claudeModelPickerVersionOutputLimit {
+		return fmt.Errorf("Claude Code version output exceeds %d bytes", claudeModelPickerVersionOutputLimit)
+	}
+	re := regexp.MustCompile(`\b(\d+)\.(\d+)\.(\d+)\b`)
+	m := re.FindSubmatch(out)
+	if len(m) != 4 {
+		return fmt.Errorf("could not parse Claude Code version from bounded output")
+	}
+	want := []int{2, 1, 243}
+	got := make([]int, 3)
+	for i := range got {
+		got[i], _ = strconv.Atoi(string(m[i+1]))
+	}
+	for i := range got {
+		if got[i] > want[i] {
+			return nil
+		}
+		if got[i] < want[i] {
+			return fmt.Errorf("Claude Code %s+ is required; found %d.%d.%d", claudeModelPickerMinVersion, got[0], got[1], got[2])
+		}
+	}
+	return nil
+}
+
+func (a *claudeAdapter) picker(args []string, stdout io.Writer) int {
+	if len(args) == 0 {
+		args = []string{"status"}
+	}
+	opts, cleanArgs, err := parsePickerOptions(args)
+	if err != nil {
+		fmt.Fprintf(a.out, "claude picker: %v\n", err)
+		return 2
+	}
+	args = cleanArgs
+	switch args[0] {
+	case "status":
+		return a.pickerStatus(stdout, false)
+	case "list":
+		return a.pickerStatus(stdout, true)
+	case "sync":
+		receiptState, casErr := a.checkPickerCAS(opts)
+		if casErr != nil {
+			if opts.JSON {
+				emitPickerMutation(stdout, opts, "sync_claude_picker", "", a, receiptState, false, false, "config_conflict", casErr.Error())
+				return 1
+			}
+			fmt.Fprintf(a.out, "claude picker sync: %v\n", casErr)
+			return 1
+		}
+		if err := a.syncModelPicker(true, opts.ConvertPickerReplacement); err != nil {
+			if opts.JSON {
+				outcome := "settings_sync_failed"
+				if isPickerManualResolution(err) {
+					outcome = "manual_resolution_required"
+				}
+				emitPickerMutation(stdout, opts, "sync_claude_picker", "", a, receiptState, false, true, outcome, err.Error())
+				return 1
+			}
+			fmt.Fprintf(a.out, "claude picker sync: %v\n", err)
+			return 1
+		}
+		if opts.JSON {
+			emitPickerMutation(stdout, opts, "sync_claude_picker", "", a, receiptState, true, false, "applied", "")
+			return 0
+		}
+		fmt.Fprintln(stdout, "claude picker: synced")
+		return 0
+	case "enable", "disable", "add", "remove", "move":
+		return a.mutatePickerConfig(args, opts, stdout)
+	default:
+		fmt.Fprintf(a.out, "unknown claude picker subcommand %q\n", args[0])
+		return 2
+	}
+}
+
+func (a *claudeAdapter) checkPickerCAS(opts mutationOptions) (*pickerReceiptState, error) {
+	raw, _, err := readExactConfig(a.configPath)
+	if err != nil {
+		return nil, err
+	}
+	state := &pickerReceiptState{previousHash: exactConfigHash(raw)}
+	if admin, adminErr := fetchRoutingAdminStatus(envDefault("BASETEN_SWITCH_ADMIN_ADDR", gateway.DefaultAdminAddr)); adminErr == nil {
+		state.previousToken = admin.activeToken()
+		state.adminBefore = &admin
+	}
+	if opts.hasConfigHash && opts.IfConfigHash != state.previousHash {
+		return state, fmt.Errorf("desired config changed: expected %s, found %s", opts.IfConfigHash, state.previousHash)
+	}
+	if opts.hasActiveToken && opts.IfActiveToken != state.previousToken {
+		return state, fmt.Errorf("active router changed: expected %s, found %s", opts.IfActiveToken, state.previousToken)
+	}
+	return state, nil
+}
+
+func (a *claudeAdapter) currentPickerStatus() (claudePickerStatus, error) {
+	if err := a.reloadModelPicker(); err != nil {
+		return claudePickerStatus{}, err
+	}
+	status := claudePickerStatus{
+		Enabled: a.modelPickerEnabled(), UserFileSync: "out_of_sync", KnownPolicy: "no_known_conflict",
+		AllowlistPolicy: "no_known_conflict", ManagedPolicy: "unverified", ReplacementMode: "append",
+		RuntimeVerification: "unverified", SettingsPath: a.settingsPath,
+	}
+	if status.Enabled {
+		status.Configuration = "enabled"
+	} else {
+		status.Configuration = "disabled"
+	}
+	if a.modelPicker != nil {
+		status.ConfiguredRows = len(a.modelPicker.Models)
+	}
+	root, _, err := readClaudeSettings(a.settingsPath)
+	if err != nil {
+		return status, err
+	}
+	if saved, ok := root["model"].(string); ok {
+		status.SavedModel = saved
+		if _, aliasExists := a.modelAliases[saved]; aliasExists && pickerModelIndex(a.modelPickerModels(), saved) < 0 {
+			status.SavedModelUnconfigured = true
+		}
+	}
+	status.LegacyDiscoveryEnabled = effectiveLegacyDiscovery(root)
+	if rawAllowlist, present := root["availableModels"]; present && status.Enabled {
+		values, ok := rawAllowlist.([]any)
+		if !ok {
+			status.AllowlistPolicy = "blocked"
+			status.KnownPolicy = status.AllowlistPolicy
+			status.Message = "availableModels is not an array"
+		} else {
+			allowed := make(map[string]bool, len(values))
+			for _, entry := range values {
+				if id, ok := entry.(string); ok {
+					allowed[id] = true
+				}
+			}
+			for _, row := range a.modelPicker.Models {
+				if !allowed[row.Alias] {
+					status.AllowlistPolicy = "possible_conflict"
+					status.KnownPolicy = "possible_allowlist_conflict"
+					break
+				}
+			}
+		}
+	}
+	obj, exists, err := modelPickerObject(root)
+	if err != nil {
+		status.Message = err.Error()
+		return status, nil
+	}
+	if exists {
+		if raw, present := obj["replaceBuiltInOptions"]; present {
+			replace, ok := raw.(bool)
+			if !ok {
+				status.ReplacementMode = "blocked"
+				status.UserFileSync = "blocked"
+				status.Message = "modelPicker.replaceBuiltInOptions is not a boolean"
+				return status, nil
+			}
+			if replace {
+				status.ReplacementMode = "replace"
+				if status.Enabled {
+					status.UserFileSync = "blocked"
+					status.Message = "modelPicker replacement mode requires explicit conversion"
+				}
+			}
+		}
+		rows, rowErr := modelPickerOptions(obj)
+		if rowErr != nil {
+			status.Message = rowErr.Error()
+			return status, nil
+		}
+		status.InstalledRows = len(rows)
+		bak, backupErr := loadClaudeBackup(a.backupPath)
+		if backupErr != nil {
+			status.UserFileSync = "blocked"
+			status.Message = backupErr.Error()
+			return status, nil
+		}
+		if status.Enabled && status.UserFileSync != "blocked" && bak != nil && bak.ModelPicker != nil && bak.ModelPicker.WrittenPickerFingerprint != "" {
+			want, _ := canonicalRows(claudePickerRows(a.modelPicker, a.modelAliases))
+			if anchoredRowsEqual(rows, want, bak.ModelPicker.WrittenAnchor) && rawRowsEqual(want, bak.ModelPicker.WrittenRows) {
+				status.UserFileSync = "synced"
+			}
+		}
+		if !status.Enabled {
+			switch {
+			case bak == nil || bak.ModelPicker == nil:
+				status.UserFileSync = "synced"
+			case bak.ModelPicker.WrittenPickerFingerprint == "":
+				status.UserFileSync = "blocked"
+				status.Message = "modelPicker backup predates anchored ownership; manual resolution is required"
+			case anchoredRowsEqual(rows, bak.ModelPicker.WrittenRows, bak.ModelPicker.WrittenAnchor):
+				status.UserFileSync = "out_of_sync"
+			default:
+				status.UserFileSync = "blocked"
+				status.Message = "Switch-managed modelPicker rows were edited, moved, or removed; manual resolution is required"
+			}
+		}
+	}
+	if !status.Enabled && !exists {
+		status.UserFileSync = "synced"
+	}
+	return status, nil
+}
+
+func (a *claudeAdapter) pickerStatus(stdout io.Writer, list bool) int {
+	status, err := a.currentPickerStatus()
+	if err != nil {
+		fmt.Fprintf(a.out, "claude picker status: %v\n", err)
+		return 1
+	}
+	if list {
+		if a.modelPicker == nil || len(a.modelPicker.Models) == 0 {
+			fmt.Fprintln(stdout, "no configured Claude picker rows")
+			return 0
+		}
+		for i, row := range a.modelPicker.Models {
+			slug := a.modelAliases[row.Alias]
+			fmt.Fprintf(stdout, "%d\t%s\t%s\tServed by Baseten.\n", i+1, row.Alias, modelmeta.ResolveBaseten(slug).DisplayName+" via Baseten")
+		}
+		return 0
+	}
+	b, _ := json.Marshal(status)
+	fmt.Fprintln(stdout, string(b))
+	if status.Enabled && status.UserFileSync != "synced" {
+		return statusExitOff
+	}
+	if !status.Enabled && status.UserFileSync != "synced" {
+		return statusExitOff
+	}
+	return 0
+}
+
+func effectiveLegacyDiscovery(root map[string]any) bool {
+	if processDiscovery, set := os.LookupEnv("CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"); set {
+		return processDiscovery == "1"
+	}
+	if env, err := settingsEnv(root); err == nil {
+		if value, ok := envString(env, "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"); ok {
+			return value == "1"
+		}
+	}
+	return false
+}
+
+func (a *claudeAdapter) pickerRemovalWarnings(alias string) []string {
+	root, _, err := readClaudeSettings(a.settingsPath)
+	if err != nil {
+		return nil
+	}
+	var warnings []string
+	if saved, ok := root["model"].(string); ok && saved == alias {
+		warnings = append(warnings, fmt.Sprintf("saved Claude default model %q still points at the removed alias; select a new default in /model", alias))
+	}
+	if effectiveLegacyDiscovery(root) {
+		warnings = append(warnings, fmt.Sprintf("legacy gateway model discovery is enabled, so removing %q from modelPicker may not hide it from /model", alias))
+	}
+	return warnings
+}
+
+func (a *claudeAdapter) mutatePickerConfig(args []string, opts mutationOptions, stdout io.Writer) int {
+	if err := a.reloadModelPicker(); err != nil {
+		fmt.Fprintf(a.out, "claude picker %s: %v\n", args[0], err)
+		return 1
+	}
+	picker := a.modelPicker
+	pickerWasAbsent := picker == nil
+	if picker == nil {
+		picker = &config.ModelPicker{}
+	}
+	p := *picker
+	p.Models = append([]config.ModelPickerModel(nil), picker.Models...)
+	verb := args[0]
+	operation := map[string]string{
+		"enable": "enable_claude_picker", "disable": "disable_claude_picker",
+		"add": "add_claude_picker_model", "remove": "remove_claude_picker_model",
+		"move": "move_claude_picker_model",
+	}[verb]
+	requestedTarget := ""
+	aliasesToAdd := map[string]string{}
+	if len(args) > 1 {
+		requestedTarget = args[1]
+	}
+	if opts.DryRun && verb == "enable" {
+		if len(args) != 1 || !opts.JSON {
+			fmt.Fprintln(a.out, "claude picker enable --dry-run requires --json")
+			return 2
+		}
+		preview := claudePickerEnablePreview{Models: []claudePickerPreview{}}
+		for _, alias := range sortedAliasIDs(a.modelAliases) {
+			slug := a.modelAliases[alias]
+			preview.Models = append(preview.Models, pickerPreview(alias, slug))
+		}
+		_ = json.NewEncoder(stdout).Encode(preview)
+		return 0
+	}
+	if verb == "add" && opts.DryRun {
+		if len(args) != 2 || !opts.JSON {
+			fmt.Fprintln(a.out, "claude picker add --dry-run requires one slug and --json")
+			return 2
+		}
+		if opts.PickerAlias == "" {
+			aliases := aliasesForSlug(args[1], a.modelAliases)
+			if len(aliases) > 1 {
+				ambiguity := claudePickerAliasAmbiguity{
+					OK: false, Slug: args[1], AliasChoices: make([]claudePickerPreview, 0, len(aliases)),
+					Error: mutationError{Code: "ambiguous_alias", Message: "multiple configured aliases route to this slug; select one", Retryable: false},
+				}
+				for _, alias := range aliases {
+					ambiguity.AliasChoices = append(ambiguity.AliasChoices, pickerPreview(alias, args[1]))
+				}
+				_ = json.NewEncoder(stdout).Encode(ambiguity)
+				return 1
+			}
+		}
+		preview, err := buildPickerPreview(args[1], a.modelAliases, opts.PickerAlias)
+		if err != nil {
+			fmt.Fprintf(a.out, "claude picker add preview: %v\n", err)
+			return 1
+		}
+		_ = json.NewEncoder(stdout).Encode(preview)
+		return 0
+	}
+	if opts.DryRun {
+		fmt.Fprintln(a.out, "--dry-run is supported only by picker enable and add")
+		return 2
+	}
+	switch verb {
+	case "enable":
+		if len(args) != 1 {
+			return pickerUsage(a.out)
+		}
+		p.Enabled = true
+		if pickerWasAbsent {
+			if len(a.modelAliases) == 0 {
+				fmt.Fprintln(a.out, "claude picker enable: no model_aliases are configured")
+				return 1
+			}
+			aliases := make([]string, 0, len(a.modelAliases))
+			for alias := range a.modelAliases {
+				aliases = append(aliases, alias)
+			}
+			sort.Strings(aliases)
+			for _, alias := range aliases {
+				p.Models = append(p.Models, config.ModelPickerModel{Alias: alias})
+			}
+		}
+	case "disable":
+		if len(args) != 1 {
+			return pickerUsage(a.out)
+		}
+		p.Enabled = false
+	case "add":
+		if len(args) != 2 || !p.Enabled {
+			return pickerUsage(a.out)
+		}
+		preview, err := buildPickerPreview(args[1], a.modelAliases, opts.PickerAlias)
+		if err != nil {
+			fmt.Fprintf(a.out, "claude picker add: %v\n", err)
+			return 1
+		}
+		alias := preview.Alias
+		for _, row := range p.Models {
+			if row.Alias == alias {
+				fmt.Fprintf(a.out, "claude picker add: %s is already configured\n", alias)
+				return 1
+			}
+		}
+		if _, exists := a.modelAliases[alias]; !exists {
+			aliasesToAdd[alias] = preview.Slug
+		}
+		p.Models = append(p.Models, config.ModelPickerModel{Alias: alias})
+	case "remove":
+		if len(args) != 2 || !p.Enabled {
+			return pickerUsage(a.out)
+		}
+		idx := pickerModelIndex(p.Models, args[1])
+		if idx < 0 {
+			fmt.Fprintf(a.out, "claude picker remove: alias %q is not configured\n", args[1])
+			return 1
+		}
+		p.Models = append(p.Models[:idx], p.Models[idx+1:]...)
+	case "move":
+		if len(args) != 4 || args[2] != "--before" || !p.Enabled {
+			return pickerUsage(a.out)
+		}
+		from, before := pickerModelIndex(p.Models, args[1]), pickerModelIndex(p.Models, args[3])
+		if from < 0 || before < 0 {
+			fmt.Fprintln(a.out, "claude picker move: both aliases must be configured")
+			return 1
+		}
+		row := p.Models[from]
+		p.Models = append(p.Models[:from], p.Models[from+1:]...)
+		before = pickerModelIndex(p.Models, args[3])
+		p.Models = append(p.Models, config.ModelPickerModel{})
+		copy(p.Models[before+1:], p.Models[before:])
+		p.Models[before] = row
+		requestedTarget = args[1] + " before " + args[3]
+	}
+	if verb == "add" && opts.PickerAlias != "" {
+		requestedTarget += " via " + opts.PickerAlias
+	}
+
+	lock, err := acquireConfigMutationLock(a.configPath)
+	if err != nil {
+		return failMutation(opts, stdout, mutationResult{
+			Operation: operation, RequestedTarget: requestedTarget, Client: a.clientName,
+			Key: "model_picker", ConfigPath: a.configPath,
+		}, "mutation_locked", err.Error(), true, 1)
+	}
+	if err := recoverInterruptedExactConfigCommit(a.configPath); err != nil {
+		lock.close()
+		return failMutation(opts, stdout, mutationResult{
+			Operation: operation, RequestedTarget: requestedTarget, Client: a.clientName,
+			Key: "model_picker", ConfigPath: a.configPath,
+		}, "commit_recovery_failed", err.Error(), true, 1)
+	}
+	journalOpts := opts
+	journalOpts.JSON = true
+	var journalOutput bytes.Buffer
+	rc := a.runClaudeJournaledMutationLocked(journalOpts, &journalOutput, journaledMutationSpec{
+		Operation:       operation,
+		RequestedTarget: requestedTarget,
+		Client:          a.clientName,
+		Key:             "model_picker",
+		Apply: func(path string) error {
+			if len(aliasesToAdd) > 0 {
+				if err := config.SetClientModelAliases(path, a.clientName, aliasesToAdd); err != nil {
+					return err
+				}
+			}
+			return config.SetClientModelPicker(path, a.clientName, &p)
+		},
+	})
+	lock.close()
+	var result mutationResult
+	if err := json.Unmarshal(bytes.TrimSpace(journalOutput.Bytes()), &result); err != nil {
+		result = mutationResult{
+			OperationID: opts.OperationID, Operation: operation,
+			RequestedTarget: requestedTarget, Client: a.clientName, Key: "model_picker",
+			ConfigPath: a.configPath,
+		}
+		result.Error = &mutationError{Code: "journal_receipt_invalid", Message: "could not decode the config mutation receipt", Retryable: true}
+		result.Outcome = "journal_receipt_invalid"
+		rc = 1
+	}
+	if rc != 0 {
+		return emitPickerJournalResult(opts, stdout, a.out, result, rc)
+	}
+	if verb == "remove" {
+		result.Warnings = a.pickerRemovalWarnings(args[1])
+	}
+	if err := a.reloadModelPicker(); err != nil {
+		return emitPickerSettingsFailure(opts, stdout, a.out, result, verb, err)
+	}
+	if verb == "disable" {
+		if err := a.syncModelPicker(false); err != nil {
+			return emitPickerSettingsFailure(opts, stdout, a.out, result, verb, err)
+		}
+	} else if err := a.syncModelPicker(true, opts.ConvertPickerReplacement); err != nil {
+		return emitPickerSettingsFailure(opts, stdout, a.out, result, verb, err)
+	}
+	return emitPickerJournalResult(opts, stdout, a.out, result, 0)
+}
+
+func emitPickerSettingsFailure(opts mutationOptions, stdout, humanOut io.Writer, result mutationResult, verb string, err error) int {
+	result.OK = false
+	result.ReconciliationRequired = true
+	if isPickerManualResolution(err) {
+		result.ReconciliationAction = "manual_claude_settings_resolution"
+		if result.Outcome != mutationOutcomeApplied && result.Outcome != mutationOutcomeUnchanged {
+			result.ReconciliationAction = "mutation_reconcile_then_manual_claude_settings_resolution"
+		}
+		result.Outcome = "manual_resolution_required"
+		result.Error = &mutationError{Code: "manual_resolution_required", Message: err.Error(), Retryable: false}
+		if opts.JSON {
+			emitMutationResult(stdout, result)
+		} else if result.ReconciliationAction == "mutation_reconcile_then_manual_claude_settings_resolution" {
+			fmt.Fprintf(humanOut, "claude picker %s: config activation and manual Claude settings resolution are pending: %v; after the router starts, run 'baseten-switch mutation reconcile %s'\n", verb, err, result.OperationID)
+		} else {
+			fmt.Fprintf(humanOut, "claude picker %s: config updated, but Claude settings need manual resolution: %v\n", verb, err)
+		}
+		return 1
+	}
+	result.ReconciliationAction = "claude_picker_sync"
+	if result.Outcome != mutationOutcomeApplied && result.Outcome != mutationOutcomeUnchanged {
+		result.ReconciliationAction = "mutation_reconcile_then_claude_picker_sync"
+	}
+	result.Outcome = "settings_sync_pending"
+	result.Error = &mutationError{Code: "settings_sync_failed", Message: err.Error(), Retryable: true}
+	if opts.JSON {
+		emitMutationResult(stdout, result)
+	} else if result.ReconciliationAction == "mutation_reconcile_then_claude_picker_sync" {
+		fmt.Fprintf(humanOut, "claude picker %s: config updated but router activation and Claude settings reconciliation are pending: %v; after the router starts, run 'baseten-switch mutation reconcile %s', then 'baseten-switch claude picker sync'\n", verb, err, result.OperationID)
+	} else {
+		fmt.Fprintf(humanOut, "claude picker %s: config updated; Claude settings reconciliation pending: %v; run 'baseten-switch claude picker sync'\n", verb, err)
+	}
+	return 1
+}
+
+func emitPickerJournalResult(opts mutationOptions, stdout, humanOut io.Writer, result mutationResult, rc int) int {
+	if opts.JSON {
+		emitMutationResult(stdout, result)
+		return rc
+	}
+	if rc != 0 {
+		if result.Error != nil {
+			fmt.Fprintln(humanOut, result.Error.Message)
+		} else {
+			fmt.Fprintln(humanOut, "Claude picker config mutation failed")
+		}
+		return rc
+	}
+	if result.ReconciliationRequired && !result.Applied {
+		fmt.Fprintf(humanOut, "Claude picker config and settings updated; router activation is pending. After the router starts, run 'baseten-switch mutation reconcile %s'.\n", result.OperationID)
+		return 0
+	}
+	for _, warning := range result.Warnings {
+		fmt.Fprintf(humanOut, "warning: %s\n", warning)
+	}
+	action := map[string]string{
+		"enable_claude_picker":       "enable",
+		"disable_claude_picker":      "disable",
+		"add_claude_picker_model":    "add",
+		"remove_claude_picker_model": "remove",
+		"move_claude_picker_model":   "move",
+	}[result.Operation]
+	if action == "" {
+		action = result.Operation
+	}
+	fmt.Fprintf(stdout, "claude picker: %s complete\n", action)
+	return 0
+}
+
+func parsePickerOptions(args []string) (mutationOptions, []string, error) {
+	opts := mutationOptions{OperationID: newOperationID()}
+	clean := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--json":
+			opts.JSON = true
+		case "--dry-run":
+			opts.DryRun = true
+		case "--alias":
+			if i+1 >= len(args) {
+				return opts, nil, fmt.Errorf("--alias requires a value")
+			}
+			i++
+			opts.PickerAlias = args[i]
+		case "--convert-replacement-mode":
+			opts.ConvertPickerReplacement = true
+		case "--operation-id":
+			if i+1 >= len(args) {
+				return opts, nil, fmt.Errorf("--operation-id requires a value")
+			}
+			i++
+			opts.OperationID = args[i]
+			opts.hasOperationID = true
+		case "--if-active-token":
+			if i+1 >= len(args) {
+				return opts, nil, fmt.Errorf("--if-active-token requires a value")
+			}
+			i++
+			opts.IfActiveToken = args[i]
+			opts.hasActiveToken = true
+		case "--if-config-hash":
+			if i+1 >= len(args) {
+				return opts, nil, fmt.Errorf("--if-config-hash requires a value")
+			}
+			i++
+			opts.IfConfigHash = args[i]
+			opts.hasConfigHash = true
+		default:
+			clean = append(clean, args[i])
+		}
+	}
+	if len(clean) == 0 {
+		return opts, nil, fmt.Errorf("missing picker subcommand")
+	}
+	return opts, clean, nil
+}
+
+func pickerTerminalReplayRequest(args []string) (mutationOptions, journaledMutationSpec, error) {
+	opts, positional, err := parsePickerOptions(args)
+	if err != nil {
+		return opts, journaledMutationSpec{}, err
+	}
+	if opts.DryRun {
+		return opts, journaledMutationSpec{}, fmt.Errorf("dry-run has no mutation terminal")
+	}
+	spec := journaledMutationSpec{Key: "model_picker"}
+	switch positional[0] {
+	case "enable":
+		if len(positional) != 1 {
+			return opts, spec, fmt.Errorf("invalid enable request")
+		}
+		spec.Operation = "enable_claude_picker"
+	case "disable":
+		if len(positional) != 1 {
+			return opts, spec, fmt.Errorf("invalid disable request")
+		}
+		spec.Operation = "disable_claude_picker"
+	case "add":
+		if len(positional) != 2 {
+			return opts, spec, fmt.Errorf("invalid add request")
+		}
+		spec.Operation = "add_claude_picker_model"
+		spec.RequestedTarget = positional[1]
+		if opts.PickerAlias != "" {
+			spec.RequestedTarget += " via " + opts.PickerAlias
+		}
+	case "remove":
+		if len(positional) != 2 {
+			return opts, spec, fmt.Errorf("invalid remove request")
+		}
+		spec.Operation = "remove_claude_picker_model"
+		spec.RequestedTarget = positional[1]
+	case "move":
+		if len(positional) != 4 || positional[2] != "--before" {
+			return opts, spec, fmt.Errorf("invalid move request")
+		}
+		spec.Operation = "move_claude_picker_model"
+		spec.RequestedTarget = positional[1] + " before " + positional[3]
+	default:
+		return opts, spec, fmt.Errorf("not a picker config mutation")
+	}
+	return opts, spec, nil
+}
+
+func emitPickerMutation(out io.Writer, opts mutationOptions, operation, target string, a *claudeAdapter, before *pickerReceiptState, applied, reconciliation bool, outcome, message string) {
+	result := mutationResult{
+		OK: message == "", OperationID: opts.OperationID, Operation: operation, Requested: true,
+		RequestedTarget: target, Client: a.clientName, Key: "model_picker",
+		ConfigPath: a.configPath, Applied: applied, ReconciliationRequired: reconciliation,
+		Outcome: outcome,
+	}
+	if before != nil {
+		result.PreviousDesiredConfigHash = before.previousHash
+		result.PreviousActiveToken = before.previousToken
+	}
+	if raw, _, err := readExactConfig(a.configPath); err == nil {
+		result.DesiredConfigHash = exactConfigHash(raw)
+	}
+	if current, err := fetchRoutingAdminStatus(envDefault("BASETEN_SWITCH_ADMIN_ADDR", gateway.DefaultAdminAddr)); err == nil {
+		result.ActiveToken = current.activeToken()
+		result.ActiveConfigHash = current.ActiveConfigHash
+	}
+	if message != "" {
+		retryable := reconciliation
+		if outcome == "manual_resolution_required" {
+			result.ReconciliationAction = "manual_claude_settings_resolution"
+			retryable = false
+		}
+		result.Error = &mutationError{Code: outcome, Message: message, Retryable: retryable}
+	}
+	emitMutationResult(out, result)
+}
+
+func (a *claudeAdapter) removeModelPickerRowsLocked(root map[string]any, snap *safefile.Snapshot) error {
+	bak, err := loadClaudeBackup(a.backupPath)
+	if err != nil || bak == nil || bak.ModelPicker == nil {
+		return err
+	}
+	clean := sha256Hex(snap.Data) == bak.WrittenHash && claudeBackupMatchesFile(bak, snap)
+	changed, err := cleanupModelPicker(root, bak.ModelPicker, clean)
+	if err != nil {
+		return err
+	}
+	if changed {
+		raw, committed, err := writeClaudeSettings(snap, root)
+		if err != nil {
+			return err
+		}
+		bak.WrittenHash = sha256Hex(raw)
+		recordClaudeBackupFile(bak, committed)
+	}
+	bak.ModelPicker = nil
+	return saveClaudeBackup(a.backupPath, bak)
+}
+
+func resolvePickerAlias(value string, aliases map[string]string) (string, error) {
+	if _, ok := aliases[value]; ok {
+		return value, nil
+	}
+	var matches []string
+	for alias, slug := range aliases {
+		if slug == value {
+			matches = append(matches, alias)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	if len(matches) > 1 {
+		sort.Strings(matches)
+		return "", fmt.Errorf("slug %q has multiple aliases: %s", value, strings.Join(matches, ", "))
+	}
+	return "", fmt.Errorf("%q has no configured model_aliases entry; add the route alias first", value)
+}
+
+func buildPickerPreview(slug string, aliases map[string]string, explicitAlias ...string) (claudePickerPreview, error) {
+	if slug == "" || strings.TrimSpace(slug) != slug || strings.ContainsAny(slug, "\x00\r\n") {
+		return claudePickerPreview{}, fmt.Errorf("invalid model slug")
+	}
+	requestedAlias := ""
+	if len(explicitAlias) > 0 {
+		requestedAlias = explicitAlias[0]
+	}
+	alias, err := generatedPickerAlias(slug, aliases)
+	if requestedAlias != "" {
+		alias, err = resolvePickerAlias(requestedAlias, aliases)
+		if err == nil && aliases[alias] != slug {
+			err = fmt.Errorf("alias %q routes to %q, not %q", alias, aliases[alias], slug)
+		}
+	}
+	if err != nil {
+		return claudePickerPreview{}, err
+	}
+	return pickerPreview(alias, slug), nil
+}
+
+func pickerPreview(alias, slug string) claudePickerPreview {
+	return claudePickerPreview{
+		Alias: alias, Slug: slug,
+		Label:       modelmeta.ResolveBaseten(slug).DisplayName + " via Baseten",
+		Description: "Served by Baseten.",
+	}
+}
+
+func generatedPickerAlias(slug string, aliases map[string]string) (string, error) {
+	existing := aliasesForSlug(slug, aliases)
+	if len(existing) == 1 {
+		return existing[0], nil
+	}
+	if len(existing) > 1 {
+		sort.Strings(existing)
+		return "", fmt.Errorf("slug %q has multiple aliases: %s; choose one with --alias", slug, strings.Join(existing, ", "))
+	}
+	leaf := slug
+	if slash := strings.LastIndex(leaf, "/"); slash >= 0 {
+		leaf = leaf[slash+1:]
+	}
+	var normalized strings.Builder
+	pendingHyphen := false
+	for _, char := range leaf {
+		if char >= 'A' && char <= 'Z' {
+			char += 'a' - 'A'
+		}
+		if (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9') {
+			if pendingHyphen && normalized.Len() > 0 {
+				normalized.WriteByte('-')
+			}
+			normalized.WriteRune(char)
+			pendingHyphen = false
+		} else {
+			pendingHyphen = normalized.Len() > 0
+		}
+	}
+	component := strings.Trim(normalized.String(), "-")
+	if component == "" {
+		return "", fmt.Errorf("slug %q has no characters usable in a Claude alias", slug)
+	}
+	const prefix = "claude-baseten-"
+	base := prefix + component
+	if len(base) > 80 {
+		base = base[:80]
+		base = strings.TrimRight(base, "-")
+	}
+	if target, collision := aliases[base]; !collision || target == slug {
+		return base, nil
+	}
+	sum := sha256.Sum256([]byte(slug))
+	hexsum := hex.EncodeToString(sum[:])
+	for _, width := range []int{8, 16} {
+		suffix := "-" + hexsum[:width]
+		stem := base
+		if len(stem)+len(suffix) > 80 {
+			stem = strings.TrimRight(stem[:80-len(suffix)], "-")
+		}
+		candidate := stem + suffix
+		if target, collision := aliases[candidate]; !collision || target == slug {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("could not generate a stable alias for %q", slug)
+}
+
+func aliasesForSlug(slug string, aliases map[string]string) []string {
+	var matches []string
+	for alias, target := range aliases {
+		if target == slug {
+			matches = append(matches, alias)
+		}
+	}
+	sort.Strings(matches)
+	return matches
+}
+
+func pickerModelIndex(models []config.ModelPickerModel, alias string) int {
+	for i := range models {
+		if models[i].Alias == alias {
+			return i
+		}
+	}
+	return -1
+}
+
+func pickerUsage(w io.Writer) int {
+	fmt.Fprintln(w, "usage: baseten-switch claude picker enable [--convert-replacement-mode]|add <slug> [--alias <alias>]|remove <alias>|move <alias> --before <alias>|sync [--convert-replacement-mode]|disable|status|list")
+	return 2
+}
+
+func shortPickerFingerprint(rows []json.RawMessage) string {
+	h := sha256.New()
+	for _, row := range rows {
+		_, _ = h.Write(row)
+	}
+	return hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+func doctorModelPickerCheck(add addCheck, a *claudeAdapter) {
+	status, err := a.currentPickerStatus()
+	if err != nil {
+		add("claude", "model_picker", docFail, err.Error(), "baseten-switch claude picker sync")
+		return
+	}
+	if status.Enabled {
+		if err := checkClaudeModelPickerVersion(); err != nil {
+			add("claude", "model_picker", docFail, err.Error(), "upgrade Claude Code, then run 'baseten-switch claude picker sync'")
+			return
+		}
+	}
+	if status.UserFileSync == "blocked" {
+		fix := "resolve the Claude user settings conflict, then run 'baseten-switch claude picker sync'"
+		if status.ReplacementMode == "replace" {
+			fix = "baseten-switch claude picker sync --convert-replacement-mode"
+		}
+		add("claude", "model_picker", docFail, status.Message, fix)
+		return
+	}
+	if status.UserFileSync != "synced" {
+		add("claude", "model_picker", docFail, "configured model_picker state is not synchronized to Claude user settings", "baseten-switch claude picker sync", "claude", "picker", "sync")
+		return
+	}
+	baseFinding := fmt.Sprintf("configuration=%s, user_file_sync=%s, managed_policy=%s, runtime=%s", status.Configuration, status.UserFileSync, status.ManagedPolicy, status.RuntimeVerification)
+	if status.AllowlistPolicy == "blocked" {
+		add("claude", "model_picker", docFail, baseFinding+"; "+status.Message, "fix availableModels in Claude user settings")
+		return
+	}
+	var warnings []string
+	if status.AllowlistPolicy == "possible_conflict" {
+		warnings = append(warnings, "possible Claude Code allowlist conflict")
+	}
+	if status.LegacyDiscoveryEnabled {
+		warnings = append(warnings, "legacy gateway discovery is also enabled")
+	}
+	if status.SavedModelUnconfigured {
+		warnings = append(warnings, fmt.Sprintf("saved default %q is no longer configured in model_picker", status.SavedModel))
+	}
+	if len(warnings) > 0 {
+		add("claude", "model_picker", docWarn, baseFinding+"; "+strings.Join(warnings, "; "), "review Claude user settings and reopen /model")
+		return
+	}
+	switch status.UserFileSync {
+	case "synced":
+		add("claude", "model_picker", docOK, baseFinding, "")
+	default:
+		add("claude", "model_picker", docFail, baseFinding, "baseten-switch claude picker sync", "claude", "picker", "sync")
+	}
+}

--- a/gateway/cmd/baseten-switch/claude_picker_safety_test.go
+++ b/gateway/cmd/baseten-switch/claude_picker_safety_test.go
@@ -348,7 +348,7 @@ func TestDisabledPickerStatusSyncedWithExternalRowsAndNoOwnership(t *testing.T) 
 	}
 }
 
-func TestPickerEnableDryRunListsEveryAliasInSortedOrder(t *testing.T) {
+func TestPickerEnableDryRunForAbsentPickerReturnsNoModels(t *testing.T) {
 	env := newSubagentTestEnv(t, true)
 	if err := config.SetClientModelAliases(env.cfgPath, "claude-code", map[string]string{
 		"claude-baseten-another-glm": "zai-org/GLM-5.2",
@@ -364,13 +364,35 @@ func TestPickerEnableDryRunListsEveryAliasInSortedOrder(t *testing.T) {
 	if err := json.Unmarshal(out.Bytes(), &preview); err != nil {
 		t.Fatal(err)
 	}
-	if len(preview.Models) != 3 {
-		t.Fatalf("preview aliases = %+v", preview.Models)
+	if len(preview.Models) != 0 {
+		t.Fatalf("preview models = %+v, want empty", preview.Models)
 	}
-	for i := 1; i < len(preview.Models); i++ {
-		if preview.Models[i-1].Alias >= preview.Models[i].Alias {
-			t.Fatalf("preview not sorted: %+v", preview.Models)
-		}
+}
+
+func TestPickerEnableDryRunReflectsDisabledSavedRows(t *testing.T) {
+	env := newSubagentTestEnv(t, true)
+	if err := config.SetClientModelPicker(env.cfgPath, "claude-code", &config.ModelPicker{
+		Enabled: false,
+		Models: []config.ModelPickerModel{
+			{Alias: "claude-baseten-kimi-k2-7"},
+			{Alias: "claude-baseten-glm-5-2"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	a, _ := newClaudeAdapterFromEnv()
+	var out bytes.Buffer
+	if rc := a.picker([]string{"enable", "--dry-run", "--json"}, &out); rc != 0 {
+		t.Fatalf("enable preview rc=%d, output=%s", rc, out.String())
+	}
+	var preview claudePickerEnablePreview
+	if err := json.Unmarshal(out.Bytes(), &preview); err != nil {
+		t.Fatal(err)
+	}
+	if len(preview.Models) != 2 ||
+		preview.Models[0].Alias != "claude-baseten-kimi-k2-7" ||
+		preview.Models[1].Alias != "claude-baseten-glm-5-2" {
+		t.Fatalf("preview models = %+v, want saved row order", preview.Models)
 	}
 }
 
@@ -397,7 +419,86 @@ func TestPickerEnablePreservesExplicitEmptySelection(t *testing.T) {
 	}
 }
 
-func TestPickerEnableAbsentFailsWithoutAliases(t *testing.T) {
+func TestPickerEnablePreservesDisabledSavedRows(t *testing.T) {
+	env := newSubagentTestEnv(t, true)
+	if err := config.SetClientModelPicker(env.cfgPath, "claude-code", &config.ModelPicker{
+		Enabled: false,
+		Models: []config.ModelPickerModel{{
+			Alias: "claude-baseten-kimi-k2-7",
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	stubPickerVersion(t, "2.1.243")
+	a, _ := newClaudeAdapterFromEnv()
+	if rc := a.on(); rc != 0 {
+		t.Fatalf("claude on rc=%d", rc)
+	}
+	var out bytes.Buffer
+	if rc := a.picker([]string{"enable", "--json"}, &out); rc != 0 {
+		t.Fatalf("enable rc=%d, output=%s", rc, out.String())
+	}
+	f, err := config.Load(env.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	picker := f.Clients[0].ModelPicker
+	if picker == nil || !picker.Enabled || len(picker.Models) != 1 ||
+		picker.Models[0].Alias != "claude-baseten-kimi-k2-7" {
+		t.Fatalf("re-enabled picker = %+v, want saved row", picker)
+	}
+	obj, _, err := modelPickerObject(readTree(t, env.settings))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := modelPickerOptions(obj)
+	if err != nil || len(rows) != 1 ||
+		rowModel(rows[0]) != "claude-baseten-kimi-k2-7" {
+		t.Fatalf("installed rows = %#v, err=%v", rows, err)
+	}
+}
+
+func TestPickerEnableAbsentCreatesEmptySelectionWithoutCopyingAliases(t *testing.T) {
+	env := newSubagentTestEnv(t, true)
+	stubPickerVersion(t, "2.1.243")
+	a, err := newClaudeAdapterFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc := a.on(); rc != 0 {
+		t.Fatalf("claude on rc=%d", rc)
+	}
+	var out bytes.Buffer
+	if rc := a.mutatePickerConfig(
+		[]string{"enable"},
+		mutationOptions{JSON: true, OperationID: "empty-enable"},
+		&out,
+	); rc != 0 {
+		t.Fatalf("enable rc=%d output=%s", rc, out.String())
+	}
+	f, err := config.Load(env.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := f.Clients[0]
+	if client.ModelPicker == nil || !client.ModelPicker.Enabled ||
+		len(client.ModelPicker.Models) != 0 {
+		t.Fatalf("enabled picker = %+v, want no models", client.ModelPicker)
+	}
+	if len(client.ModelAliases) == 0 {
+		t.Fatal("fixture unexpectedly has no model aliases")
+	}
+	obj, exists, err := modelPickerObject(readTree(t, env.settings))
+	if err != nil || !exists {
+		t.Fatalf("Claude settings modelPicker exists=%t err=%v", exists, err)
+	}
+	rows, err := modelPickerOptions(obj)
+	if err != nil || len(rows) != 0 || obj["replaceBuiltInOptions"] != false {
+		t.Fatalf("Claude settings modelPicker = %#v, rows=%#v, err=%v", obj, rows, err)
+	}
+}
+
+func TestPickerEnableAbsentSucceedsWithoutAliases(t *testing.T) {
 	env := newSubagentTestEnv(t, true)
 	raw, err := os.ReadFile(env.cfgPath)
 	if err != nil {
@@ -413,16 +514,25 @@ func TestPickerEnableAbsentFailsWithoutAliases(t *testing.T) {
 	if err := os.WriteFile(env.cfgPath, []byte(withoutAliases), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	stubPickerVersion(t, "2.1.243")
 	a, err := newClaudeAdapterFromEnv()
 	if err != nil {
 		t.Fatal(err)
 	}
+	if rc := a.on(); rc != 0 {
+		t.Fatalf("claude on rc=%d", rc)
+	}
 	var out bytes.Buffer
-	if rc := a.mutatePickerConfig([]string{"enable"}, mutationOptions{JSON: true, OperationID: "no-aliases"}, &out); rc != 1 {
+	if rc := a.mutatePickerConfig([]string{"enable"}, mutationOptions{JSON: true, OperationID: "no-aliases"}, &out); rc != 0 {
 		t.Fatalf("enable rc=%d output=%s", rc, out.String())
 	}
-	if _, err := os.Stat(mutationJournalDir(env.cfgPath)); !os.IsNotExist(err) {
-		t.Fatalf("failed enable created mutation state: %v", err)
+	f, err := config.Load(env.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Clients[0].ModelPicker == nil || !f.Clients[0].ModelPicker.Enabled ||
+		len(f.Clients[0].ModelPicker.Models) != 0 {
+		t.Fatalf("enabled picker = %+v, want no models", f.Clients[0].ModelPicker)
 	}
 }
 
@@ -479,6 +589,7 @@ func TestPickerAddExplicitAliasSelectsOneOfSeveralRoutes(t *testing.T) {
 
 func TestPickerRemovalReceiptWarnsForSavedDefaultAndLegacyDiscovery(t *testing.T) {
 	env, a := prepareManagedPicker(t, true)
+	stubPickerVersion(t, "2.1.243")
 	t.Setenv("CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY", "1")
 	root := readTree(t, env.settings)
 	root["model"] = "claude-baseten-glm-5-2"

--- a/gateway/cmd/baseten-switch/claude_picker_safety_test.go
+++ b/gateway/cmd/baseten-switch/claude_picker_safety_test.go
@@ -1,0 +1,671 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
+)
+
+func stubPickerVersion(t *testing.T, version string) {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "claude")
+	if err := os.WriteFile(bin, []byte("stub"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	oldLook, oldCommand, oldTimeout := claudePickerLookPath, claudePickerCommand, claudePickerVersionTimeout
+	t.Cleanup(func() {
+		claudePickerLookPath, claudePickerCommand, claudePickerVersionTimeout = oldLook, oldCommand, oldTimeout
+	})
+	claudePickerLookPath = func(string) (string, error) { return bin, nil }
+	claudePickerCommand = func(context.Context, string, ...string) ([]byte, error) { return []byte(version), nil }
+}
+
+func prepareManagedPicker(t *testing.T, adminDown bool) (*subagentTestEnv, *claudeAdapter) {
+	t.Helper()
+	env := newSubagentTestEnv(t, adminDown)
+	if err := config.SetClientModelPicker(env.cfgPath, "claude-code", &config.ModelPicker{
+		Enabled: true, Models: []config.ModelPickerModel{{Alias: "claude-baseten-glm-5-2"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	a, err := newClaudeAdapterFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc := a.on(); rc != 0 {
+		t.Fatalf("claude on rc=%d", rc)
+	}
+	if err := a.syncModelPicker(false); err != nil {
+		t.Fatalf("initial picker sync: %v", err)
+	}
+	return env, a
+}
+
+func TestPickerSyncSettingsCASFailureRestoresExactPriorBackup(t *testing.T) {
+	env := newSubagentTestEnv(t, true)
+	if err := config.SetClientModelPicker(env.cfgPath, "claude-code", &config.ModelPicker{
+		Enabled: true, Models: []config.ModelPickerModel{{Alias: "claude-baseten-glm-5-2"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	a, err := newClaudeAdapterFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc := a.on(); rc != 0 {
+		t.Fatalf("claude on rc=%d", rc)
+	}
+	backupBefore, err := os.ReadFile(a.backupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldHook := claudeBeforeSettingsMutation
+	t.Cleanup(func() { claudeBeforeSettingsMutation = oldHook })
+	claudeBeforeSettingsMutation = func() {
+		root := readTree(t, env.settings)
+		root["concurrent"] = true
+		raw, _ := json.Marshal(root)
+		if err := os.WriteFile(env.settings, raw, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := a.syncModelPicker(false); err == nil {
+		t.Fatal("expected stale settings CAS failure")
+	}
+	backupAfter, err := os.ReadFile(a.backupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(backupBefore, backupAfter) {
+		t.Fatal("staged picker backup was not rolled back byte-for-byte")
+	}
+	if readTree(t, env.settings)["concurrent"] != true {
+		t.Fatal("concurrent settings edit was not preserved")
+	}
+}
+
+func TestPickerSyncSettingsCASFailureRemovesNewlyStagedBackup(t *testing.T) {
+	env := newSubagentTestEnv(t, true)
+	if err := config.SetClientModelPicker(env.cfgPath, "claude-code", &config.ModelPicker{
+		Enabled: true, Models: []config.ModelPickerModel{{Alias: "claude-baseten-glm-5-2"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	root := readTree(t, env.settings)
+	envBlock, _ := settingsEnv(root)
+	envBlock[claudeAttributionEnvKey] = claudeAttributionValue
+	envBlock[claudeToolSearchEnvKey] = claudeToolSearchValue
+	raw, _ := json.Marshal(root)
+	if err := os.WriteFile(env.settings, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	a, err := newClaudeAdapterFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(a.backupPath); !os.IsNotExist(err) {
+		t.Fatalf("unexpected initial backup: %v", err)
+	}
+	oldHook := claudeBeforeSettingsMutation
+	t.Cleanup(func() { claudeBeforeSettingsMutation = oldHook })
+	claudeBeforeSettingsMutation = func() {
+		concurrent := readTree(t, env.settings)
+		concurrent["concurrent"] = true
+		updated, _ := json.Marshal(concurrent)
+		if err := os.WriteFile(env.settings, updated, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := a.syncModelPicker(false); err == nil {
+		t.Fatal("expected stale settings CAS failure")
+	}
+	if _, err := os.Stat(a.backupPath); !os.IsNotExist(err) {
+		t.Fatalf("newly staged backup was not removed: %v", err)
+	}
+}
+
+func TestPickerSyncRefusesConfigChangeAfterProjectionAndRestoresBackup(t *testing.T) {
+	env := newSubagentTestEnv(t, true)
+	if err := config.SetClientModelPicker(env.cfgPath, "claude-code", &config.ModelPicker{
+		Enabled: true, Models: []config.ModelPickerModel{{Alias: "claude-baseten-glm-5-2"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	a, err := newClaudeAdapterFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc := a.on(); rc != 0 {
+		t.Fatalf("claude on rc=%d", rc)
+	}
+	backupBefore, _ := os.ReadFile(a.backupPath)
+	settingsBefore, _ := os.ReadFile(env.settings)
+	oldHook := claudeBeforeSettingsMutation
+	t.Cleanup(func() { claudeBeforeSettingsMutation = oldHook })
+	claudeBeforeSettingsMutation = func() {
+		if err := config.SetClientModelPicker(env.cfgPath, "claude-code", &config.ModelPicker{Enabled: false}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	err = a.syncModelPicker(false)
+	if err == nil || !strings.Contains(err.Error(), "config changed") {
+		t.Fatalf("sync error = %v", err)
+	}
+	backupAfter, _ := os.ReadFile(a.backupPath)
+	settingsAfter, _ := os.ReadFile(env.settings)
+	if !bytes.Equal(backupBefore, backupAfter) || !bytes.Equal(settingsBefore, settingsAfter) {
+		t.Fatal("stale projection changed settings or backup")
+	}
+}
+
+func TestPickerSyncNeverHoldsConfigAndSettingsLocksTogether(t *testing.T) {
+	env := newSubagentTestEnv(t, true)
+	if err := config.SetClientModelPicker(env.cfgPath, "claude-code", &config.ModelPicker{
+		Enabled: true, Models: []config.ModelPickerModel{{Alias: "claude-baseten-glm-5-2"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	a, err := newClaudeAdapterFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc := a.on(); rc != 0 {
+		t.Fatalf("claude on rc=%d", rc)
+	}
+	oldHook := claudeBeforeSettingsMutation
+	t.Cleanup(func() { claudeBeforeSettingsMutation = oldHook })
+	claudeBeforeSettingsMutation = func() {
+		lock, lockErr := acquireConfigMutationLock(env.cfgPath)
+		if lockErr != nil {
+			t.Fatalf("config lock remained held during settings mutation: %v", lockErr)
+		}
+		lock.close()
+	}
+	if err := a.syncModelPicker(false); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClaudeOffRemovesBaseWiringWhenMovedPickerNeedsManualResolution(t *testing.T) {
+	env, a := prepareManagedPicker(t, true)
+	root := readTree(t, env.settings)
+	obj := root["modelPicker"].(map[string]any)
+	rows := obj["options"].([]any)
+	obj["options"] = append([]any{map[string]any{"model": "external", "label": "keep"}}, rows...)
+	raw, _ := json.Marshal(root)
+	if err := os.WriteFile(env.settings, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if rc := a.off(); rc != 1 {
+		t.Fatalf("claude off rc=%d, want manual-resolution failure", rc)
+	}
+	after := readTree(t, env.settings)
+	envBlock, _ := settingsEnv(after)
+	if _, ok := envString(envBlock, claudeManagedEnvKey); ok {
+		t.Fatal("claude off left base URL wiring installed")
+	}
+	if _, ok := after["modelPicker"]; !ok {
+		t.Fatal("moved picker rows should be preserved")
+	}
+	bak, err := loadClaudeBackup(a.backupPath)
+	if err != nil || bak == nil || bak.ModelPicker == nil {
+		t.Fatalf("picker recovery backup = %+v, err=%v", bak, err)
+	}
+}
+
+func TestReplacementModeRequiresConfirmationAndRestoresOriginal(t *testing.T) {
+	root := map[string]any{"modelPicker": map[string]any{
+		"replaceBuiltInOptions": true,
+		"options":               pickerTestRows("external"),
+	}}
+	if _, _, err := installModelPicker(root, pickerTestRows("claude-baseten-a"), nil); err == nil {
+		t.Fatal("expected replacement-mode confirmation error")
+	}
+	bak, _, err := installModelPickerWithOptions(root, pickerTestRows("claude-baseten-a"), nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root["modelPicker"].(map[string]any)["replaceBuiltInOptions"] != false {
+		t.Fatal("confirmed conversion did not select append mode")
+	}
+	if _, err := cleanupModelPicker(root, bak, true); err != nil {
+		t.Fatal(err)
+	}
+	obj := root["modelPicker"].(map[string]any)
+	if obj["replaceBuiltInOptions"] != true || len(obj["options"].([]any)) != 1 {
+		t.Fatalf("replacement object was not restored: %#v", obj)
+	}
+}
+
+func TestReplacementModeRejectsNonBoolean(t *testing.T) {
+	root := map[string]any{"modelPicker": map[string]any{
+		"replaceBuiltInOptions": "false", "options": []any{},
+	}}
+	if _, _, err := installModelPickerWithOptions(root, pickerTestRows("a"), nil, true); err == nil {
+		t.Fatal("expected non-boolean replacement mode error")
+	}
+}
+
+func TestPickerManualConflictsAreTypedButConversionConfirmationIsNot(t *testing.T) {
+	tests := []struct {
+		name string
+		root map[string]any
+	}{
+		{name: "non-object", root: map[string]any{"modelPicker": "bad"}},
+		{name: "non-array options", root: map[string]any{"modelPicker": map[string]any{"options": "bad"}}},
+		{name: "malformed row", root: map[string]any{"modelPicker": map[string]any{"options": []any{"bad"}}}},
+		{name: "non-bool replacement", root: map[string]any{"modelPicker": map[string]any{"replaceBuiltInOptions": "false", "options": []any{}}}},
+		{name: "duplicate desired id", root: map[string]any{"modelPicker": map[string]any{"options": pickerTestRows("claude-baseten-a")}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := installModelPicker(tc.root, pickerTestRows("claude-baseten-a"), nil)
+			if err == nil || !isPickerManualResolution(err) {
+				t.Fatalf("error = %v, want typed manual resolution", err)
+			}
+		})
+	}
+	root := map[string]any{"modelPicker": map[string]any{"replaceBuiltInOptions": true, "options": []any{}}}
+	_, _, err := installModelPicker(root, pickerTestRows("claude-baseten-a"), nil)
+	if err == nil || isPickerManualResolution(err) {
+		t.Fatalf("replacement confirmation error = %v, want non-manual retry with explicit flag", err)
+	}
+}
+
+func TestDisabledPickerSyncRemovesOwnedRowsAndPreservesExternalRows(t *testing.T) {
+	env, a := prepareManagedPicker(t, true)
+	root := readTree(t, env.settings)
+	obj := root["modelPicker"].(map[string]any)
+	obj["options"] = append(obj["options"].([]any), map[string]any{"model": "external", "label": "keep"})
+	raw, _ := json.Marshal(root)
+	if err := os.WriteFile(env.settings, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SetClientModelPicker(env.cfgPath, "claude-code", &config.ModelPicker{Enabled: false}); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.syncModelPicker(false); err != nil {
+		t.Fatal(err)
+	}
+	obj = readTree(t, env.settings)["modelPicker"].(map[string]any)
+	rows := obj["options"].([]any)
+	if len(rows) != 1 || rowModel(rows[0]) != "external" {
+		t.Fatalf("rows after disabled sync = %#v", rows)
+	}
+	status, err := a.currentPickerStatus()
+	if err != nil || status.UserFileSync != "synced" {
+		t.Fatalf("disabled status = %+v, err=%v", status, err)
+	}
+}
+
+func TestPickerDisableMovedRowReturnsManualResolutionAction(t *testing.T) {
+	env, a := prepareManagedPicker(t, true)
+	root := readTree(t, env.settings)
+	obj := root["modelPicker"].(map[string]any)
+	rows := obj["options"].([]any)
+	obj["options"] = append([]any{map[string]any{"model": "external", "label": "keep"}}, rows...)
+	raw, _ := json.Marshal(root)
+	if err := os.WriteFile(env.settings, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if rc := a.mutatePickerConfig(
+		[]string{"disable"},
+		mutationOptions{JSON: true, OperationID: "disable-moved"},
+		&out,
+	); rc != 1 {
+		t.Fatalf("disable rc=%d output=%s", rc, out.String())
+	}
+	var receipt mutationResult
+	if err := json.Unmarshal(out.Bytes(), &receipt); err != nil {
+		t.Fatal(err)
+	}
+	if receipt.ReconciliationAction != "mutation_reconcile_then_manual_claude_settings_resolution" || receipt.Outcome != "manual_resolution_required" ||
+		receipt.Error == nil || receipt.Error.Retryable {
+		t.Fatalf("receipt = %+v", receipt)
+	}
+}
+
+func TestDisabledPickerStatusSyncedWithExternalRowsAndNoOwnership(t *testing.T) {
+	env := newSubagentTestEnv(t, true)
+	if err := config.SetClientModelPicker(env.cfgPath, "claude-code", &config.ModelPicker{Enabled: false}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(env.settings, []byte(`{"modelPicker":{"replaceBuiltInOptions":false,"options":[{"model":"external"}]}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	a, _ := newClaudeAdapterFromEnv()
+	status, err := a.currentPickerStatus()
+	if err != nil || status.UserFileSync != "synced" {
+		t.Fatalf("status = %+v, err=%v", status, err)
+	}
+}
+
+func TestPickerEnableDryRunListsEveryAliasInSortedOrder(t *testing.T) {
+	env := newSubagentTestEnv(t, true)
+	if err := config.SetClientModelAliases(env.cfgPath, "claude-code", map[string]string{
+		"claude-baseten-another-glm": "zai-org/GLM-5.2",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	a, _ := newClaudeAdapterFromEnv()
+	var out bytes.Buffer
+	if rc := a.picker([]string{"enable", "--dry-run", "--json"}, &out); rc != 0 {
+		t.Fatalf("enable preview rc=%d, output=%s", rc, out.String())
+	}
+	var preview claudePickerEnablePreview
+	if err := json.Unmarshal(out.Bytes(), &preview); err != nil {
+		t.Fatal(err)
+	}
+	if len(preview.Models) != 3 {
+		t.Fatalf("preview aliases = %+v", preview.Models)
+	}
+	for i := 1; i < len(preview.Models); i++ {
+		if preview.Models[i-1].Alias >= preview.Models[i].Alias {
+			t.Fatalf("preview not sorted: %+v", preview.Models)
+		}
+	}
+}
+
+func TestPickerEnablePreservesExplicitEmptySelection(t *testing.T) {
+	env := newSubagentTestEnv(t, true)
+	if err := config.SetClientModelPicker(env.cfgPath, "claude-code", &config.ModelPicker{Enabled: false, Models: []config.ModelPickerModel{}}); err != nil {
+		t.Fatal(err)
+	}
+	stubPickerVersion(t, "2.1.243")
+	a, _ := newClaudeAdapterFromEnv()
+	if rc := a.on(); rc != 0 {
+		t.Fatalf("claude on rc=%d", rc)
+	}
+	var out bytes.Buffer
+	if rc := a.picker([]string{"enable", "--json"}, &out); rc != 0 {
+		t.Fatalf("enable rc=%d, output=%s", rc, out.String())
+	}
+	f, err := config.Load(env.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Clients[0].ModelPicker == nil || !f.Clients[0].ModelPicker.Enabled || len(f.Clients[0].ModelPicker.Models) != 0 {
+		t.Fatalf("explicit empty picker was bootstrapped: %+v", f.Clients[0].ModelPicker)
+	}
+}
+
+func TestPickerEnableAbsentFailsWithoutAliases(t *testing.T) {
+	env := newSubagentTestEnv(t, true)
+	raw, err := os.ReadFile(env.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withoutAliases := strings.Replace(string(raw), `    model_aliases:
+      claude-baseten-glm-5-2: zai-org/GLM-5.2
+      claude-baseten-kimi-k2-7: moonshotai/Kimi-K2-7
+`, "", 1)
+	if withoutAliases == string(raw) {
+		t.Fatal("test fixture model_aliases block changed")
+	}
+	if err := os.WriteFile(env.cfgPath, []byte(withoutAliases), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	a, err := newClaudeAdapterFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if rc := a.mutatePickerConfig([]string{"enable"}, mutationOptions{JSON: true, OperationID: "no-aliases"}, &out); rc != 1 {
+		t.Fatalf("enable rc=%d output=%s", rc, out.String())
+	}
+	if _, err := os.Stat(mutationJournalDir(env.cfgPath)); !os.IsNotExist(err) {
+		t.Fatalf("failed enable created mutation state: %v", err)
+	}
+}
+
+func TestPickerAddDryRunReturnsSortedAliasChoices(t *testing.T) {
+	env := newSubagentTestEnv(t, true)
+	const slug = "zai-org/GLM-5.2"
+	if err := config.SetClientModelAliases(env.cfgPath, "claude-code", map[string]string{
+		"claude-baseten-a-glm": slug,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	a, _ := newClaudeAdapterFromEnv()
+	var out bytes.Buffer
+	if rc := a.picker([]string{"add", slug, "--dry-run", "--json"}, &out); rc != 1 {
+		t.Fatalf("ambiguous preview rc=%d, output=%s", rc, out.String())
+	}
+	var got claudePickerAliasAmbiguity
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Error.Code != "ambiguous_alias" || len(got.AliasChoices) != 2 ||
+		got.AliasChoices[0].Alias != "claude-baseten-a-glm" || got.AliasChoices[1].Alias != "claude-baseten-glm-5-2" {
+		t.Fatalf("ambiguity = %+v", got)
+	}
+	if _, err := os.Stat(mutationJournalDir(env.cfgPath)); !os.IsNotExist(err) {
+		t.Fatalf("dry-run created mutation state: %v", err)
+	}
+}
+
+func TestPickerAddExplicitAliasSelectsOneOfSeveralRoutes(t *testing.T) {
+	env := newSubagentTestEnv(t, true)
+	const slug = "zai-org/GLM-5.2"
+	const selected = "claude-baseten-a-glm"
+	if err := config.SetClientModelAliases(env.cfgPath, "claude-code", map[string]string{selected: slug}); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SetClientModelPicker(env.cfgPath, "claude-code", &config.ModelPicker{Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	stubPickerVersion(t, "2.1.243")
+	a, _ := newClaudeAdapterFromEnv()
+	if rc := a.on(); rc != 0 {
+		t.Fatalf("claude on rc=%d", rc)
+	}
+	var out bytes.Buffer
+	if rc := a.picker([]string{"add", slug, "--alias", selected, "--json"}, &out); rc != 0 {
+		t.Fatalf("explicit alias add rc=%d, output=%s", rc, out.String())
+	}
+	f, _ := config.Load(env.cfgPath)
+	if got := f.Clients[0].ModelPicker.Models; len(got) != 1 || got[0].Alias != selected {
+		t.Fatalf("configured rows = %+v", got)
+	}
+}
+
+func TestPickerRemovalReceiptWarnsForSavedDefaultAndLegacyDiscovery(t *testing.T) {
+	env, a := prepareManagedPicker(t, true)
+	t.Setenv("CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY", "1")
+	root := readTree(t, env.settings)
+	root["model"] = "claude-baseten-glm-5-2"
+	raw, _ := json.Marshal(root)
+	if err := os.WriteFile(env.settings, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if rc := a.mutatePickerConfig(
+		[]string{"remove", "claude-baseten-glm-5-2"},
+		mutationOptions{JSON: true, OperationID: "remove-saved"},
+		&out,
+	); rc != 0 {
+		t.Fatalf("remove rc=%d output=%s", rc, out.String())
+	}
+	var receipt mutationResult
+	if err := json.Unmarshal(out.Bytes(), &receipt); err != nil {
+		t.Fatal(err)
+	}
+	if len(receipt.Warnings) != 2 || !strings.Contains(receipt.Warnings[0], "saved Claude default") ||
+		!strings.Contains(receipt.Warnings[1], "legacy gateway model discovery") {
+		t.Fatalf("warnings = %#v", receipt.Warnings)
+	}
+}
+
+func TestPickerStatusReportsReplacementAllowlistManagedAndRuntimeAxes(t *testing.T) {
+	env := newSubagentTestEnv(t, true)
+	if err := config.SetClientModelPicker(env.cfgPath, "claude-code", &config.ModelPicker{
+		Enabled: true, Models: []config.ModelPickerModel{{Alias: "claude-baseten-glm-5-2"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	root := readTree(t, env.settings)
+	root["availableModels"] = []any{"claude-native"}
+	root["modelPicker"] = map[string]any{"replaceBuiltInOptions": true, "options": []any{}}
+	envBlock, _ := settingsEnv(root)
+	envBlock["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] = "1"
+	raw, _ := json.Marshal(root)
+	if err := os.WriteFile(env.settings, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY", "0")
+	a, _ := newClaudeAdapterFromEnv()
+	status, err := a.currentPickerStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Configuration != "enabled" || status.UserFileSync != "blocked" ||
+		status.ReplacementMode != "replace" || status.AllowlistPolicy != "possible_conflict" ||
+		status.ManagedPolicy != "unverified" || status.RuntimeVerification != "unverified" || status.LegacyDiscoveryEnabled {
+		t.Fatalf("status axes = %+v", status)
+	}
+}
+
+func TestPickerStatusAndDoctorWarnForAllowlistAndSavedUnconfiguredModel(t *testing.T) {
+	env, a := prepareManagedPicker(t, true)
+	root := readTree(t, env.settings)
+	root["availableModels"] = []any{"claude-native"}
+	root["model"] = "claude-baseten-kimi-k2-7"
+	raw, _ := json.Marshal(root)
+	if err := os.WriteFile(env.settings, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	status, err := a.currentPickerStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.UserFileSync != "synced" || status.AllowlistPolicy != "possible_conflict" || !status.SavedModelUnconfigured {
+		t.Fatalf("status = %+v", status)
+	}
+	stubPickerVersion(t, "2.1.243")
+	var checks []doctorCheck
+	doctorModelPickerCheck(func(section, name, status, finding, fix string, fixArgv ...string) {
+		checks = append(checks, doctorCheck{Section: section, Name: name, Status: status, Finding: finding, Fix: fix})
+	}, a)
+	if len(checks) != 1 || checks[0].Status != docWarn || !strings.Contains(checks[0].Finding, "possible Claude Code allowlist conflict") ||
+		!strings.Contains(checks[0].Finding, "managed_policy=unverified") || !strings.Contains(checks[0].Finding, "saved default") {
+		t.Fatalf("doctor checks = %+v", checks)
+	}
+}
+
+func TestPickerDoctorFailsReplacementModeWithExplicitConversionFix(t *testing.T) {
+	env := newSubagentTestEnv(t, true)
+	if err := config.SetClientModelPicker(env.cfgPath, "claude-code", &config.ModelPicker{
+		Enabled: true, Models: []config.ModelPickerModel{{Alias: "claude-baseten-glm-5-2"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	root := readTree(t, env.settings)
+	root["modelPicker"] = map[string]any{"replaceBuiltInOptions": true, "options": []any{}}
+	raw, _ := json.Marshal(root)
+	if err := os.WriteFile(env.settings, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stubPickerVersion(t, "2.1.243")
+	a, _ := newClaudeAdapterFromEnv()
+	var checks []doctorCheck
+	doctorModelPickerCheck(func(section, name, status, finding, fix string, fixArgv ...string) {
+		checks = append(checks, doctorCheck{Section: section, Name: name, Status: status, Finding: finding, Fix: fix})
+	}, a)
+	if len(checks) != 1 || checks[0].Status != docFail || !strings.Contains(checks[0].Finding, "replacement mode") ||
+		!strings.Contains(checks[0].Fix, "--convert-replacement-mode") {
+		t.Fatalf("doctor checks = %+v", checks)
+	}
+}
+
+func TestPickerDoctorFailsDisabledOutOfSyncWithValidSyncFix(t *testing.T) {
+	env, a := prepareManagedPicker(t, true)
+	if err := config.SetClientModelPicker(env.cfgPath, "claude-code", &config.ModelPicker{Enabled: false}); err != nil {
+		t.Fatal(err)
+	}
+	var checks []doctorCheck
+	doctorModelPickerCheck(func(section, name, status, finding, fix string, fixArgv ...string) {
+		checks = append(checks, doctorCheck{Section: section, Name: name, Status: status, Finding: finding, Fix: fix})
+	}, a)
+	if len(checks) != 1 || checks[0].Status != docFail || !strings.Contains(checks[0].Finding, "not synchronized") ||
+		checks[0].Fix != "baseten-switch claude picker sync" {
+		t.Fatalf("doctor checks = %+v", checks)
+	}
+}
+
+func TestPickerVersionProbeResolvesSymlinkAndRejectsUnsafeOutput(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "claude-real")
+	link := filepath.Join(dir, "claude")
+	if err := os.WriteFile(target, []byte("stub"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	oldLook, oldCommand := claudePickerLookPath, claudePickerCommand
+	t.Cleanup(func() { claudePickerLookPath, claudePickerCommand = oldLook, oldCommand })
+	claudePickerLookPath = func(string) (string, error) { return link, nil }
+	resolvedTarget, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claudePickerCommand = func(_ context.Context, path string, _ ...string) ([]byte, error) {
+		if path != resolvedTarget {
+			t.Fatalf("version command path=%q, want resolved %q", path, resolvedTarget)
+		}
+		return []byte("2.1.243"), nil
+	}
+	if err := checkClaudeModelPickerVersion(); err != nil {
+		t.Fatal(err)
+	}
+	claudePickerLookPath = func(string) (string, error) { return "relative/claude", nil }
+	if err := checkClaudeModelPickerVersion(); err == nil {
+		t.Fatal("expected relative executable rejection")
+	}
+	claudePickerLookPath = func(string) (string, error) { return target, nil }
+	claudePickerCommand = func(context.Context, string, ...string) ([]byte, error) { return []byte("not-a-version"), nil }
+	if err := checkClaudeModelPickerVersion(); err == nil {
+		t.Fatal("expected malformed version rejection")
+	}
+	claudePickerCommand = func(context.Context, string, ...string) ([]byte, error) {
+		return bytes.Repeat([]byte("x"), claudeModelPickerVersionOutputLimit+1), nil
+	}
+	if err := checkClaudeModelPickerVersion(); err == nil {
+		t.Fatal("expected oversized version output rejection")
+	}
+}
+
+func TestPickerVersionProbeReportsMissingExecutable(t *testing.T) {
+	oldLook := claudePickerLookPath
+	t.Cleanup(func() { claudePickerLookPath = oldLook })
+	claudePickerLookPath = func(string) (string, error) { return "", os.ErrNotExist }
+	if err := checkClaudeModelPickerVersion(); err == nil || !strings.Contains(err.Error(), claudeModelPickerMinVersion) {
+		t.Fatalf("missing executable error = %v", err)
+	}
+}
+
+func TestPickerVersionProbeTimeout(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "claude")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\nsleep 1\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	oldLook, oldCommand, oldTimeout := claudePickerLookPath, claudePickerCommand, claudePickerVersionTimeout
+	t.Cleanup(func() {
+		claudePickerLookPath, claudePickerCommand, claudePickerVersionTimeout = oldLook, oldCommand, oldTimeout
+	})
+	claudePickerLookPath = func(string) (string, error) { return bin, nil }
+	claudePickerCommand = boundedClaudePickerCommand
+	claudePickerVersionTimeout = 20 * time.Millisecond
+	if err := checkClaudeModelPickerVersion(); err == nil {
+		t.Fatal("expected bounded version timeout")
+	}
+}

--- a/gateway/cmd/baseten-switch/claude_picker_safety_test.go
+++ b/gateway/cmd/baseten-switch/claude_picker_safety_test.go
@@ -498,6 +498,49 @@ func TestPickerEnableAbsentCreatesEmptySelectionWithoutCopyingAliases(t *testing
 	}
 }
 
+func TestPickerEnableAbsentWithRunningRouterPublishesTerminalAndSyncsSettings(t *testing.T) {
+	env := newSubagentTestEnv(t, false)
+	stubPickerVersion(t, "2.1.243")
+	a, err := newClaudeAdapterFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc := a.on(); rc != 0 {
+		t.Fatalf("claude on rc=%d", rc)
+	}
+	const operationID = "empty-enable-running-router"
+	var out bytes.Buffer
+	if rc := a.mutatePickerConfig(
+		[]string{"enable"},
+		mutationOptions{JSON: true, OperationID: operationID},
+		&out,
+	); rc != 0 {
+		t.Fatalf("enable rc=%d output=%s", rc, out.String())
+	}
+	receipt := decodeMutationResult(t, out.String())
+	if !receipt.OK || !receipt.Applied || receipt.ReconciliationRequired ||
+		receipt.Outcome != mutationOutcomeApplied {
+		t.Fatalf("enable receipt = %+v", receipt)
+	}
+	terminal, err := readMutationTerminal(env.cfgPath, operationID)
+	if err != nil {
+		t.Fatalf("read enable terminal: %v", err)
+	}
+	if terminal.Operation != "enable_claude_picker" ||
+		terminal.RequestedTargetHash != "" ||
+		terminal.Outcome != mutationOutcomeApplied {
+		t.Fatalf("enable terminal = %+v", terminal)
+	}
+	obj, exists, err := modelPickerObject(readTree(t, env.settings))
+	if err != nil || !exists {
+		t.Fatalf("Claude settings modelPicker exists=%t err=%v", exists, err)
+	}
+	rows, err := modelPickerOptions(obj)
+	if err != nil || len(rows) != 0 || obj["replaceBuiltInOptions"] != false {
+		t.Fatalf("Claude settings modelPicker = %#v, rows=%#v, err=%v", obj, rows, err)
+	}
+}
+
 func TestPickerEnableAbsentSucceedsWithoutAliases(t *testing.T) {
 	env := newSubagentTestEnv(t, true)
 	raw, err := os.ReadFile(env.cfgPath)

--- a/gateway/cmd/baseten-switch/claude_picker_test.go
+++ b/gateway/cmd/baseten-switch/claude_picker_test.go
@@ -260,8 +260,20 @@ func TestPickerAddRejectsAbsentLiveKnownSubMinimumContextBeforeAnyWrite(t *testi
 	}
 }
 
-func TestPickerEnableRejectsLastKnownSubMinimumWhenLiveCatalogUnavailableBeforeAnyWrite(t *testing.T) {
+func TestPickerReenableRejectsLastKnownSubMinimumWhenLiveCatalogUnavailableBeforeAnyWrite(t *testing.T) {
 	env := newSubagentTestEnv(t, true)
+	if err := config.SetClientModelPicker(
+		env.cfgPath,
+		"claude-code",
+		&config.ModelPicker{
+			Enabled: false,
+			Models: []config.ModelPickerModel{{
+				Alias: "claude-baseten-glm-5-2",
+			}},
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
 	stubPickerCatalogResult(
 		t,
 		"error",

--- a/gateway/cmd/baseten-switch/claude_picker_test.go
+++ b/gateway/cmd/baseten-switch/claude_picker_test.go
@@ -1,0 +1,351 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
+)
+
+func pickerTestRows(ids ...string) []any {
+	rows := make([]any, 0, len(ids))
+	for _, id := range ids {
+		rows = append(rows, map[string]any{"model": id, "label": id + " label"})
+	}
+	return rows
+}
+
+func TestPickerAddDryRunJSONDoesNotWrite(t *testing.T) {
+	env := newSubagentTestEnv(t, true)
+	a, err := newClaudeAdapterFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeConfig, err := os.ReadFile(env.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeSettings, err := os.ReadFile(env.settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	rc := a.mutatePickerConfig(
+		[]string{"add", "example-org/New_Model-v1"},
+		mutationOptions{JSON: true, DryRun: true, OperationID: "preview"},
+		&out,
+	)
+	if rc != 0 {
+		t.Fatalf("dry-run rc=%d stderr=%v", rc, a.out)
+	}
+	var preview claudePickerPreview
+	if err := json.Unmarshal(out.Bytes(), &preview); err != nil {
+		t.Fatalf("parse preview %q: %v", out.String(), err)
+	}
+	if preview.Alias != "claude-baseten-new-model-v1" || preview.Slug != "example-org/New_Model-v1" ||
+		preview.Label != "New Model v1 via Baseten" || preview.Description != "Served by Baseten." {
+		t.Fatalf("preview = %+v", preview)
+	}
+	afterConfig, _ := os.ReadFile(env.cfgPath)
+	afterSettings, _ := os.ReadFile(env.settings)
+	if !bytes.Equal(beforeConfig, afterConfig) || !bytes.Equal(beforeSettings, afterSettings) {
+		t.Fatal("dry-run changed config or Claude settings")
+	}
+}
+
+func TestPickerAddGeneratesAliasAndInstallsRow(t *testing.T) {
+	env := newSubagentTestEnv(t, true)
+	if err := config.SetClientModelPicker(env.cfgPath, "claude-code", &config.ModelPicker{Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(t.TempDir(), "claude")
+	if err := os.WriteFile(bin, []byte("stub"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	oldLook, oldCommand := claudePickerLookPath, claudePickerCommand
+	t.Cleanup(func() { claudePickerLookPath, claudePickerCommand = oldLook, oldCommand })
+	claudePickerLookPath = func(string) (string, error) { return bin, nil }
+	claudePickerCommand = func(context.Context, string, ...string) ([]byte, error) {
+		return []byte("2.1.243"), nil
+	}
+	a, err := newClaudeAdapterFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	rc := a.mutatePickerConfig(
+		[]string{"add", "example-org/New_Model-v1"},
+		mutationOptions{JSON: true, OperationID: "add-generated"},
+		&out,
+	)
+	if rc != 0 {
+		t.Fatalf("add rc=%d output=%s", rc, out.String())
+	}
+	var receipt mutationResult
+	if err := json.Unmarshal(out.Bytes(), &receipt); err != nil {
+		t.Fatalf("parse mutation receipt %q: %v", out.String(), err)
+	}
+	if !receipt.OK || receipt.Operation != "add_claude_picker_model" || receipt.OperationID != "add-generated" ||
+		receipt.DesiredConfigHash == "" || receipt.PreviousDesiredConfigHash == "" || !receipt.ReconciliationRequired {
+		t.Fatalf("mutation receipt = %+v", receipt)
+	}
+	if _, err := readMutationJournal(env.cfgPath, "add-generated"); err != nil {
+		t.Fatalf("picker config mutation was not journaled: %v", err)
+	}
+	f, err := config.Load(env.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := f.Clients[0]
+	const alias = "claude-baseten-new-model-v1"
+	if client.ModelAliases[alias] != "example-org/New_Model-v1" ||
+		client.ModelPicker == nil || len(client.ModelPicker.Models) != 1 || client.ModelPicker.Models[0].Alias != alias {
+		t.Fatalf("client config = %+v", client)
+	}
+	settings := readTree(t, env.settings)
+	picker := settings["modelPicker"].(map[string]any)
+	rows := picker["options"].([]any)
+	row := rows[0].(map[string]any)
+	if row["model"] != alias || row["label"] != "New Model v1 via Baseten" || row["description"] != "Served by Baseten." {
+		t.Fatalf("installed row = %#v", row)
+	}
+}
+
+func TestPickerSettingsFailureAfterAppliedConfigHasPickerSyncAction(t *testing.T) {
+	env := newSubagentTestEnv(t, false)
+	if err := config.SetClientModelPicker(env.cfgPath, "claude-code", &config.ModelPicker{Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(t.TempDir(), "claude")
+	if err := os.WriteFile(bin, []byte("stub"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	oldLook, oldCommand := claudePickerLookPath, claudePickerCommand
+	t.Cleanup(func() { claudePickerLookPath, claudePickerCommand = oldLook, oldCommand })
+	claudePickerLookPath = func(string) (string, error) { return bin, nil }
+	claudePickerCommand = func(context.Context, string, ...string) ([]byte, error) {
+		return []byte("2.1.242"), nil
+	}
+	a, err := newClaudeAdapterFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	rc := a.mutatePickerConfig(
+		[]string{"add", "example-org/New_Model-v1"},
+		mutationOptions{JSON: true, OperationID: "settings-failure"},
+		&out,
+	)
+	if rc != 1 {
+		t.Fatalf("add rc=%d output=%s", rc, out.String())
+	}
+	var receipt mutationResult
+	if err := json.Unmarshal(out.Bytes(), &receipt); err != nil {
+		t.Fatalf("parse mutation receipt %q: %v", out.String(), err)
+	}
+	if receipt.OK || !receipt.Applied || !receipt.ReconciliationRequired ||
+		receipt.ReconciliationAction != "claude_picker_sync" || receipt.Outcome != "settings_sync_pending" ||
+		receipt.Error == nil || receipt.Error.Code != "settings_sync_failed" {
+		t.Fatalf("mutation receipt = %+v", receipt)
+	}
+	if _, err := readMutationTerminal(env.cfgPath, "settings-failure"); err != nil {
+		t.Fatalf("applied picker config mutation has no terminal receipt: %v", err)
+	}
+}
+
+func TestCheckClaudeModelPickerVersion(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "claude")
+	if err := os.WriteFile(bin, []byte("stub"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	oldLook, oldCommand := claudePickerLookPath, claudePickerCommand
+	t.Cleanup(func() { claudePickerLookPath, claudePickerCommand = oldLook, oldCommand })
+	claudePickerLookPath = func(string) (string, error) { return bin, nil }
+	claudePickerCommand = func(context.Context, string, ...string) ([]byte, error) {
+		return []byte("2.1.243 (Claude Code)"), nil
+	}
+	if err := checkClaudeModelPickerVersion(); err != nil {
+		t.Fatal(err)
+	}
+	claudePickerCommand = func(context.Context, string, ...string) ([]byte, error) {
+		return []byte("2.1.242 (Claude Code)"), nil
+	}
+	if err := checkClaudeModelPickerVersion(); err == nil {
+		t.Fatal("expected old version error")
+	}
+}
+
+func TestParsePickerOptions(t *testing.T) {
+	opts, args, err := parsePickerOptions([]string{
+		"move", "a", "--before", "b", "--json", "--operation-id", "op-1",
+		"--if-active-token", "boot:2", "--if-config-hash", "sha256:abc", "--alias", "chosen", "--convert-replacement-mode",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !opts.JSON || opts.OperationID != "op-1" || !opts.hasOperationID || opts.PickerAlias != "chosen" || !opts.ConvertPickerReplacement {
+		t.Fatalf("opts = %+v", opts)
+	}
+	if !opts.hasActiveToken || opts.IfActiveToken != "boot:2" || !opts.hasConfigHash || opts.IfConfigHash != "sha256:abc" {
+		t.Fatalf("CAS opts = %+v", opts)
+	}
+	want := []string{"move", "a", "--before", "b"}
+	if len(args) != len(want) {
+		t.Fatalf("args = %v", args)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Fatalf("args = %v", args)
+		}
+	}
+}
+
+func TestInstallModelPickerPreservesExternalRows(t *testing.T) {
+	root := map[string]any{
+		"theme": "dark",
+		"modelPicker": map[string]any{
+			"options": pickerTestRows("external"),
+			"future":  "keep",
+		},
+	}
+	bak, changed, err := installModelPicker(root, pickerTestRows("claude-baseten-a"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed || bak == nil || bak.OriginalMissing {
+		t.Fatalf("changed=%t backup=%+v", changed, bak)
+	}
+	obj, _, err := modelPickerObject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := modelPickerOptions(obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 || rowModel(rows[0]) != "external" || rowModel(rows[1]) != "claude-baseten-a" {
+		t.Fatalf("rows = %#v", rows)
+	}
+	if obj["future"] != "keep" || obj["replaceBuiltInOptions"] != false {
+		t.Fatalf("object = %#v", obj)
+	}
+	if _, err := cleanupModelPicker(root, bak, true); err != nil {
+		t.Fatal(err)
+	}
+	obj, _, _ = modelPickerObject(root)
+	rows, _ = modelPickerOptions(obj)
+	if len(rows) != 1 || rowModel(rows[0]) != "external" || obj["future"] != "keep" {
+		t.Fatalf("restored object = %#v", obj)
+	}
+}
+
+func TestInstallModelPickerRefusesSameIDExternalRow(t *testing.T) {
+	root := map[string]any{"modelPicker": map[string]any{"options": pickerTestRows("claude-baseten-a")}}
+	if _, _, err := installModelPicker(root, pickerTestRows("claude-baseten-a"), nil); err == nil {
+		t.Fatal("expected duplicate identity error")
+	}
+}
+
+func TestCleanupModelPickerRefusesMovedExactOwnedRow(t *testing.T) {
+	root := map[string]any{}
+	bak, _, err := installModelPicker(root, pickerTestRows("claude-baseten-a"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, _, _ := modelPickerObject(root)
+	rows, _ := modelPickerOptions(obj)
+	rows = append([]any{map[string]any{"model": "external", "label": "keep"}}, rows...)
+	obj["options"] = rows
+	changed, err := cleanupModelPicker(root, bak, false)
+	if err == nil || changed {
+		t.Fatalf("cleanup changed=%t err=%v, want moved-row refusal", changed, err)
+	}
+	obj, exists, _ := modelPickerObject(root)
+	if !exists {
+		t.Fatal("external picker object was removed")
+	}
+	rows, _ = modelPickerOptions(obj)
+	if len(rows) != 2 || rowModel(rows[0]) != "external" || rowModel(rows[1]) != "claude-baseten-a" {
+		t.Fatalf("rows = %#v", rows)
+	}
+}
+
+func TestCleanupModelPickerDriftRemovesAnchoredRowAndPreservesLaterExternalRow(t *testing.T) {
+	root := map[string]any{}
+	bak, _, err := installModelPicker(root, pickerTestRows("claude-baseten-a"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, _, _ := modelPickerObject(root)
+	rows, _ := modelPickerOptions(obj)
+	obj["options"] = append(rows, map[string]any{"model": "external", "label": "keep"})
+	changed, err := cleanupModelPicker(root, bak, false)
+	if err != nil || !changed {
+		t.Fatalf("cleanup changed=%t err=%v", changed, err)
+	}
+	obj, exists, _ := modelPickerObject(root)
+	if !exists {
+		t.Fatal("external picker object was removed")
+	}
+	rows, _ = modelPickerOptions(obj)
+	if len(rows) != 1 || rowModel(rows[0]) != "external" {
+		t.Fatalf("rows = %#v", rows)
+	}
+}
+
+func TestCleanupModelPickerRefusesEditedOwnedRow(t *testing.T) {
+	root := map[string]any{}
+	bak, _, err := installModelPicker(root, pickerTestRows("claude-baseten-a"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, _, _ := modelPickerObject(root)
+	obj["options"] = []any{map[string]any{"model": "claude-baseten-a", "label": "user edited"}}
+	if _, err := cleanupModelPicker(root, bak, false); err == nil {
+		t.Fatal("expected edited row ownership error")
+	}
+}
+
+func TestClaudePickerBackupRoundTrip(t *testing.T) {
+	bak := claudeBackup{
+		ConfigPath: "/tmp/settings.json", Values: map[string]string{},
+		ModelPicker: &claudeModelPickerBackup{
+			Original:                 json.RawMessage(`{"options":[{"model":"external"}]}`),
+			WrittenRows:              []json.RawMessage{json.RawMessage(`{"label":"A","model":"claude-baseten-a"}`)},
+			WrittenAnchor:            1,
+			WrittenPickerFingerprint: "fingerprint",
+		},
+	}
+	raw, err := json.Marshal(bak)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got claudeBackup
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	clone := cloneClaudeBackup(&got)
+	clone.ModelPicker.WrittenRows[0][0] = '['
+	if got.ModelPicker.WrittenRows[0][0] == '[' {
+		t.Fatal("clone shares picker row backing array")
+	}
+}
+
+func TestClaudePickerRowsProjectSavedPresentation(t *testing.T) {
+	p := &config.ModelPicker{Enabled: true, Models: []config.ModelPickerModel{{
+		Alias: "claude-baseten-a",
+	}}}
+	rows := claudePickerRows(p, map[string]string{"claude-baseten-a": "org/GLM-5.2"})
+	if len(rows) != 1 {
+		t.Fatalf("rows = %#v", rows)
+	}
+	row := rows[0].(map[string]any)
+	if row["model"] != "claude-baseten-a" || row["label"] != "GLM 5.2 via Baseten" || row["description"] != "Served by Baseten." {
+		t.Fatalf("row = %#v", row)
+	}
+}

--- a/gateway/cmd/baseten-switch/claude_picker_test.go
+++ b/gateway/cmd/baseten-switch/claude_picker_test.go
@@ -4,12 +4,97 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
 )
+
+func prepareMillionContextPicker(
+	t *testing.T,
+) (*subagentTestEnv, *claudeAdapter, func(bool, int64)) {
+	t.Helper()
+	env := newSubagentTestEnv(t, true)
+	if err := config.SetClientModelPicker(
+		env.cfgPath,
+		"claude-code",
+		&config.ModelPicker{
+			Enabled: true,
+			Models: []config.ModelPickerModel{{
+				Alias: "claude-baseten-glm-5-2",
+			}},
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+	a, err := newClaudeAdapterFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc := a.on(); rc != 0 {
+		t.Fatalf("claude on rc=%d", rc)
+	}
+	online := true
+	contextTokens := int64(1_048_576)
+	oldFetch := fetchRoutingAdminStatus
+	t.Cleanup(func() { fetchRoutingAdminStatus = oldFetch })
+	fetchRoutingAdminStatus = func(string) (routingAdminStatus, error) {
+		if !online {
+			return routingAdminStatus{}, errors.New("router unavailable")
+		}
+		raw, _, err := readExactConfig(env.cfgPath)
+		if err != nil {
+			return routingAdminStatus{}, err
+		}
+		return routingAdminStatus{
+			ConfigPath:        env.cfgPath,
+			RouterPID:         os.Getpid(),
+			RouterBootID:      "picker-context-test",
+			ActiveGeneration:  1,
+			ActiveConfigHash:  exactConfigHash(raw),
+			DesiredConfigHash: exactConfigHash(raw),
+			Clients: []fallbackAdminClient{{
+				Name: "claude-code",
+				ModelPicker: &modelPickerAdminStatus{
+					Enabled: true,
+					Models: []modelPickerAdminStatusModel{{
+						Alias:         "claude-baseten-glm-5-2",
+						Slug:          "zai-org/GLM-5.2",
+						ContextTokens: contextTokens,
+					}},
+				},
+			}},
+		}, nil
+	}
+	setProjection := func(wantOnline bool, tokens int64) {
+		online = wantOnline
+		contextTokens = tokens
+		if wantOnline {
+			if err := os.WriteFile(
+				gatewayPidfilePath(),
+				[]byte(fmt.Sprintf("%d\n", os.Getpid())),
+				0o600,
+			); err != nil {
+				t.Fatal(err)
+			}
+			return
+		}
+		if err := os.Remove(gatewayPidfilePath()); err != nil &&
+			!errors.Is(err, os.ErrNotExist) {
+			t.Fatal(err)
+		}
+	}
+	setProjection(true, contextTokens)
+	if err := a.syncModelPicker(false); err != nil {
+		t.Fatalf("initial one-million picker sync: %v", err)
+	}
+	return env, a, setProjection
+}
 
 func pickerTestRows(ids ...string) []any {
 	rows := make([]any, 0, len(ids))
@@ -17,6 +102,42 @@ func pickerTestRows(ids ...string) []any {
 		rows = append(rows, map[string]any{"model": id, "label": id + " label"})
 	}
 	return rows
+}
+
+func stubPickerCatalog(
+	t *testing.T,
+	models ...claudePickerCatalogModel,
+) {
+	stubPickerCatalogProjection(t, models, models)
+}
+
+func stubPickerCatalogProjection(
+	t *testing.T,
+	liveModels []claudePickerCatalogModel,
+	contextLimits []claudePickerCatalogModel,
+) {
+	stubPickerCatalogResult(t, "ready", liveModels, contextLimits)
+}
+
+func stubPickerCatalogResult(
+	t *testing.T,
+	state string,
+	liveModels []claudePickerCatalogModel,
+	contextLimits []claudePickerCatalogModel,
+) {
+	t.Helper()
+	oldFetch := fetchClaudePickerCatalog
+	t.Cleanup(func() { fetchClaudePickerCatalog = oldFetch })
+	fetchClaudePickerCatalog = func(string) (
+		claudePickerCatalogResponse,
+		error,
+	) {
+		return claudePickerCatalogResponse{
+			State:         state,
+			Models:        liveModels,
+			ContextLimits: contextLimits,
+		}, nil
+	}
 }
 
 func TestPickerAddDryRunJSONDoesNotWrite(t *testing.T) {
@@ -57,7 +178,146 @@ func TestPickerAddDryRunJSONDoesNotWrite(t *testing.T) {
 	}
 }
 
-func TestPickerAddGeneratesAliasAndInstallsRow(t *testing.T) {
+func TestPickerAddRejectsAbsentLiveKnownSubMinimumContextBeforeAnyWrite(t *testing.T) {
+	env := newSubagentTestEnv(t, true)
+	if err := config.SetClientModelPicker(
+		env.cfgPath,
+		"claude-code",
+		&config.ModelPicker{Enabled: true},
+	); err != nil {
+		t.Fatal(err)
+	}
+	stubPickerCatalogProjection(
+		t,
+		[]claudePickerCatalogModel{},
+		[]claudePickerCatalogModel{{
+			Slug: "example-org/Small-Model", ContextTokens: 199_999,
+		}},
+	)
+	a, err := newClaudeAdapterFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeConfig, err := os.ReadFile(env.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeSettings, err := os.ReadFile(env.settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var dryRun bytes.Buffer
+	dryRunRC := a.mutatePickerConfig(
+		[]string{"add", "example-org/Small-Model"},
+		mutationOptions{
+			JSON: true, DryRun: true,
+			OperationID: "preview-reject-small-picker-model",
+		},
+		&dryRun,
+	)
+	var dryRunResult mutationResult
+	if dryRunRC != 1 || json.Unmarshal(
+		dryRun.Bytes(),
+		&dryRunResult,
+	) != nil || dryRunResult.Error == nil ||
+		dryRunResult.Error.Code != claudePickerContextMinimumErrorCode ||
+		dryRunResult.Error.Retryable {
+		t.Fatalf("dry-run rc=%d result=%+v output=%s",
+			dryRunRC, dryRunResult, dryRun.String())
+	}
+	var out bytes.Buffer
+	rc := a.mutatePickerConfig(
+		[]string{"add", "example-org/Small-Model"},
+		mutationOptions{
+			JSON: true, OperationID: "reject-small-picker-model",
+		},
+		&out,
+	)
+	if rc != 1 {
+		t.Fatalf("add rc=%d output=%s", rc, out.String())
+	}
+	var result mutationResult
+	if err := json.Unmarshal(out.Bytes(), &result); err != nil {
+		t.Fatalf("parse mutation result %q: %v", out.String(), err)
+	}
+	if result.OK || result.Operation != "add_claude_picker_model" ||
+		result.Error == nil ||
+		result.Error.Code != claudePickerContextMinimumErrorCode ||
+		result.Error.Retryable {
+		t.Fatalf("mutation result = %+v", result)
+	}
+	afterConfig, err := os.ReadFile(env.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterSettings, err := os.ReadFile(env.settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(beforeConfig, afterConfig) ||
+		!bytes.Equal(beforeSettings, afterSettings) {
+		t.Fatal("rejected add changed config or Claude settings")
+	}
+}
+
+func TestPickerEnableRejectsLastKnownSubMinimumWhenLiveCatalogUnavailableBeforeAnyWrite(t *testing.T) {
+	env := newSubagentTestEnv(t, true)
+	stubPickerCatalogResult(
+		t,
+		"error",
+		[]claudePickerCatalogModel{},
+		[]claudePickerCatalogModel{{
+			Slug: "zai-org/GLM-5.2", ContextTokens: 1,
+		}},
+	)
+	a, err := newClaudeAdapterFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeConfig, err := os.ReadFile(env.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeSettings, err := os.ReadFile(env.settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	rc := a.mutatePickerConfig(
+		[]string{"enable"},
+		mutationOptions{
+			JSON: true, OperationID: "reject-small-picker-enable",
+		},
+		&out,
+	)
+	if rc != 1 {
+		t.Fatalf("enable rc=%d output=%s", rc, out.String())
+	}
+	var result mutationResult
+	if err := json.Unmarshal(out.Bytes(), &result); err != nil {
+		t.Fatalf("parse mutation result %q: %v", out.String(), err)
+	}
+	if result.OK || result.Operation != "enable_claude_picker" ||
+		result.Error == nil ||
+		result.Error.Code != claudePickerContextMinimumErrorCode ||
+		result.Error.Retryable {
+		t.Fatalf("mutation result = %+v", result)
+	}
+	afterConfig, err := os.ReadFile(env.cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterSettings, err := os.ReadFile(env.settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(beforeConfig, afterConfig) ||
+		!bytes.Equal(beforeSettings, afterSettings) {
+		t.Fatal("rejected enable changed config or Claude settings")
+	}
+}
+
+func TestPickerAddAllowsGenuinelyUnknownContextAndInstallsConservativeRow(t *testing.T) {
 	env := newSubagentTestEnv(t, true)
 	if err := config.SetClientModelPicker(env.cfgPath, "claude-code", &config.ModelPicker{Enabled: true}); err != nil {
 		t.Fatal(err)
@@ -72,6 +332,11 @@ func TestPickerAddGeneratesAliasAndInstallsRow(t *testing.T) {
 	claudePickerCommand = func(context.Context, string, ...string) ([]byte, error) {
 		return []byte("2.1.243"), nil
 	}
+	stubPickerCatalogProjection(
+		t,
+		[]claudePickerCatalogModel{{Slug: "example-org/New_Model-v1"}},
+		[]claudePickerCatalogModel{},
+	)
 	a, err := newClaudeAdapterFromEnv()
 	if err != nil {
 		t.Fatal(err)
@@ -340,12 +605,262 @@ func TestClaudePickerRowsProjectSavedPresentation(t *testing.T) {
 	p := &config.ModelPicker{Enabled: true, Models: []config.ModelPickerModel{{
 		Alias: "claude-baseten-a",
 	}}}
-	rows := claudePickerRows(p, map[string]string{"claude-baseten-a": "org/GLM-5.2"})
+	rows, err := claudePickerRows(
+		p,
+		map[string]string{"claude-baseten-a": "org/GLM-5.2"},
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(rows) != 1 {
 		t.Fatalf("rows = %#v", rows)
 	}
 	row := rows[0].(map[string]any)
 	if row["model"] != "claude-baseten-a" || row["label"] != "GLM 5.2 via Baseten" || row["description"] != "Served by Baseten." {
 		t.Fatalf("row = %#v", row)
+	}
+}
+
+func TestClaudePickerRowsProjectExactContextBuckets(t *testing.T) {
+	p := &config.ModelPicker{Enabled: true, Models: []config.ModelPickerModel{
+		{Alias: "claude-baseten-million"},
+		{Alias: "claude-baseten-standard"},
+		{Alias: "claude-baseten-unknown"},
+	}}
+	aliases := map[string]string{
+		"claude-baseten-million":  "org/model-million",
+		"claude-baseten-standard": "org/model-standard",
+		"claude-baseten-unknown":  "org/model-name-claims-1m",
+	}
+	rows, err := claudePickerRows(p, aliases, map[string]int64{
+		"org/model-million":  1_048_576,
+		"org/model-standard": 200_000,
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	models := make([]string, 0, len(rows))
+	for _, raw := range rows {
+		row := raw.(map[string]any)
+		if _, exists := row["behavesAs"]; exists {
+			t.Fatalf("generated row contains behavesAs: %#v", row)
+		}
+		models = append(models, row["model"].(string))
+	}
+	want := []string{
+		"claude-baseten-million[1m]",
+		"claude-baseten-standard",
+		"claude-baseten-unknown",
+	}
+	if !reflect.DeepEqual(models, want) {
+		t.Fatalf("models = %v, want %v", models, want)
+	}
+}
+
+func TestClaudePickerRowsContextBoundaries(t *testing.T) {
+	const alias = "claude-baseten-boundary"
+	const slug = "org/model"
+	picker := &config.ModelPicker{
+		Enabled: true,
+		Models:  []config.ModelPickerModel{{Alias: alias}},
+	}
+	aliases := map[string]string{alias: slug}
+	tests := []struct {
+		name      string
+		context   map[string]int64
+		wantModel string
+		wantErr   bool
+	}{
+		{name: "missing", context: map[string]int64{}, wantModel: alias},
+		{name: "zero", context: map[string]int64{slug: 0}, wantModel: alias},
+		{name: "one", context: map[string]int64{slug: 1}, wantErr: true},
+		{name: "199999", context: map[string]int64{slug: 199_999}, wantErr: true},
+		{name: "200000", context: map[string]int64{slug: 200_000}, wantModel: alias},
+		{name: "999999", context: map[string]int64{slug: 999_999}, wantModel: alias},
+		{name: "1000000", context: map[string]int64{slug: 1_000_000}, wantModel: alias + "[1m]"},
+		{name: "1048576", context: map[string]int64{slug: 1_048_576}, wantModel: alias + "[1m]"},
+		{name: "above one million", context: map[string]int64{slug: 2_000_000}, wantModel: alias + "[1m]"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rows, err := claudePickerRows(picker, aliases, tc.context, nil)
+			if tc.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "below Claude Code's 200000-token model picker minimum") {
+					t.Fatalf("error = %v, want actionable unsupported-limit error", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			row := rows[0].(map[string]any)
+			if got := rowModel(row); got != tc.wantModel {
+				t.Fatalf("model = %q, want %q", got, tc.wantModel)
+			}
+			if _, exists := row["behavesAs"]; exists {
+				t.Fatalf("generated row contains behavesAs: %#v", row)
+			}
+		})
+	}
+}
+
+func TestClaudePickerRowsRejectDuplicateAliases(t *testing.T) {
+	picker := &config.ModelPicker{
+		Enabled: true,
+		Models: []config.ModelPickerModel{
+			{Alias: "claude-baseten-duplicate"},
+			{Alias: "claude-baseten-duplicate"},
+		},
+	}
+	_, err := claudePickerRows(
+		picker,
+		map[string]string{"claude-baseten-duplicate": "org/model"},
+		map[string]int64{"org/model": 200_000},
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "is duplicated") {
+		t.Fatalf("error = %v, want duplicate alias error", err)
+	}
+}
+
+func TestPickerContextTokensFromAdminUsesExactClientRows(t *testing.T) {
+	status := routingAdminStatus{Clients: []fallbackAdminClient{
+		{
+			Name: "other-client",
+			ModelPicker: &modelPickerAdminStatus{Models: []modelPickerAdminStatusModel{{
+				Slug: "org/shared", ContextTokens: 200_000,
+			}}},
+		},
+		{
+			Name: "claude-code",
+			ModelPicker: &modelPickerAdminStatus{Models: []modelPickerAdminStatusModel{
+				{Slug: "org/shared", ContextTokens: 1_048_576},
+				{Slug: "org/unknown", ContextTokens: 0},
+			}},
+		},
+	}}
+	got := pickerContextTokensFromAdmin(status, "claude-code")
+	want := map[string]int64{
+		"org/shared":  1_048_576,
+		"org/unknown": 0,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("context tokens = %v, want %v", got, want)
+	}
+}
+
+func TestOfflinePickerStatusAndSyncPreserveOwnedOneMillionSuffix(t *testing.T) {
+	env, a, setProjection := prepareMillionContextPicker(t)
+	setProjection(false, 0)
+
+	status, err := a.currentPickerStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.UserFileSync != "synced" {
+		t.Fatalf("offline user_file_sync = %q, want synced", status.UserFileSync)
+	}
+	if err := a.syncModelPicker(false); err != nil {
+		t.Fatalf("offline picker sync: %v", err)
+	}
+	root := readTree(t, env.settings)
+	obj, _, err := modelPickerObject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := modelPickerOptions(obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := rowModel(rows[0]); got != "claude-baseten-glm-5-2[1m]" {
+		t.Fatalf("offline picker model = %q, want preserved [1m] suffix", got)
+	}
+}
+
+func TestTrustedUnknownContextDowngradesOwnedOneMillionSuffix(t *testing.T) {
+	env, a, setProjection := prepareMillionContextPicker(t)
+	root := readTree(t, env.settings)
+	root["model"] = "claude-baseten-glm-5-2[1M]"
+	raw, err := json.Marshal(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(env.settings, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	warnings := a.pickerRemovalWarnings("claude-baseten-glm-5-2")
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "saved Claude default model") {
+		t.Fatalf("decorated saved-default removal warnings = %v", warnings)
+	}
+	setProjection(true, 0)
+
+	if err := a.syncModelPicker(false); err != nil {
+		t.Fatalf("known-unknown picker sync: %v", err)
+	}
+	root = readTree(t, env.settings)
+	obj, _, err := modelPickerObject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := modelPickerOptions(obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := rowModel(rows[0]); got != "claude-baseten-glm-5-2" {
+		t.Fatalf("known-unknown picker model = %q, want conservative bare alias", got)
+	}
+	if got := root["model"]; got != "claude-baseten-glm-5-2[1M]" {
+		t.Fatalf("saved default was mutated: %v", got)
+	}
+	status, err := a.currentPickerStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.UserFileSync != "synced" {
+		t.Fatalf("known-unknown user_file_sync = %q, want synced", status.UserFileSync)
+	}
+	if status.SavedModelUnconfigured || !status.SavedModelContextMismatch {
+		t.Fatalf(
+			"saved default diagnostics = unconfigured:%t context_mismatch:%t",
+			status.SavedModelUnconfigured,
+			status.SavedModelContextMismatch,
+		)
+	}
+}
+
+func TestKnownUnsupportedContextBlocksPickerSync(t *testing.T) {
+	env, a, setProjection := prepareMillionContextPicker(t)
+	setProjection(true, 199_999)
+
+	err := a.syncModelPicker(false)
+	if err == nil || !strings.Contains(
+		err.Error(),
+		"below Claude Code's 200000-token model picker minimum",
+	) {
+		t.Fatalf("sync error = %v, want actionable unsupported-limit error", err)
+	}
+	root := readTree(t, env.settings)
+	obj, _, objectErr := modelPickerObject(root)
+	if objectErr != nil {
+		t.Fatal(objectErr)
+	}
+	rows, rowsErr := modelPickerOptions(obj)
+	if rowsErr != nil {
+		t.Fatal(rowsErr)
+	}
+	if got := rowModel(rows[0]); got != "claude-baseten-glm-5-2[1m]" {
+		t.Fatalf("failed sync changed installed picker row to %q", got)
+	}
+	status, statusErr := a.currentPickerStatus()
+	if statusErr != nil {
+		t.Fatal(statusErr)
+	}
+	if status.UserFileSync != "blocked" || !strings.Contains(
+		status.Message,
+		"below Claude Code's 200000-token model picker minimum",
+	) {
+		t.Fatalf("status = %+v, want blocked actionable diagnostic", status)
 	}
 }

--- a/gateway/cmd/baseten-switch/config.go
+++ b/gateway/cmd/baseten-switch/config.go
@@ -13,6 +13,8 @@ func cmdConfig(args []string) int {
 	switch args[0] {
 	case "init":
 		return cmdConfigInit(args[1:])
+	case "fallback":
+		return cmdConfigFallback(args[1:])
 	case "reset":
 		return cmdConfigReset(args[1:])
 	case "preview-snapshot":
@@ -25,4 +27,4 @@ func cmdConfig(args []string) int {
 	}
 }
 
-const configUsage = "usage: baseten-switch config init [--force] | baseten-switch config reset --yes [--preview-root PATH --router-addr HOST:PORT --door-addr HOST:PORT]"
+const configUsage = "usage: baseten-switch config init [--force] | baseten-switch config reset --yes [--preview-root PATH --router-addr HOST:PORT --door-addr HOST:PORT] | baseten-switch config fallback ..."

--- a/gateway/cmd/baseten-switch/config_fallback.go
+++ b/gateway/cmd/baseten-switch/config_fallback.go
@@ -1,0 +1,343 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/basetenlabs/baseten-switch/gateway/cmd/gateway"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
+)
+
+const configFallbackUsage = `usage:
+  baseten-switch config fallback status [--json]
+  baseten-switch config fallback 429 on|off [mutation options]
+  baseten-switch config fallback 5xx on|off [mutation options]
+  baseten-switch config fallback model <client> [--json]
+  baseten-switch config fallback model <client> <native-model> [mutation options]`
+
+type fallbackAdminClient struct {
+	Name                 string `json:"name"`
+	BasetenModelFallback struct {
+		ConfiguredModel string  `json:"configured_model"`
+		ResolvedModel   string  `json:"resolved_model"`
+		DisplayName     string  `json:"display_name"`
+		ProviderReady   bool    `json:"provider_ready"`
+		Ready           bool    `json:"ready"`
+		Reason          *string `json:"reason"`
+	} `json:"baseten_model_fallback"`
+}
+
+type fallbackReadStatus struct {
+	ConfigPath       string                         `json:"config_path"`
+	Configured       config.ResolvedFallbackPolicy  `json:"configured"`
+	Active           *config.ResolvedFallbackPolicy `json:"active,omitempty"`
+	DesiredActiveGap bool                           `json:"desired_active_mismatch"`
+	Clients          []fallbackReadClient           `json:"clients,omitempty"`
+}
+
+type fallbackReadClient struct {
+	Name            string `json:"name"`
+	ConfiguredModel string `json:"configured_model"`
+	ActiveModel     string `json:"active_model,omitempty"`
+	DisplayName     string `json:"display_name,omitempty"`
+	Ready           bool   `json:"ready"`
+	Reason          string `json:"reason,omitempty"`
+	activeKnown     bool
+}
+
+func cmdConfigFallback(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, configFallbackUsage)
+		return 2
+	}
+	opts, positional, err := parseMutationOptions(args)
+	if err != nil {
+		return failMutation(opts, os.Stdout, mutationResult{}, "usage", configFallbackUsage+": "+err.Error(), false, 2)
+	}
+	if len(positional) == 1 && positional[0] == "status" {
+		return readFallbackStatus(opts, "", os.Stdout)
+	}
+	if len(positional) == 2 && positional[0] == "model" {
+		return readFallbackStatus(opts, positional[1], os.Stdout)
+	}
+	if len(positional) == 2 && (positional[0] == "429" || positional[0] == "5xx") &&
+		(positional[1] == "on" || positional[1] == "off") {
+		return mutateFallbackPolicy(positional[0], positional[1] == "on", opts, os.Stdout)
+	}
+	if len(positional) == 3 && positional[0] == "model" {
+		return mutateNativeFallbackModel(positional[1], positional[2], opts, os.Stdout)
+	}
+	return failMutation(opts, os.Stdout, mutationResult{}, "usage", configFallbackUsage, false, 2)
+}
+
+func readFallbackStatus(opts mutationOptions, onlyClient string, out io.Writer) int {
+	if opts.hasOperationID || opts.hasActiveToken || opts.hasConfigHash {
+		return failMutation(opts, out, mutationResult{}, "usage", "read-only fallback status accepts only --json", false, 2)
+	}
+	path, notices := resolveConfigPath()
+	if !opts.JSON {
+		for _, notice := range notices {
+			fmt.Fprintln(os.Stderr, notice)
+		}
+	}
+	file, err := config.Load(path)
+	if err != nil {
+		message := config.MalformedConfigMessage(path, err)
+		if errors.Is(err, os.ErrNotExist) {
+			message = config.MissingConfigMessage(path)
+		}
+		return failMutation(opts, out, mutationResult{ConfigPath: path}, "config_load_failed", message, false, 1)
+	}
+	status := fallbackReadStatus{ConfigPath: path, Configured: config.ResolveFallbackPolicy(file.Global.FallbackPolicy)}
+	admin, adminOK := matchingFallbackAdminStatus(path)
+	if adminOK {
+		active := admin.FallbackPolicy
+		status.Active = &active
+		status.DesiredActiveGap = admin.ActiveConfigHash != "" && admin.DesiredConfigHash != "" && admin.ActiveConfigHash != admin.DesiredConfigHash
+	}
+	for _, client := range file.Clients {
+		if onlyClient != "" && client.Name != onlyClient {
+			continue
+		}
+		entry := fallbackReadClient{Name: client.Name, ConfiguredModel: client.NativeFallbackModel}
+		if adminOK {
+			for _, activeClient := range admin.Clients {
+				if activeClient.Name != client.Name {
+					continue
+				}
+				entry.ActiveModel = activeClient.BasetenModelFallback.ResolvedModel
+				entry.activeKnown = true
+				entry.DisplayName = activeClient.BasetenModelFallback.DisplayName
+				entry.Ready = activeClient.BasetenModelFallback.Ready
+				if activeClient.BasetenModelFallback.Reason != nil {
+					entry.Reason = *activeClient.BasetenModelFallback.Reason
+				}
+				break
+			}
+		}
+		status.Clients = append(status.Clients, entry)
+	}
+	if onlyClient != "" && len(status.Clients) == 0 {
+		return failMutation(opts, out, mutationResult{ConfigPath: path, Client: onlyClient}, "invalid_client", fmt.Sprintf("no client named %q", onlyClient), false, 2)
+	}
+	if opts.JSON {
+		emitJSON(out, status)
+		return 0
+	}
+	if onlyClient != "" {
+		printFallbackModelStatus(out, status.Clients[0], adminOK)
+		return 0
+	}
+	printFallbackPolicyStatus(out, status, adminOK)
+	return 0
+}
+
+func matchingFallbackAdminStatus(path string) (routingAdminStatus, bool) {
+	if state, _ := classifyPidfile(gatewayPidfilePath()); state != pidfileAlive {
+		return routingAdminStatus{}, false
+	}
+	status, err := fetchRoutingAdminStatus(envDefault("BASETEN_SWITCH_ADMIN_ADDR", gateway.DefaultAdminAddr))
+	if err != nil || canonicalPath(status.ConfigPath) != canonicalPath(path) || !containsString(status.Capabilities, "fallback_policy") {
+		return routingAdminStatus{}, false
+	}
+	return status, true
+}
+
+func printFallbackPolicyStatus(out io.Writer, status fallbackReadStatus, active bool) {
+	fmt.Fprintln(out, "Automatic fallback")
+	printFallbackPolicyTrigger(out, "429", status.Configured.OnBaseten429, status.Active, func(policy config.ResolvedFallbackPolicy) bool {
+		return policy.OnBaseten429
+	}, "Retry Baseten rate limits through the native provider")
+	printFallbackPolicyTrigger(out, "5xx", status.Configured.OnBaseten5xx, status.Active, func(policy config.ResolvedFallbackPolicy) bool {
+		return policy.OnBaseten5xx
+	}, "Retry Baseten server errors through the native provider")
+	if !active {
+		fmt.Fprintln(out, "Active router values unavailable; showing configured values.")
+	} else if status.DesiredActiveGap {
+		fmt.Fprintln(out, "Configured and active router generations differ.")
+	}
+	fmt.Fprintln(out, "\nFallback for Baseten-specific models")
+	for _, client := range status.Clients {
+		if client.ConfiguredModel == "" && (!client.activeKnown || client.ActiveModel == "") {
+			continue
+		}
+		if client.activeKnown && client.ActiveModel != client.ConfiguredModel {
+			fmt.Fprintf(out, "%-13s   Baseten-specific models   configured   %-8s   %s\n",
+				client.Name, nativeFallbackDisplayName(client.ConfiguredModel), client.ConfiguredModel)
+			if client.ActiveModel == "" {
+				fmt.Fprintf(out, "%-13s   Baseten-specific models   active       unavailable\n", client.Name)
+			} else {
+				fmt.Fprintf(out, "%-13s   Baseten-specific models   active       %-8s   %s\n",
+					client.Name, nativeFallbackDisplayName(client.ActiveModel), client.ActiveModel)
+			}
+			continue
+		}
+		model := client.ConfiguredModel
+		if client.activeKnown {
+			model = client.ActiveModel
+		}
+		label := client.DisplayName
+		if label == "" {
+			label = nativeFallbackDisplayName(model)
+		}
+		fmt.Fprintf(out, "%-13s   Baseten-specific models   %-8s   %s\n", client.Name, label, model)
+	}
+	fmt.Fprintln(out, "\nNative-origin requests preserve the exact model requested by the client.")
+	if status.Configured.OnBaseten429 || status.Configured.OnBaseten5xx ||
+		(status.Active != nil && (status.Active.OnBaseten429 || status.Active.OnBaseten5xx)) {
+		fmt.Fprintln(out, "\nWarning: cross-provider fallback replays the current conversation. Provider-specific reasoning history may be rejected by the native provider.")
+	}
+}
+
+func printFallbackPolicyTrigger(
+	out io.Writer,
+	trigger string,
+	configured bool,
+	active *config.ResolvedFallbackPolicy,
+	activeValue func(config.ResolvedFallbackPolicy) bool,
+	description string,
+) {
+	if active != nil && activeValue(*active) != configured {
+		fmt.Fprintf(out, "%s   configured %-3s   active %-3s   %s\n", trigger, onOff(configured), onOff(activeValue(*active)), description)
+		return
+	}
+	fmt.Fprintf(out, "%s   %-3s   %s\n", trigger, onOff(configured), description)
+}
+
+func printFallbackModelStatus(out io.Writer, client fallbackReadClient, active bool) {
+	if client.ConfiguredModel == "" && (!active || !client.activeKnown || client.ActiveModel == "") {
+		fmt.Fprintf(out, "%s: no fallback model configured for Baseten-specific identities\n", client.Name)
+		return
+	}
+	if active && client.activeKnown && client.ActiveModel != client.ConfiguredModel {
+		fmt.Fprintf(out, "%s   configured   %s   %s\n", client.Name, nativeFallbackDisplayName(client.ConfiguredModel), client.ConfiguredModel)
+		if client.ActiveModel == "" {
+			fmt.Fprintf(out, "%s   active       unavailable\n", client.Name)
+		} else {
+			fmt.Fprintf(out, "%s   active       %s   %s\n", client.Name, nativeFallbackDisplayName(client.ActiveModel), client.ActiveModel)
+		}
+		return
+	}
+	model := client.ConfiguredModel
+	if active && client.activeKnown {
+		model = client.ActiveModel
+	}
+	fmt.Fprintf(out, "%s   %s   %s\n", client.Name, nativeFallbackDisplayName(model), model)
+}
+
+func mutateFallbackPolicy(trigger string, enabled bool, opts mutationOptions, out io.Writer) int {
+	target := onOff(enabled)
+	spec := journaledMutationSpec{
+		Operation: "set_fallback_policy", Surface: mutationSurfaceConfig,
+		Requested: enabled, RequestedTarget: target, Key: trigger,
+		Apply:        func(path string) error { return config.SetFallbackPolicyTrigger(path, trigger, enabled) },
+		HumanSuccess: "automatic fallback for HTTP " + trigger + " " + target,
+	}
+	if enabled {
+		spec.StructuredWarnings = []mutationWarning{{Code: "cross_provider_history_may_be_incompatible"}}
+	}
+	return runConfigFallbackMutation(opts, spec, out)
+}
+
+func mutateNativeFallbackModel(clientName, model string, opts mutationOptions, out io.Writer) int {
+	spec := journaledMutationSpec{
+		Operation: "set_native_fallback_model", Surface: mutationSurfaceConfig,
+		Client: clientName, Key: "native_fallback_model", RequestedTarget: model,
+		Apply:        func(path string) error { return config.SetClientNativeFallbackModel(path, clientName, model) },
+		HumanSuccess: fmt.Sprintf("%s Baseten-model fallback set to %s", clientName, model),
+	}
+	if strings.TrimSpace(model) == "" {
+		return failMutation(opts, out, mutationResultForSpec(spec, opts.OperationID, "", ""), "invalid_native_fallback_model", "native fallback model cannot be empty", false, 2)
+	}
+	return runConfigFallbackMutation(opts, spec, out)
+}
+
+func runConfigFallbackMutation(opts mutationOptions, spec journaledMutationSpec, out io.Writer) int {
+	path, notices := resolveConfigPath()
+	if !opts.JSON {
+		for _, notice := range notices {
+			fmt.Fprintln(os.Stderr, notice)
+		}
+	}
+	if replayed, rc := preflightTerminalReplay(path, opts, spec, out); replayed {
+		if rc == 0 && spec.Operation == "set_fallback_policy" && spec.Requested && !opts.JSON {
+			fmt.Fprintln(os.Stderr, "warning: cross-provider fallback replays the current conversation; provider-specific reasoning history may be rejected by the native provider")
+		}
+		return rc
+	}
+	file, err := config.Load(path)
+	if err != nil {
+		message := config.MalformedConfigMessage(path, err)
+		if errors.Is(err, os.ErrNotExist) {
+			message = config.MissingConfigMessage(path)
+		}
+		return failMutation(opts, out, mutationResultForSpec(spec, opts.OperationID, path, ""), "config_load_failed", message, false, 1)
+	}
+	if spec.Operation == "set_native_fallback_model" {
+		found := false
+		for _, client := range file.Clients {
+			if client.Name == spec.Client {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return failMutation(opts, out, mutationResultForSpec(spec, opts.OperationID, path, ""), "invalid_client", fmt.Sprintf("no client named %q", spec.Client), false, 2)
+		}
+	}
+	lock, err := acquireConfigMutationLock(path)
+	if err != nil {
+		return failMutation(opts, out, mutationResultForSpec(spec, opts.OperationID, path, ""), "mutation_locked", err.Error(), true, 1)
+	}
+	defer lock.close()
+	if err := recoverInterruptedExactConfigCommit(path); err != nil {
+		return failMutation(opts, out, mutationResultForSpec(spec, opts.OperationID, path, ""), "commit_recovery_failed", err.Error(), true, 1)
+	}
+	prior, mode, err := readExactConfig(path)
+	if err != nil {
+		return failMutation(opts, out, mutationResultForSpec(spec, opts.OperationID, path, ""), "config_read_failed", err.Error(), true, 1)
+	}
+	rc := runJournaledMutationLocked(path, prior, mode, opts, out, spec)
+	if rc == 0 && spec.Operation == "set_fallback_policy" && spec.Requested && !opts.JSON {
+		fmt.Fprintln(os.Stderr, "warning: cross-provider fallback replays the current conversation; provider-specific reasoning history may be rejected by the native provider")
+	}
+	return rc
+}
+
+func emitJSON(out io.Writer, value any) {
+	encoder := json.NewEncoder(out)
+	encoder.SetEscapeHTML(false)
+	_ = encoder.Encode(value)
+}
+
+func onOff(value bool) string {
+	if value {
+		return "on"
+	}
+	return "off"
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func nativeFallbackDisplayName(model string) string {
+	lower := strings.ToLower(model)
+	for _, family := range []struct{ token, label string }{
+		{"opus", "Opus"}, {"sonnet", "Sonnet"}, {"haiku", "Haiku"}, {"fable", "Fable"},
+	} {
+		if strings.Contains(lower, family.token) {
+			return family.label
+		}
+	}
+	return model
+}

--- a/gateway/cmd/baseten-switch/config_fallback.go
+++ b/gateway/cmd/baseten-switch/config_fallback.go
@@ -20,7 +20,8 @@ const configFallbackUsage = `usage:
   baseten-switch config fallback model <client> <native-model> [mutation options]`
 
 type fallbackAdminClient struct {
-	Name                 string `json:"name"`
+	Name                 string                  `json:"name"`
+	ModelPicker          *modelPickerAdminStatus `json:"model_picker"`
 	BasetenModelFallback struct {
 		ConfiguredModel string  `json:"configured_model"`
 		ResolvedModel   string  `json:"resolved_model"`
@@ -29,6 +30,17 @@ type fallbackAdminClient struct {
 		Ready           bool    `json:"ready"`
 		Reason          *string `json:"reason"`
 	} `json:"baseten_model_fallback"`
+}
+
+type modelPickerAdminStatus struct {
+	Enabled bool                          `json:"enabled"`
+	Models  []modelPickerAdminStatusModel `json:"models"`
+}
+
+type modelPickerAdminStatusModel struct {
+	Alias         string `json:"alias"`
+	Slug          string `json:"slug"`
+	ContextTokens int64  `json:"context_tokens"`
 }
 
 type fallbackReadStatus struct {
@@ -187,10 +199,6 @@ func printFallbackPolicyStatus(out io.Writer, status fallbackReadStatus, active 
 		fmt.Fprintf(out, "%-13s   Baseten-specific models   %-8s   %s\n", client.Name, label, model)
 	}
 	fmt.Fprintln(out, "\nNative-origin requests preserve the exact model requested by the client.")
-	if status.Configured.OnBaseten429 || status.Configured.OnBaseten5xx ||
-		(status.Active != nil && (status.Active.OnBaseten429 || status.Active.OnBaseten5xx)) {
-		fmt.Fprintln(out, "\nWarning: cross-provider fallback replays the current conversation. Provider-specific reasoning history may be rejected by the native provider.")
-	}
 }
 
 func printFallbackPolicyTrigger(
@@ -237,9 +245,6 @@ func mutateFallbackPolicy(trigger string, enabled bool, opts mutationOptions, ou
 		Apply:        func(path string) error { return config.SetFallbackPolicyTrigger(path, trigger, enabled) },
 		HumanSuccess: "automatic fallback for HTTP " + trigger + " " + target,
 	}
-	if enabled {
-		spec.StructuredWarnings = []mutationWarning{{Code: "cross_provider_history_may_be_incompatible"}}
-	}
 	return runConfigFallbackMutation(opts, spec, out)
 }
 
@@ -264,9 +269,6 @@ func runConfigFallbackMutation(opts mutationOptions, spec journaledMutationSpec,
 		}
 	}
 	if replayed, rc := preflightTerminalReplay(path, opts, spec, out); replayed {
-		if rc == 0 && spec.Operation == "set_fallback_policy" && spec.Requested && !opts.JSON {
-			fmt.Fprintln(os.Stderr, "warning: cross-provider fallback replays the current conversation; provider-specific reasoning history may be rejected by the native provider")
-		}
 		return rc
 	}
 	file, err := config.Load(path)
@@ -301,11 +303,7 @@ func runConfigFallbackMutation(opts mutationOptions, spec journaledMutationSpec,
 	if err != nil {
 		return failMutation(opts, out, mutationResultForSpec(spec, opts.OperationID, path, ""), "config_read_failed", err.Error(), true, 1)
 	}
-	rc := runJournaledMutationLocked(path, prior, mode, opts, out, spec)
-	if rc == 0 && spec.Operation == "set_fallback_policy" && spec.Requested && !opts.JSON {
-		fmt.Fprintln(os.Stderr, "warning: cross-provider fallback replays the current conversation; provider-specific reasoning history may be rejected by the native provider")
-	}
-	return rc
+	return runJournaledMutationLocked(path, prior, mode, opts, out, spec)
 }
 
 func emitJSON(out io.Writer, value any) {

--- a/gateway/cmd/baseten-switch/config_fallback_test.go
+++ b/gateway/cmd/baseten-switch/config_fallback_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
 )
 
-func TestFallbackPolicyJSONReceiptUsesStructuredWarning(t *testing.T) {
+func TestFallbackPolicyJSONReceiptUsesOnlyActivationWarning(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "gateway.yaml")
 	if err := os.WriteFile(path, config.InitTemplate, 0o600); err != nil {
@@ -31,15 +31,12 @@ func TestFallbackPolicyJSONReceiptUsesStructuredWarning(t *testing.T) {
 		t.Fatal(err)
 	}
 	warnings, ok := receipt["warnings"].([]any)
-	if !ok || len(warnings) != 2 {
+	if !ok || len(warnings) != 1 {
 		t.Fatalf("warnings=%#v", receipt["warnings"])
 	}
-	wantWarnings := []string{"cross_provider_history_may_be_incompatible", "capable_router_activation_required"}
-	for i, want := range wantWarnings {
-		warning, ok := warnings[i].(map[string]any)
-		if !ok || warning["code"] != want {
-			t.Fatalf("warning[%d]=%#v want=%q", i, warnings[i], want)
-		}
+	warning, ok := warnings[0].(map[string]any)
+	if !ok || warning["code"] != "capable_router_activation_required" {
+		t.Fatalf("warning=%#v", warnings[0])
 	}
 	if receipt["operation"] != "set_fallback_policy" || receipt["key"] != "429" || receipt["requested_target"] != "on" {
 		t.Fatalf("receipt identity=%#v", receipt)
@@ -225,6 +222,9 @@ func TestFallbackHumanStatusDistinguishesConfiguredAndActiveValues(t *testing.T)
 			t.Fatalf("status output missing %q:\n%s", want, text)
 		}
 	}
+	if strings.Contains(strings.ToLower(text), "warning") {
+		t.Fatalf("status output retained removed warning:\n%s", text)
+	}
 
 	out.Reset()
 	printFallbackModelStatus(&out, status.Clients[0], true)
@@ -236,7 +236,7 @@ func TestFallbackHumanStatusDistinguishesConfiguredAndActiveValues(t *testing.T)
 func TestMutationResultWarningWireRoundTripsBothShapes(t *testing.T) {
 	structured := mutationResult{
 		OK: true, Operation: "set_fallback_policy",
-		StructuredWarnings: []mutationWarning{{Code: "cross_provider_history_may_be_incompatible"}},
+		StructuredWarnings: []mutationWarning{{Code: "capable_router_activation_required"}},
 	}
 	data, err := json.Marshal(structured)
 	if err != nil {
@@ -246,7 +246,7 @@ func TestMutationResultWarningWireRoundTripsBothShapes(t *testing.T) {
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		t.Fatal(err)
 	}
-	if len(decoded.StructuredWarnings) != 1 || decoded.StructuredWarnings[0].Code != "cross_provider_history_may_be_incompatible" {
+	if len(decoded.StructuredWarnings) != 1 || decoded.StructuredWarnings[0].Code != "capable_router_activation_required" {
 		t.Fatalf("structured warnings=%#v data=%s", decoded.StructuredWarnings, data)
 	}
 	if err := json.Unmarshal([]byte(`{"ok":true,"warnings":["legacy warning"]}`), &decoded); err != nil {
@@ -257,11 +257,11 @@ func TestMutationResultWarningWireRoundTripsBothShapes(t *testing.T) {
 	}
 }
 
-func TestFallbackPolicyTerminalReplayRetainsStructuredWarning(t *testing.T) {
+func TestTerminalReplayRetainsStructuredWarning(t *testing.T) {
 	spec := journaledMutationSpec{
 		Operation: "set_fallback_policy", Surface: mutationSurfaceConfig,
 		Requested: true, RequestedTarget: "on", Key: "429",
-		StructuredWarnings: []mutationWarning{{Code: "cross_provider_history_may_be_incompatible"}},
+		StructuredWarnings: []mutationWarning{{Code: "capable_router_activation_required"}},
 	}
 	result := resultFromTerminal("/synthetic/gateway.yaml", mutationTerminalRecord{
 		OperationID: "policy-replay", Operation: spec.Operation, Requested: true,
@@ -276,7 +276,7 @@ func TestFallbackPolicyTerminalReplayRetainsStructuredWarning(t *testing.T) {
 		t.Fatal(err)
 	}
 	warnings := wire["warnings"].([]any)
-	if len(warnings) != 1 || warnings[0].(map[string]any)["code"] != "cross_provider_history_may_be_incompatible" {
+	if len(warnings) != 1 || warnings[0].(map[string]any)["code"] != "capable_router_activation_required" {
 		t.Fatalf("replay warnings=%#v", wire["warnings"])
 	}
 }

--- a/gateway/cmd/baseten-switch/config_fallback_test.go
+++ b/gateway/cmd/baseten-switch/config_fallback_test.go
@@ -1,0 +1,305 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
+)
+
+func TestFallbackPolicyJSONReceiptUsesStructuredWarning(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gateway.yaml")
+	if err := os.WriteFile(path, config.InitTemplate, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BASETEN_SWITCH_CONFIG_PATH", path)
+	t.Setenv("BASETEN_SWITCH_GATEWAY_PIDFILE", filepath.Join(dir, "router.pid"))
+	opts := mutationOptions{JSON: true, OperationID: "fallback-warning-test", hasOperationID: true}
+	var out bytes.Buffer
+	if rc := mutateFallbackPolicy("429", true, opts, &out); rc != 0 {
+		t.Fatalf("rc=%d receipt=%s", rc, out.String())
+	}
+	var receipt map[string]any
+	if err := json.Unmarshal(out.Bytes(), &receipt); err != nil {
+		t.Fatal(err)
+	}
+	warnings, ok := receipt["warnings"].([]any)
+	if !ok || len(warnings) != 2 {
+		t.Fatalf("warnings=%#v", receipt["warnings"])
+	}
+	wantWarnings := []string{"cross_provider_history_may_be_incompatible", "capable_router_activation_required"}
+	for i, want := range wantWarnings {
+		warning, ok := warnings[i].(map[string]any)
+		if !ok || warning["code"] != want {
+			t.Fatalf("warning[%d]=%#v want=%q", i, warnings[i], want)
+		}
+	}
+	if receipt["operation"] != "set_fallback_policy" || receipt["key"] != "429" || receipt["requested_target"] != "on" {
+		t.Fatalf("receipt identity=%#v", receipt)
+	}
+}
+
+func TestOfflineFallbackTargetReceiptRequiresCapableRouterActivation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gateway.yaml")
+	if err := os.WriteFile(path, config.InitTemplate, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BASETEN_SWITCH_CONFIG_PATH", path)
+	t.Setenv("BASETEN_SWITCH_GATEWAY_PIDFILE", filepath.Join(dir, "router.pid"))
+	opts := mutationOptions{JSON: true, OperationID: "fallback-target-offline", hasOperationID: true}
+	var out bytes.Buffer
+	if rc := mutateNativeFallbackModel("claude-code", "claude-sonnet-5", opts, &out); rc != 0 {
+		t.Fatalf("rc=%d receipt=%s", rc, out.String())
+	}
+	result := decodeMutationResult(t, out.String())
+	if len(result.StructuredWarnings) != 1 || result.StructuredWarnings[0].Code != "capable_router_activation_required" {
+		t.Fatalf("warnings=%#v", result.StructuredWarnings)
+	}
+}
+
+func TestFallbackMutationRejectsReachableRouterWithoutCapabilityBeforeWrite(t *testing.T) {
+	installRoutingMutationSeams(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gateway.yaml")
+	if err := os.WriteFile(path, config.InitTemplate, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	prior, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	priorHash := exactConfigHash(prior)
+	t.Setenv("BASETEN_SWITCH_CONFIG_PATH", path)
+	t.Setenv("BASETEN_SWITCH_GATEWAY_PIDFILE", filepath.Join(dir, "router.pid"))
+	if err := os.WriteFile(gatewayPidfilePath(), []byte(fmt.Sprintf("%d\n", os.Getpid())), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fetchRoutingAdminStatus = func(string) (routingAdminStatus, error) {
+		return liveRoutingStatus(path, priorHash, true, 1), nil
+	}
+	opts := mutationOptions{JSON: true, OperationID: "unsupported-fallback-router", hasOperationID: true}
+	var out bytes.Buffer
+	if rc := mutateFallbackPolicy("429", false, opts, &out); rc != 1 {
+		t.Fatalf("rc=%d receipt=%s", rc, out.String())
+	}
+	result := decodeMutationResult(t, out.String())
+	if result.Error == nil || result.Error.Code != "router_unsupported" {
+		t.Fatalf("result=%+v", result)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, prior) {
+		t.Fatal("unsupported router rejection changed the config")
+	}
+}
+
+func TestFallbackActivationRequiresOperationSpecificProjection(t *testing.T) {
+	installRoutingMutationSeams(t)
+	path := filepath.Join(t.TempDir(), "gateway.yaml")
+	hash := exactConfigHash(config.InitTemplate)
+	base := liveRoutingStatus(path, hash, true, 2)
+	base.Capabilities = []string{"fallback_policy"}
+
+	t.Run("policy", func(t *testing.T) {
+		status := base
+		status.FallbackPolicy.OnBaseten429 = false
+		fetchRoutingAdminStatus = func(string) (routingAdminStatus, error) { return status, nil }
+		if _, ok := waitConfigMutationActivation("unused", path, hash, "", false, 5*time.Millisecond,
+			"set_fallback_policy", "429", "", "on", true); ok {
+			t.Fatal("hash-only match accepted the wrong active policy")
+		}
+		status.FallbackPolicy.OnBaseten429 = true
+		if _, ok := waitConfigMutationActivation("unused", path, hash, "", false, 5*time.Millisecond,
+			"set_fallback_policy", "429", "", "on", true); !ok {
+			t.Fatal("matching active policy was not accepted")
+		}
+	})
+
+	t.Run("target", func(t *testing.T) {
+		status := base
+		client := fallbackAdminClient{Name: "claude-code"}
+		client.BasetenModelFallback.ResolvedModel = "claude-opus-5"
+		status.Clients = []fallbackAdminClient{client}
+		fetchRoutingAdminStatus = func(string) (routingAdminStatus, error) { return status, nil }
+		if _, ok := waitConfigMutationActivation("unused", path, hash, "", false, 5*time.Millisecond,
+			"set_native_fallback_model", "native_fallback_model", "claude-code", "claude-sonnet-5", false); ok {
+			t.Fatal("hash-only match accepted the wrong active target")
+		}
+		status.Clients[0].BasetenModelFallback.ResolvedModel = "claude-sonnet-5"
+		if _, ok := waitConfigMutationActivation("unused", path, hash, "", false, 5*time.Millisecond,
+			"set_native_fallback_model", "native_fallback_model", "claude-code", "claude-sonnet-5", false); !ok {
+			t.Fatal("matching active target was not accepted")
+		}
+	})
+}
+
+func TestFallbackRecoveryDoesNotClassifyHashOnlyMatchAsDesiredActive(t *testing.T) {
+	installRoutingMutationSeams(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gateway.yaml")
+	desired := append([]byte(nil), config.InitTemplate...)
+	prior := bytes.Replace(desired, []byte("on_baseten_429: true"), []byte("on_baseten_429: false"), 1)
+	if bytes.Equal(prior, desired) {
+		t.Fatal("fixture did not change fallback policy")
+	}
+	if err := os.WriteFile(path, desired, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BASETEN_SWITCH_CONFIG_PATH", path)
+	t.Setenv("BASETEN_SWITCH_GATEWAY_PIDFILE", filepath.Join(dir, "router.pid"))
+	if err := os.WriteFile(gatewayPidfilePath(), []byte(fmt.Sprintf("%d\n", os.Getpid())), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	opts := mutationOptions{OperationID: "fallback-recovery-projection", hasOperationID: true}
+	spec := journaledMutationSpec{
+		Operation: "set_fallback_policy", Surface: mutationSurfaceConfig,
+		Requested: true, RequestedTarget: "on", Key: "429",
+	}
+	fingerprint, err := mutationRequestFingerprint(path, opts, spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	desiredHash := exactConfigHash(desired)
+	journal := routingMutationJournal{
+		Version: mutationJournalVersion, OperationID: opts.OperationID, Operation: spec.Operation,
+		Surface: spec.Surface, ConfigPath: path, Requested: true, RequestedTarget: spec.RequestedTarget,
+		Key: spec.Key, PreviousConfig: prior, PreviousMode: 0o600,
+		PreviousConfigHash: exactConfigHash(prior), DesiredConfigHash: desiredHash,
+		PreviousActiveToken: "boot:1", RequestFingerprint: fingerprint, CreatedAt: time.Now().UTC(),
+	}
+	if err := writeMutationJournal(journal); err != nil {
+		t.Fatal(err)
+	}
+	active := liveRoutingStatus(path, desiredHash, true, 2)
+	active.Capabilities = []string{"fallback_policy"}
+	active.FallbackPolicy.OnBaseten429 = false
+	fetchRoutingAdminStatus = func(string) (routingAdminStatus, error) { return active, nil }
+	status, err := inspectRoutingMutationStatus(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Classification != mutationStatusDesiredPending {
+		t.Fatalf("wrong projection classification=%s", status.Classification)
+	}
+	active.FallbackPolicy.OnBaseten429 = true
+	status, err = inspectRoutingMutationStatus(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Classification != mutationStatusDesiredActive {
+		t.Fatalf("matching projection classification=%s", status.Classification)
+	}
+}
+
+func TestFallbackHumanStatusDistinguishesConfiguredAndActiveValues(t *testing.T) {
+	active := config.ResolvedFallbackPolicy{OnBaseten429: false, OnBaseten5xx: true}
+	status := fallbackReadStatus{
+		Configured: config.ResolvedFallbackPolicy{OnBaseten429: true, OnBaseten5xx: true},
+		Active:     &active,
+		Clients: []fallbackReadClient{{
+			Name:            "claude-code",
+			ConfiguredModel: "claude-opus-5",
+			ActiveModel:     "claude-sonnet-5",
+			activeKnown:     true,
+		}},
+	}
+	var out bytes.Buffer
+	printFallbackPolicyStatus(&out, status, true)
+	text := out.String()
+	for _, want := range []string{
+		"429   configured on    active off",
+		"configured   Opus",
+		"active       Sonnet",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("status output missing %q:\n%s", want, text)
+		}
+	}
+
+	out.Reset()
+	printFallbackModelStatus(&out, status.Clients[0], true)
+	if !strings.Contains(out.String(), "configured   Opus") || !strings.Contains(out.String(), "active       Sonnet") {
+		t.Fatalf("model output did not distinguish configured and active:\n%s", out.String())
+	}
+}
+
+func TestMutationResultWarningWireRoundTripsBothShapes(t *testing.T) {
+	structured := mutationResult{
+		OK: true, Operation: "set_fallback_policy",
+		StructuredWarnings: []mutationWarning{{Code: "cross_provider_history_may_be_incompatible"}},
+	}
+	data, err := json.Marshal(structured)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded mutationResult
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded.StructuredWarnings) != 1 || decoded.StructuredWarnings[0].Code != "cross_provider_history_may_be_incompatible" {
+		t.Fatalf("structured warnings=%#v data=%s", decoded.StructuredWarnings, data)
+	}
+	if err := json.Unmarshal([]byte(`{"ok":true,"warnings":["legacy warning"]}`), &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded.Warnings) != 1 || decoded.Warnings[0] != "legacy warning" {
+		t.Fatalf("string warnings=%#v", decoded.Warnings)
+	}
+}
+
+func TestFallbackPolicyTerminalReplayRetainsStructuredWarning(t *testing.T) {
+	spec := journaledMutationSpec{
+		Operation: "set_fallback_policy", Surface: mutationSurfaceConfig,
+		Requested: true, RequestedTarget: "on", Key: "429",
+		StructuredWarnings: []mutationWarning{{Code: "cross_provider_history_may_be_incompatible"}},
+	}
+	result := resultFromTerminal("/synthetic/gateway.yaml", mutationTerminalRecord{
+		OperationID: "policy-replay", Operation: spec.Operation, Requested: true,
+		Outcome: mutationOutcomeApplied,
+	}, true, spec)
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(data, &wire); err != nil {
+		t.Fatal(err)
+	}
+	warnings := wire["warnings"].([]any)
+	if len(warnings) != 1 || warnings[0].(map[string]any)["code"] != "cross_provider_history_may_be_incompatible" {
+		t.Fatalf("replay warnings=%#v", wire["warnings"])
+	}
+}
+
+func TestNormalizeMutationInvocationAcceptsConfigFallback(t *testing.T) {
+	got, err := normalizeMutationInvocation([]string{"--json", "--operation-id", "policy-1", "config", "fallback", "5xx", "off"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"config", "fallback", "5xx", "off", "--json", "--operation-id", "policy-1"}
+	if !equalStringSlices(got, want) {
+		t.Fatalf("normalized=%q want=%q", got, want)
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/gateway/cmd/baseten-switch/doctor.go
+++ b/gateway/cmd/baseten-switch/doctor.go
@@ -1083,7 +1083,7 @@ func doctorClaudeChecks(add addCheck, f *config.File, telPath string) {
 	a, err := newClaudeAdapterFromEnv()
 	if err != nil {
 		reason := fmt.Sprintf("cannot resolve the claude door port: %v", err)
-		for _, name := range []string{"settings", "base_url", "attribution_header", "tool_search", "shell_env", "subagents", "model_routes", "model_env", "backup"} {
+		for _, name := range []string{"settings", "base_url", "attribution_header", "tool_search", "shell_env", "subagents", "model_routes", "model_env", "model_picker", "backup"} {
 			add("claude", name, docSkip, reason, "")
 		}
 		return
@@ -1195,6 +1195,7 @@ func doctorClaudeChecks(add addCheck, f *config.File, telPath string) {
 	// the all-families-pinned warn, and the harness env-slot warn. All
 	// manual, no fixArgv.
 	doctorModelRoutesCheck(add, a, f, root, existed)
+	doctorModelPickerCheck(add, a)
 
 	if !(curSet && a.isGatewayURL(cur)) {
 		add("claude", "backup", docSkip, "not gateway-managed; no backup expected", "")

--- a/gateway/cmd/baseten-switch/fallback_policy_migration.go
+++ b/gateway/cmd/baseten-switch/fallback_policy_migration.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
+)
+
+type fallbackPolicyMigrationVerificationOps struct {
+	readInstalled func(string) ([]byte, os.FileMode, error)
+	restore       func(string, string, []byte, os.FileMode) error
+	readRestored  func(string) ([]byte, os.FileMode, error)
+}
+
+var defaultFallbackPolicyMigrationVerificationOps = fallbackPolicyMigrationVerificationOps{
+	readInstalled: readExactConfig,
+	restore:       compareAndSwapExactConfig,
+	readRestored:  readExactConfig,
+}
+
+// migrateFallbackPolicyConfig writes the explicit Claude fallback target
+// required by this binary before a new router process reads the config. It is
+// intentionally a launcher migration, never a request-time router mutation.
+func migrateFallbackPolicyConfig(path string) (bool, string, error) {
+	lock, err := acquireConfigMutationLock(path)
+	if err != nil {
+		return false, "", err
+	}
+	defer lock.close()
+	if err := recoverInterruptedExactConfigCommit(path); err != nil {
+		return false, "", fmt.Errorf("recover interrupted exact config commit: %w", err)
+	}
+	if operationID, err := unfinishedMutationOperation(path); err != nil {
+		return false, "", fmt.Errorf("inspect routing mutation state: %w", err)
+	} else if operationID != "" {
+		return false, "", fmt.Errorf("routing mutation %s must be reconciled before config migration", operationID)
+	}
+	prior, mode, err := readExactConfig(path)
+	if err != nil {
+		return false, "", err
+	}
+	file, err := config.Load(path)
+	if err != nil {
+		return false, "", err
+	}
+	needsMigration := false
+	for _, client := range file.Clients {
+		if client.Name == "claude-code" && client.FallbackRoute == "anthropic" && client.NativeFallbackModel == "" {
+			needsMigration = true
+			break
+		}
+	}
+	if !needsMigration {
+		return false, "", nil
+	}
+	desired, err := previewExactConfigEdit(path, prior, mode, func(editPath string) error {
+		return config.SetClientNativeFallbackModel(editPath, "claude-code", config.DefaultClaudeNativeFallbackModel)
+	})
+	if err != nil {
+		return false, "", fmt.Errorf("prepare fallback policy migration: %w", err)
+	}
+	if err := validateConfigBytesForRouter(path, desired, mode); err != nil {
+		return false, "", fmt.Errorf("validate fallback policy migration: %w", err)
+	}
+	backup, err := writeUniqueConfigBackup(path, prior, "pre-fallback-policy")
+	if err != nil {
+		return false, "", fmt.Errorf("create fallback policy migration backup: %w", err)
+	}
+	if err := compareAndSwapExactConfig(path, exactConfigHash(prior), desired, mode); err != nil {
+		return false, backup, fmt.Errorf("install fallback policy migration (backup retained at %s): %w", backup, err)
+	}
+	if err := verifyOrRestoreFallbackPolicyMigration(path, prior, desired, mode, backup, defaultFallbackPolicyMigrationVerificationOps); err != nil {
+		return false, backup, err
+	}
+	return true, backup, nil
+}
+
+func verifyOrRestoreFallbackPolicyMigration(
+	path string,
+	prior, desired []byte,
+	mode os.FileMode,
+	backup string,
+	ops fallbackPolicyMigrationVerificationOps,
+) error {
+	written, writtenMode, verificationErr := ops.readInstalled(path)
+	if verificationErr == nil && exactConfigHash(written) == exactConfigHash(desired) && writtenMode.Perm() == mode.Perm() {
+		return nil
+	}
+	if verificationErr == nil {
+		verificationErr = fmt.Errorf("installed bytes or permissions differ from the validated migration")
+	}
+
+	if restoreErr := ops.restore(path, exactConfigHash(desired), prior, mode); restoreErr != nil {
+		return fmt.Errorf(
+			"verify fallback policy migration: %v; restore prior exact config failed: %v (backup retained at %s)",
+			verificationErr, restoreErr, backup,
+		)
+	}
+	restored, restoredMode, restoreVerificationErr := ops.readRestored(path)
+	if restoreVerificationErr != nil || exactConfigHash(restored) != exactConfigHash(prior) || restoredMode.Perm() != mode.Perm() {
+		if restoreVerificationErr == nil {
+			restoreVerificationErr = fmt.Errorf("restored bytes or permissions differ from the prior exact config")
+		}
+		return fmt.Errorf(
+			"verify fallback policy migration: %v; prior config restore could not be verified: %v (backup retained at %s)",
+			verificationErr, restoreVerificationErr, backup,
+		)
+	}
+	return fmt.Errorf(
+		"verify fallback policy migration: %v; prior exact config restored (backup retained at %s)",
+		verificationErr, backup,
+	)
+}
+
+func migrateFallbackPolicyBeforeStart(path string, out *os.File) error {
+	if _, err := os.Lstat(path); errors.Is(err, os.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	changed, backup, err := migrateFallbackPolicyConfig(path)
+	if errors.Is(err, os.ErrNotExist) {
+		// Preserve the existing startup error path for a missing config. There
+		// is nothing for this migration to change before the router validates it.
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if changed {
+		fmt.Fprintf(out, "config: added Claude fallback target %s (backup: %s)\n", config.DefaultClaudeNativeFallbackModel, backup)
+	}
+	return nil
+}

--- a/gateway/cmd/baseten-switch/fallback_policy_migration_test.go
+++ b/gateway/cmd/baseten-switch/fallback_policy_migration_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
+)
+
+func TestMigrateFallbackPolicyConfigAddsExplicitClaudeTargetOnce(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gateway.yaml")
+	prior := bytes.Replace(config.InitTemplate,
+		[]byte("    native_fallback_model: "+config.DefaultClaudeNativeFallbackModel+"\n"), nil, 1)
+	if bytes.Equal(prior, config.InitTemplate) {
+		t.Fatal("test fixture did not remove native_fallback_model")
+	}
+	if err := os.WriteFile(path, prior, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	changed, backup, err := migrateFallbackPolicyConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed || backup == "" {
+		t.Fatalf("changed=%t backup=%q", changed, backup)
+	}
+	backupBytes, err := os.ReadFile(backup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(backupBytes, prior) {
+		t.Fatal("backup did not preserve exact prior bytes")
+	}
+	file, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if file.Clients[0].NativeFallbackModel != config.DefaultClaudeNativeFallbackModel {
+		t.Fatalf("native_fallback_model=%q", file.Clients[0].NativeFallbackModel)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o640 {
+		t.Fatalf("mode=%04o want 0640", info.Mode().Perm())
+	}
+	changed, secondBackup, err := migrateFallbackPolicyConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed || secondBackup != "" {
+		t.Fatalf("second migration changed=%t backup=%q", changed, secondBackup)
+	}
+}
+
+func TestMigrateFallbackPolicyConfigPreservesCustomTarget(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gateway.yaml")
+	custom := bytes.Replace(config.InitTemplate,
+		[]byte(config.DefaultClaudeNativeFallbackModel), []byte("claude-sonnet-5"), 1)
+	if err := os.WriteFile(path, custom, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	changed, backup, err := migrateFallbackPolicyConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed || backup != "" {
+		t.Fatalf("changed=%t backup=%q", changed, backup)
+	}
+	written, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(written, custom) {
+		t.Fatal("custom config changed")
+	}
+}
+
+func TestFallbackPolicyMigrationVerificationFailureRestoresExactPriorConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gateway.yaml")
+	prior := []byte("prior exact config\n")
+	desired := []byte("desired migrated config\n")
+	if err := os.WriteFile(path, desired, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	verificationErr := errors.New("synthetic post-install read failure")
+	err := verifyOrRestoreFallbackPolicyMigration(
+		path,
+		prior,
+		desired,
+		0o640,
+		path+".backup",
+		fallbackPolicyMigrationVerificationOps{
+			readInstalled: func(string) ([]byte, os.FileMode, error) {
+				return nil, 0, verificationErr
+			},
+			restore:      compareAndSwapExactConfig,
+			readRestored: readExactConfig,
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), verificationErr.Error()) || !strings.Contains(err.Error(), "prior exact config restored") {
+		t.Fatalf("error=%v", err)
+	}
+	restored, restoredMode, readErr := readExactConfig(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !bytes.Equal(restored, prior) || restoredMode.Perm() != 0o640 {
+		t.Fatalf("restored=%q mode=%04o", restored, restoredMode.Perm())
+	}
+}
+
+func TestFallbackPolicyMigrationReportsRestoreFailureAndRetainsBackupPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gateway.yaml")
+	prior := []byte("prior exact config\n")
+	desired := []byte("desired migrated config\n")
+	if err := os.WriteFile(path, desired, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	backup := path + ".backup"
+	restoreErr := errors.New("synthetic atomic restore failure")
+	err := verifyOrRestoreFallbackPolicyMigration(
+		path,
+		prior,
+		desired,
+		0o600,
+		backup,
+		fallbackPolicyMigrationVerificationOps{
+			readInstalled: func(string) ([]byte, os.FileMode, error) {
+				return nil, 0, errors.New("synthetic verification failure")
+			},
+			restore: func(string, string, []byte, os.FileMode) error {
+				return restoreErr
+			},
+			readRestored: func(string) ([]byte, os.FileMode, error) {
+				t.Fatal("restore verification must not run after restore failure")
+				return nil, 0, nil
+			},
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), restoreErr.Error()) || !strings.Contains(err.Error(), backup) {
+		t.Fatalf("error=%v", err)
+	}
+	written, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !bytes.Equal(written, desired) {
+		t.Fatal("restore failure path unexpectedly changed the installed config")
+	}
+}

--- a/gateway/cmd/baseten-switch/lifecycle.go
+++ b/gateway/cmd/baseten-switch/lifecycle.go
@@ -361,6 +361,10 @@ func upRouter(lc *lifecycleConfig) int {
 			portOwner(lc.adminAddr), lc.adminAddr)
 		return 1
 	}
+	if err := migrateFallbackPolicyBeforeStart(lc.path, os.Stderr); err != nil {
+		fmt.Fprintf(os.Stderr, "router: fallback policy config migration failed: %v\n", err)
+		return 1
+	}
 	// An installed LaunchAgent means launchd owns this component:
 	// re-bootstrap a booted-out job instead of spawning an unmanaged
 	// process next to the plist.

--- a/gateway/cmd/baseten-switch/main.go
+++ b/gateway/cmd/baseten-switch/main.go
@@ -331,6 +331,7 @@ Plain doctor is read-only. --fix cannot be combined with --json.
 `},
 	{"claude", "Manage Claude Code gateway wiring and model routing", `Usage:
   baseten-switch claude on|off|status
+  baseten-switch claude picker status|enable [--dry-run --json] [--convert-replacement-mode]|list|add <slug> [--alias <alias>] [--dry-run --json]|remove <alias>|move <alias> --before <alias>|sync [--convert-replacement-mode]|disable
   baseten-switch claude subagents [<model>|on|inherit]
   baseten-switch claude route [<family> <target|default>]
   baseten-switch claude reasoning baseten <model> off|follow-harness|effort <value>|default
@@ -339,6 +340,10 @@ on sets ANTHROPIC_BASE_URL, CLAUDE_CODE_ATTRIBUTION_HEADER, and
 ENABLE_TOOL_SEARCH in ~/.claude/settings.json, and backs up prior values. off
 restores them exactly when possible, or strips only values proven to have been
 written by Switch after drift. start and stop alias on and off.
+
+picker manages the ordered Baseten rows appended to Claude Code's /model
+picker. Claude Code 2.1.243 or later is required. Built-in rows remain owned
+by Claude Code; remove leaves the routing alias intact.
 
 subagents selects a configured alias, raw Baseten slug, or native model for
 Task and sidechain requests. "on" re-enables the kept model. "inherit" leaves

--- a/gateway/cmd/baseten-switch/main.go
+++ b/gateway/cmd/baseten-switch/main.go
@@ -246,6 +246,9 @@ gateway binds 127.0.0.1 only.
 	{"config", "Initialize or reset gateway configuration", `Usage:
   baseten-switch config init [--force]
   baseten-switch config reset --yes [--preview-root PATH --router-addr HOST:PORT --door-addr HOST:PORT]
+  baseten-switch config fallback status
+  baseten-switch config fallback 429|5xx on|off [mutation options]
+  baseten-switch config fallback model <client> [<native-model>] [mutation options]
 
 init writes the canonical single-port gateway.yaml, refuses to overwrite by
 default, and backs up the old file before --force replacement.
@@ -254,6 +257,9 @@ reset replaces the entire active config, saves a unique 0600 exact-byte
 backup, validates, and hot-reloads a running router. Activation failure
 restores and reactivates the prior bytes. The three Preview flags must be
 supplied together.
+
+fallback reads or changes the automatic native-provider fallback policy and
+the per-client native target used for Baseten-specific model identities.
 `},
 	{"setup", "Check prerequisites, sign in, and initialize configuration", `Usage: baseten-switch setup
 
@@ -457,6 +463,8 @@ func commandOptionConsumesValue(args []string, index int) bool {
 			return valueOption &&
 				index+1 < len(args) &&
 				!strings.HasPrefix(args[index+1], "--")
+		case "fallback":
+			return mutationValue
 		case "preview-snapshot":
 			return option == "--source" ||
 				option == "--output" ||
@@ -647,6 +655,11 @@ func cmdGatewayStart(args []string) int {
 		fmt.Fprintf(os.Stderr, "gateway already running on 127.0.0.1:%d\n", port)
 		return 0
 	}
+	if err := migrateFallbackPolicyBeforeStart(cfg.ConfigPath, os.Stderr); err != nil {
+		fmt.Fprintf(os.Stderr, "gateway start: fallback policy config migration failed: %v\n", err)
+		return 1
+	}
+	cfg = gateway.LoadConfig()
 	if foreground {
 		return runForeground(cfg)
 	}

--- a/gateway/cmd/baseten-switch/routing_mutation.go
+++ b/gateway/cmd/baseten-switch/routing_mutation.go
@@ -69,13 +69,16 @@ func (e *exactConfigCommitIndeterminateError) Unwrap() error {
 }
 
 type mutationOptions struct {
-	JSON           bool
-	OperationID    string
-	IfActiveToken  string
-	IfConfigHash   string
-	hasOperationID bool
-	hasActiveToken bool
-	hasConfigHash  bool
+	JSON                     bool
+	DryRun                   bool
+	PickerAlias              string
+	ConvertPickerReplacement bool
+	OperationID              string
+	IfActiveToken            string
+	IfConfigHash             string
+	hasOperationID           bool
+	hasActiveToken           bool
+	hasConfigHash            bool
 }
 
 type mutationError struct {
@@ -100,11 +103,13 @@ type mutationResult struct {
 	ActiveConfigHash          string         `json:"active_config_hash"`
 	Applied                   bool           `json:"applied"`
 	ReconciliationRequired    bool           `json:"reconciliation_required,omitempty"`
+	ReconciliationAction      string         `json:"reconciliation_action,omitempty"`
 	BlockingOperationID       string         `json:"blocking_operation_id,omitempty"`
 	Outcome                   string         `json:"outcome,omitempty"`
 	RequestFingerprint        string         `json:"request_fingerprint,omitempty"`
 	IdentityStrength          string         `json:"identity_strength,omitempty"`
 	CleanupPending            bool           `json:"cleanup_pending,omitempty"`
+	Warnings                  []string       `json:"warnings,omitempty"`
 	Error                     *mutationError `json:"error"`
 }
 

--- a/gateway/cmd/baseten-switch/routing_mutation.go
+++ b/gateway/cmd/baseten-switch/routing_mutation.go
@@ -24,6 +24,7 @@ const (
 	mutationSurfaceSwitch = "switch"
 	mutationSurfaceClaude = "claude"
 	mutationSurfaceCodex  = "codex"
+	mutationSurfaceConfig = "config"
 )
 
 var (
@@ -87,41 +88,109 @@ type mutationError struct {
 	Retryable bool   `json:"retryable"`
 }
 
+type mutationWarning struct {
+	Code string `json:"code"`
+}
+
+func appendMutationWarning(warnings []mutationWarning, warning mutationWarning) []mutationWarning {
+	for _, existing := range warnings {
+		if existing.Code == warning.Code {
+			return warnings
+		}
+	}
+	return append(warnings, warning)
+}
+
+func printCapableRouterActivationWarning(opts mutationOptions, path string) {
+	if opts.JSON {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "router not running; %s is configured, but only a router with fallback policy support can activate it\n", path)
+}
+
 type mutationResult struct {
-	OK                        bool           `json:"ok"`
-	OperationID               string         `json:"operation_id"`
-	Operation                 string         `json:"operation"`
-	Requested                 bool           `json:"requested"`
-	RequestedTarget           string         `json:"requested_target,omitempty"`
-	Client                    string         `json:"client,omitempty"`
-	Key                       string         `json:"key,omitempty"`
-	ConfigPath                string         `json:"config_path"`
-	PreviousActiveToken       string         `json:"previous_active_token"`
-	PreviousDesiredConfigHash string         `json:"previous_desired_config_hash"`
-	DesiredConfigHash         string         `json:"desired_config_hash"`
-	ActiveToken               string         `json:"active_token"`
-	ActiveConfigHash          string         `json:"active_config_hash"`
-	Applied                   bool           `json:"applied"`
-	ReconciliationRequired    bool           `json:"reconciliation_required,omitempty"`
-	ReconciliationAction      string         `json:"reconciliation_action,omitempty"`
-	BlockingOperationID       string         `json:"blocking_operation_id,omitempty"`
-	Outcome                   string         `json:"outcome,omitempty"`
-	RequestFingerprint        string         `json:"request_fingerprint,omitempty"`
-	IdentityStrength          string         `json:"identity_strength,omitempty"`
-	CleanupPending            bool           `json:"cleanup_pending,omitempty"`
-	Warnings                  []string       `json:"warnings,omitempty"`
-	Error                     *mutationError `json:"error"`
+	OK                        bool              `json:"ok"`
+	OperationID               string            `json:"operation_id"`
+	Operation                 string            `json:"operation"`
+	Requested                 bool              `json:"requested"`
+	RequestedTarget           string            `json:"requested_target,omitempty"`
+	Client                    string            `json:"client,omitempty"`
+	Key                       string            `json:"key,omitempty"`
+	ConfigPath                string            `json:"config_path"`
+	PreviousActiveToken       string            `json:"previous_active_token"`
+	PreviousDesiredConfigHash string            `json:"previous_desired_config_hash"`
+	DesiredConfigHash         string            `json:"desired_config_hash"`
+	ActiveToken               string            `json:"active_token"`
+	ActiveConfigHash          string            `json:"active_config_hash"`
+	Applied                   bool              `json:"applied"`
+	ReconciliationRequired    bool              `json:"reconciliation_required,omitempty"`
+	ReconciliationAction      string            `json:"reconciliation_action,omitempty"`
+	BlockingOperationID       string            `json:"blocking_operation_id,omitempty"`
+	Outcome                   string            `json:"outcome,omitempty"`
+	RequestFingerprint        string            `json:"request_fingerprint,omitempty"`
+	IdentityStrength          string            `json:"identity_strength,omitempty"`
+	CleanupPending            bool              `json:"cleanup_pending,omitempty"`
+	Warnings                  []string          `json:"warnings,omitempty"`
+	StructuredWarnings        []mutationWarning `json:"-"`
+	Error                     *mutationError    `json:"error"`
+}
+
+func (r mutationResult) MarshalJSON() ([]byte, error) {
+	type alias mutationResult
+	base := alias(r)
+	base.Warnings = nil
+	warnings := any(nil)
+	if len(r.StructuredWarnings) > 0 {
+		warnings = r.StructuredWarnings
+	} else if len(r.Warnings) > 0 {
+		warnings = r.Warnings
+	}
+	return json.Marshal(struct {
+		alias
+		Warnings any `json:"warnings,omitempty"`
+	}{alias: base, Warnings: warnings})
+}
+
+func (r *mutationResult) UnmarshalJSON(data []byte) error {
+	type alias mutationResult
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	rawWarnings := fields["warnings"]
+	delete(fields, "warnings")
+	withoutWarnings, err := json.Marshal(fields)
+	if err != nil {
+		return err
+	}
+	var decoded alias
+	if err := json.Unmarshal(withoutWarnings, &decoded); err != nil {
+		return err
+	}
+	*r = mutationResult(decoded)
+	if len(rawWarnings) == 0 || string(rawWarnings) == "null" {
+		return nil
+	}
+	if err := json.Unmarshal(rawWarnings, &r.Warnings); err == nil {
+		return nil
+	}
+	if err := json.Unmarshal(rawWarnings, &r.StructuredWarnings); err != nil {
+		return fmt.Errorf("decode mutation warnings: %w", err)
+	}
+	return nil
 }
 
 type routingAdminStatus struct {
-	ConfigPath           string   `json:"config_path"`
-	RouterPID            int      `json:"router_pid"`
-	RouterBootID         string   `json:"router_boot_id"`
-	ActiveGeneration     uint64   `json:"active_generation"`
-	ActiveConfigHash     string   `json:"active_config_hash"`
-	DesiredConfigHash    string   `json:"desired_config_hash"`
-	GlobalRoutingEnabled bool     `json:"global_routing_enabled"`
-	Capabilities         []string `json:"capabilities"`
+	ConfigPath           string                        `json:"config_path"`
+	RouterPID            int                           `json:"router_pid"`
+	RouterBootID         string                        `json:"router_boot_id"`
+	ActiveGeneration     uint64                        `json:"active_generation"`
+	ActiveConfigHash     string                        `json:"active_config_hash"`
+	DesiredConfigHash    string                        `json:"desired_config_hash"`
+	GlobalRoutingEnabled bool                          `json:"global_routing_enabled"`
+	Capabilities         []string                      `json:"capabilities"`
+	FallbackPolicy       config.ResolvedFallbackPolicy `json:"fallback_policy"`
+	Clients              []fallbackAdminClient         `json:"clients"`
 }
 
 func (s routingAdminStatus) activeToken() string {
@@ -206,11 +275,14 @@ func normalizeMutationInvocation(args []string) ([]string, error) {
 		i += consumed
 	}
 	if i >= len(args) {
-		return nil, fmt.Errorf("mutation options require an on, off, claude, codex, or mutation command")
+		return nil, fmt.Errorf("mutation options require an on, off, claude, codex, config, or mutation command")
 	}
 	command := args[i]
-	if command != "on" && command != "off" && command != "claude" && command != "codex" && command != "mutation" {
-		return nil, fmt.Errorf("mutation options are supported only by on, off, claude, codex, and mutation reconcile")
+	if command != "on" && command != "off" && command != "claude" && command != "codex" && command != "config" && command != "mutation" {
+		return nil, fmt.Errorf("mutation options are supported only by on, off, claude, codex, config fallback, and mutation reconcile")
+	}
+	if command == "config" && (i+1 >= len(args) || args[i+1] != "fallback") {
+		return nil, fmt.Errorf("mutation options under config are supported only by config fallback")
 	}
 	out := []string{command}
 	out = append(out, args[i+1:]...)
@@ -657,6 +729,27 @@ func validateManagedRouterIdentity(status routingAdminStatus, managedPID int) er
 }
 
 func waitConfigHashActivation(adminAddr, configPath, desiredHash, previousToken string, requireAdvance bool, timeout time.Duration) (routingAdminStatus, bool) {
+	return waitConfigActivation(adminAddr, configPath, desiredHash, previousToken, requireAdvance, timeout, nil)
+}
+
+func waitConfigMutationActivation(
+	adminAddr, configPath, desiredHash, previousToken string,
+	requireAdvance bool,
+	timeout time.Duration,
+	operation, key, client, requestedTarget string,
+	requested bool,
+) (routingAdminStatus, bool) {
+	return waitConfigActivation(adminAddr, configPath, desiredHash, previousToken, requireAdvance, timeout, func(status routingAdminStatus) bool {
+		return mutationProjectionMatches(status, operation, key, client, requestedTarget, requested)
+	})
+}
+
+func waitConfigActivation(
+	adminAddr, configPath, desiredHash, previousToken string,
+	requireAdvance bool,
+	timeout time.Duration,
+	projectionMatches func(routingAdminStatus) bool,
+) (routingAdminStatus, bool) {
 	deadline := time.Now().Add(timeout)
 	var last routingAdminStatus
 	for {
@@ -672,7 +765,8 @@ func waitConfigHashActivation(adminAddr, configPath, desiredHash, previousToken 
 				status.ConfigPath != "" &&
 				canonicalPath(status.ConfigPath) == canonicalPath(configPath) &&
 				status.ActiveConfigHash == desiredHash &&
-				status.DesiredConfigHash == desiredHash {
+				status.DesiredConfigHash == desiredHash &&
+				(projectionMatches == nil || projectionMatches(status)) {
 				return status, true
 			}
 		}
@@ -681,6 +775,52 @@ func waitConfigHashActivation(adminAddr, configPath, desiredHash, previousToken 
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
+}
+
+func requiredMutationCapability(operation string) string {
+	switch operation {
+	case "set_fallback_policy", "set_native_fallback_model":
+		return "fallback_policy"
+	default:
+		return ""
+	}
+}
+
+func mutationProjectionMatches(status routingAdminStatus, operation, key, client, requestedTarget string, requested bool) bool {
+	if capability := requiredMutationCapability(operation); capability != "" && !containsString(status.Capabilities, capability) {
+		return false
+	}
+	switch operation {
+	case "set_fallback_policy":
+		switch key {
+		case "429":
+			return status.FallbackPolicy.OnBaseten429 == requested
+		case "5xx":
+			return status.FallbackPolicy.OnBaseten5xx == requested
+		default:
+			return false
+		}
+	case "set_native_fallback_model":
+		for _, activeClient := range status.Clients {
+			if activeClient.Name == client {
+				return activeClient.BasetenModelFallback.ResolvedModel == requestedTarget
+			}
+		}
+		return false
+	default:
+		return true
+	}
+}
+
+func mutationJournalProjectionMatches(status routingAdminStatus, journal routingMutationJournal) bool {
+	return mutationProjectionMatches(
+		status,
+		journal.Operation,
+		journal.Key,
+		journal.Client,
+		journal.RequestedTarget,
+		journal.Requested,
+	)
 }
 
 // signalExpectedRouter resolves the managed pidfile immediately before
@@ -728,14 +868,15 @@ func signalVerifiedRouter(expected routingAdminStatus, adminAddr string) (int, e
 }
 
 type journaledMutationSpec struct {
-	Operation       string
-	Surface         string
-	Requested       bool
-	RequestedTarget string
-	Client          string
-	Key             string
-	Apply           func(path string) error
-	HumanSuccess    string
+	Operation          string
+	Surface            string
+	Requested          bool
+	RequestedTarget    string
+	Client             string
+	Key                string
+	Apply              func(path string) error
+	HumanSuccess       string
+	StructuredWarnings []mutationWarning
 }
 
 func mutationResultForSpec(spec journaledMutationSpec, operationID, path, priorHash string) mutationResult {
@@ -749,6 +890,7 @@ func mutationResultForSpec(spec journaledMutationSpec, operationID, path, priorH
 		ConfigPath:                path,
 		PreviousDesiredConfigHash: priorHash,
 		DesiredConfigHash:         priorHash,
+		StructuredWarnings:        spec.StructuredWarnings,
 	}
 }
 
@@ -1309,6 +1451,9 @@ func runJournaledMutationLocked(path string, prior []byte, mode os.FileMode, opt
 		if err := validateManagedRouterIdentity(status, managedPID); err != nil {
 			return failMutation(opts, out, result, "router_identity_mismatch", err.Error(), false, 1)
 		}
+		if capability := requiredMutationCapability(spec.Operation); capability != "" && !containsString(status.Capabilities, capability) {
+			return failMutation(opts, out, result, "router_unsupported", reviewedMutationMessage("router_unsupported"), false, 1)
+		}
 		before = status
 		result.PreviousActiveToken = status.activeToken()
 		result.PreviousDesiredConfigHash = status.DesiredConfigHash
@@ -1323,6 +1468,9 @@ func runJournaledMutationLocked(path string, prior []byte, mode os.FileMode, opt
 	if opts.IfActiveToken != "" && opts.IfActiveToken != before.activeToken() {
 		return failMutation(opts, out, result, "stale_active_token",
 			fmt.Sprintf("router changed: expected active token %s, found %s", opts.IfActiveToken, before.activeToken()), true, 1)
+	}
+	if !routerRunning && requiredMutationCapability(spec.Operation) != "" {
+		result.StructuredWarnings = appendMutationWarning(result.StructuredWarnings, mutationWarning{Code: "capable_router_activation_required"})
 	}
 
 	desired, err := previewExactConfigEdit(path, prior, mode, spec.Apply)
@@ -1340,6 +1488,9 @@ func runJournaledMutationLocked(path string, prior []byte, mode os.FileMode, opt
 			fmt.Sprintf("edited config would not load in the gateway: %v", err), false, 1)
 	}
 	if desiredHash == priorHash {
+		if routerRunning && !mutationProjectionMatches(before, spec.Operation, spec.Key, spec.Client, spec.RequestedTarget, spec.Requested) {
+			return failMutation(opts, out, result, "router_state_mismatch", "the running router does not report the requested active fallback value", true, 1)
+		}
 		result.OK = true
 		result.Applied = routerRunning
 		result.Outcome = mutationOutcomeUnchanged
@@ -1361,6 +1512,9 @@ func runJournaledMutationLocked(path string, prior []byte, mode os.FileMode, opt
 			emitMutationResult(out, result)
 		} else if spec.HumanSuccess != "" {
 			fmt.Fprintln(out, spec.HumanSuccess+"  (unchanged)")
+		}
+		if !routerRunning && requiredMutationCapability(spec.Operation) != "" {
+			printCapableRouterActivationWarning(opts, path)
 		}
 		return 0
 	}
@@ -1416,13 +1570,29 @@ func runJournaledMutationLocked(path string, prior []byte, mode os.FileMode, opt
 			if spec.HumanSuccess != "" {
 				fmt.Fprintln(out, spec.HumanSuccess)
 			}
-			fmt.Fprintf(os.Stderr, "router not running; %s updated and applies at next start; reconcile operation %s after startup\n", path, opts.OperationID)
+			if requiredMutationCapability(spec.Operation) != "" {
+				fmt.Fprintf(os.Stderr, "router not running; %s updated, but only a router with fallback policy support can activate it; reconcile operation %s after startup\n", path, opts.OperationID)
+			} else {
+				fmt.Fprintf(os.Stderr, "router not running; %s updated and applies at next start; reconcile operation %s after startup\n", path, opts.OperationID)
+			}
 		}
 		return 0
 	}
 
 	signaledPID, signalErr := signalVerifiedRouter(before, adminAddr)
-	active, activated := waitConfigHashActivation(adminAddr, path, desiredHash, before.activeToken(), true, routeApplyTimeout)
+	active, activated := waitConfigMutationActivation(
+		adminAddr,
+		path,
+		desiredHash,
+		before.activeToken(),
+		true,
+		routeApplyTimeout,
+		spec.Operation,
+		spec.Key,
+		spec.Client,
+		spec.RequestedTarget,
+		spec.Requested,
+	)
 	if activated {
 		result.Applied = true
 		result.ActiveToken = active.activeToken()
@@ -1637,8 +1807,23 @@ func cmdMutation(args []string) int {
 		if err := validateManagedRouterIdentity(before, pid); err != nil {
 			return failMutation(opts, os.Stdout, result, "router_identity_mismatch", reviewedMutationMessage("router_identity_mismatch"), false, 1)
 		}
+		if capability := requiredMutationCapability(journal.Operation); capability != "" && !containsString(before.Capabilities, capability) {
+			return failMutation(opts, os.Stdout, result, "router_unsupported", reviewedMutationMessage("router_unsupported"), false, 1)
+		}
 		if currentHash == journal.DesiredConfigHash {
-			if active, ok := waitConfigHashActivation(adminAddr, path, journal.DesiredConfigHash, "", false, 250*time.Millisecond); ok {
+			if active, ok := waitConfigMutationActivation(
+				adminAddr,
+				path,
+				journal.DesiredConfigHash,
+				"",
+				false,
+				250*time.Millisecond,
+				journal.Operation,
+				journal.Key,
+				journal.Client,
+				journal.RequestedTarget,
+				journal.Requested,
+			); ok {
 				published, err := publishMutationTerminal(path, terminalFromJournal(journal, mutationOutcomeApplied, active, "", false), &journal)
 				if err != nil {
 					result.ReconciliationRequired = true
@@ -1658,7 +1843,19 @@ func cmdMutation(args []string) int {
 				return 0
 			}
 			if _, err := signalVerifiedRouter(before, adminAddr); err == nil {
-				if active, ok := waitConfigHashActivation(adminAddr, path, journal.DesiredConfigHash, journal.PreviousActiveToken, true, routeApplyTimeout); ok {
+				if active, ok := waitConfigMutationActivation(
+					adminAddr,
+					path,
+					journal.DesiredConfigHash,
+					journal.PreviousActiveToken,
+					true,
+					routeApplyTimeout,
+					journal.Operation,
+					journal.Key,
+					journal.Client,
+					journal.RequestedTarget,
+					journal.Requested,
+				); ok {
 					published, err := publishMutationTerminal(path, terminalFromJournal(journal, mutationOutcomeApplied, active, "", false), &journal)
 					if err != nil {
 						result.ReconciliationRequired = true

--- a/gateway/cmd/baseten-switch/routing_mutation_recovery.go
+++ b/gateway/cmd/baseten-switch/routing_mutation_recovery.go
@@ -237,7 +237,9 @@ func validTerminalOperationShape(record mutationTerminalRecord) bool {
 	switch record.Operation {
 	case "set_global_routing":
 		return validMutationSurface(record.Operation, record.Surface) && record.Client == "" && record.KeyHash == "" && record.RequestedTargetHash == ""
-	case "set_claude_route", "set_claude_subagents":
+	case "set_claude_route", "set_claude_subagents",
+		"enable_claude_picker", "disable_claude_picker",
+		"add_claude_picker_model", "remove_claude_picker_model", "move_claude_picker_model":
 		return validMutationSurface(record.Operation, record.Surface) && !record.Requested && record.Client != "" && validConfigHash(record.KeyHash) && validConfigHash(record.RequestedTargetHash)
 	case "set_codex_route":
 		return validMutationSurface(record.Operation, record.Surface) && !record.Requested && record.Client != "" && validConfigHash(record.KeyHash) && validConfigHash(record.RequestedTargetHash)
@@ -253,7 +255,9 @@ func validMutationSurface(operation, surface string) bool {
 	switch operation {
 	case "set_global_routing":
 		return surface == mutationSurfaceSwitch
-	case "set_claude_route", "set_claude_subagents":
+	case "set_claude_route", "set_claude_subagents",
+		"enable_claude_picker", "disable_claude_picker",
+		"add_claude_picker_model", "remove_claude_picker_model", "move_claude_picker_model":
 		return surface == mutationSurfaceClaude
 	case "set_codex_route":
 		return surface == mutationSurfaceCodex

--- a/gateway/cmd/baseten-switch/routing_mutation_recovery.go
+++ b/gateway/cmd/baseten-switch/routing_mutation_recovery.go
@@ -119,7 +119,7 @@ type mutationRecoveryResult struct {
 }
 
 func requestedPresent(operation string) bool {
-	return operation == "set_global_routing"
+	return operation == "set_global_routing" || operation == "set_fallback_policy"
 }
 
 func domainHash(domain, value string) string {
@@ -237,6 +237,10 @@ func validTerminalOperationShape(record mutationTerminalRecord) bool {
 	switch record.Operation {
 	case "set_global_routing":
 		return validMutationSurface(record.Operation, record.Surface) && record.Client == "" && record.KeyHash == "" && record.RequestedTargetHash == ""
+	case "set_fallback_policy":
+		return validMutationSurface(record.Operation, record.Surface) && record.Client == "" && validConfigHash(record.KeyHash) && validConfigHash(record.RequestedTargetHash)
+	case "set_native_fallback_model":
+		return validMutationSurface(record.Operation, record.Surface) && !record.Requested && record.Client != "" && validConfigHash(record.KeyHash) && validConfigHash(record.RequestedTargetHash)
 	case "set_claude_route", "set_claude_subagents",
 		"enable_claude_picker", "disable_claude_picker",
 		"add_claude_picker_model", "remove_claude_picker_model", "move_claude_picker_model":
@@ -255,6 +259,8 @@ func validMutationSurface(operation, surface string) bool {
 	switch operation {
 	case "set_global_routing":
 		return surface == mutationSurfaceSwitch
+	case "set_fallback_policy", "set_native_fallback_model":
+		return surface == mutationSurfaceConfig
 	case "set_claude_route", "set_claude_subagents",
 		"enable_claude_picker", "disable_claude_picker",
 		"add_claude_picker_model", "remove_claude_picker_model", "move_claude_picker_model":
@@ -656,6 +662,7 @@ func resultFromTerminal(path string, record mutationTerminalRecord, includeReque
 	if includeRequest {
 		result.Key = spec.Key
 		result.RequestedTarget = spec.RequestedTarget
+		result.StructuredWarnings = spec.StructuredWarnings
 	}
 	switch record.Outcome {
 	case mutationOutcomeApplied:
@@ -804,7 +811,7 @@ func reviewedMutationMessage(code string) string {
 	case "router_unavailable":
 		return "the router is unavailable; routing recovery state was preserved"
 	case "router_unsupported":
-		return "the router does not expose the state required for safe automatic cleanup"
+		return "the running router does not support the state required for this routing operation"
 	case "mutation_locked":
 		return "another routing mutation is in progress; retry this operation"
 	case "stale_config_hash", "stale_active_token":
@@ -1013,13 +1020,18 @@ func inspectRoutingMutationStatusLocked(configPath string) (routingMutationStatu
 		status.Error = &mutationError{Code: mutationStatusRouterUnsupported, Message: reviewedMutationMessage(mutationStatusRouterUnsupported)}
 		return status, nil
 	}
+	if capability := requiredMutationCapability(journal.Operation); capability != "" && !containsString(admin.Capabilities, capability) {
+		status.Classification = mutationStatusRouterUnsupported
+		status.Error = &mutationError{Code: mutationStatusRouterUnsupported, Message: reviewedMutationMessage(mutationStatusRouterUnsupported)}
+		return status, nil
+	}
 	if diskHash != journal.PreviousConfigHash && diskHash != journal.DesiredConfigHash {
 		status.Classification = mutationStatusExternalChange
 		status.Error = &mutationError{Code: mutationStatusExternalChange, Message: reviewedMutationMessage(mutationStatusExternalChange)}
 		return status, nil
 	}
 	if diskHash == journal.DesiredConfigHash {
-		if admin.DesiredConfigHash == diskHash && admin.ActiveConfigHash == diskHash {
+		if admin.DesiredConfigHash == diskHash && admin.ActiveConfigHash == diskHash && mutationJournalProjectionMatches(admin, journal) {
 			status.Classification = mutationStatusDesiredActive
 		} else {
 			status.Classification = mutationStatusDesiredPending
@@ -1084,10 +1096,13 @@ func finalCleanupSnapshot(configPath string, expected routingMutationStatus) (ro
 		canonicalPath(admin.ConfigPath) != canonicalPath(configPath) || validateManagedRouterIdentity(admin, managedPID) != nil {
 		return routingMutationJournal{}, routingAdminStatus{}, fmt.Errorf("cleanup predicate changed")
 	}
+	if capability := requiredMutationCapability(journal.Operation); capability != "" && !containsString(admin.Capabilities, capability) {
+		return routingMutationJournal{}, routingAdminStatus{}, fmt.Errorf("cleanup predicate changed")
+	}
 	classification := mutationStatusPriorPending
 	if diskHash == journal.DesiredConfigHash {
 		classification = mutationStatusDesiredPending
-		if admin.DesiredConfigHash == diskHash && admin.ActiveConfigHash == diskHash {
+		if admin.DesiredConfigHash == diskHash && admin.ActiveConfigHash == diskHash && mutationJournalProjectionMatches(admin, journal) {
 			classification = mutationStatusDesiredActive
 		}
 	} else if diskHash == journal.PreviousConfigHash {

--- a/gateway/cmd/baseten-switch/routing_mutation_recovery.go
+++ b/gateway/cmd/baseten-switch/routing_mutation_recovery.go
@@ -242,9 +242,10 @@ func validTerminalOperationShape(record mutationTerminalRecord) bool {
 	case "set_native_fallback_model":
 		return validMutationSurface(record.Operation, record.Surface) && !record.Requested && record.Client != "" && validConfigHash(record.KeyHash) && validConfigHash(record.RequestedTargetHash)
 	case "set_claude_route", "set_claude_subagents",
-		"enable_claude_picker", "disable_claude_picker",
 		"add_claude_picker_model", "remove_claude_picker_model", "move_claude_picker_model":
 		return validMutationSurface(record.Operation, record.Surface) && !record.Requested && record.Client != "" && validConfigHash(record.KeyHash) && validConfigHash(record.RequestedTargetHash)
+	case "enable_claude_picker", "disable_claude_picker":
+		return validMutationSurface(record.Operation, record.Surface) && !record.Requested && record.Client != "" && validConfigHash(record.KeyHash) && record.RequestedTargetHash == ""
 	case "set_codex_route":
 		return validMutationSurface(record.Operation, record.Surface) && !record.Requested && record.Client != "" && validConfigHash(record.KeyHash) && validConfigHash(record.RequestedTargetHash)
 	case "set_model_reasoning":

--- a/gateway/cmd/baseten-switch/routing_mutation_recovery.go
+++ b/gateway/cmd/baseten-switch/routing_mutation_recovery.go
@@ -828,6 +828,8 @@ func reviewedMutationMessage(code string) string {
 		return "the routing result could not be confirmed; recovery state was preserved"
 	case "reasoning_preflight_failed":
 		return "the reasoning policy could not be validated against the running router"
+	case claudePickerContextMinimumErrorCode:
+		return "the selected Baseten model has a known context window below Claude Code's 200000-token model picker minimum; choose a model with at least 200000 tokens"
 	case "fingerprint_failed":
 		return "the routing request could not be identified safely"
 	case "cleanup_predicate_changed":

--- a/gateway/cmd/baseten-switch/routing_mutation_recovery_test.go
+++ b/gateway/cmd/baseten-switch/routing_mutation_recovery_test.go
@@ -1128,6 +1128,38 @@ func TestTerminalReaderRejectsTrailingAndInconsistentJSON(t *testing.T) {
 	}
 }
 
+func TestTerminalPickerToggleOperationShapeRequiresNoTargetHash(t *testing.T) {
+	installRoutingMutationSeams(t)
+	for _, operation := range []string{"enable_claude_picker", "disable_claude_picker"} {
+		t.Run(operation, func(t *testing.T) {
+			path := writeSwitchFixture(t, globalRoutingFixtureYAML)
+			journal := legacyJournalForTest(t, path, operation+"-terminal-shape")
+			journal.Operation = operation
+			journal.Surface = mutationSurfaceClaude
+			journal.Client = "claude-code"
+			journal.Key = "model_picker"
+			journal.RequestedTarget = ""
+			journal.RequestFingerprint = domainHash("request", operation)
+			record := terminalFromJournal(
+				journal,
+				mutationOutcomeUnchanged,
+				routingAdminStatus{},
+				"",
+				false,
+			)
+			record.DesiredConfigHash = record.PreviousConfigHash
+			record.PreviousActiveToken = ""
+			if err := validateTerminalRecord(record, path, journal.OperationID); err != nil {
+				t.Fatalf("valid picker toggle terminal rejected: %v", err)
+			}
+			record.RequestedTargetHash = domainHash("requested-target-v1", "unexpected")
+			if err := validateTerminalRecord(record, path, journal.OperationID); err == nil {
+				t.Fatal("picker toggle terminal with a target hash was accepted")
+			}
+		})
+	}
+}
+
 func TestMutationWritersEnforceReaderBoundsBeforeCommit(t *testing.T) {
 	installRoutingMutationSeams(t)
 	t.Run("journal", func(t *testing.T) {

--- a/gateway/cmd/gateway/admin.go
+++ b/gateway/cmd/gateway/admin.go
@@ -280,16 +280,20 @@ type modelPickerStatus struct {
 }
 
 type modelPickerStatusModel struct {
-	Alias       string `json:"alias"`
-	Slug        string `json:"slug"`
-	Label       string `json:"label"`
-	Description string `json:"description,omitempty"`
+	Alias         string `json:"alias"`
+	Slug          string `json:"slug"`
+	Label         string `json:"label"`
+	Description   string `json:"description,omitempty"`
+	ContextTokens int64  `json:"context_tokens"`
 }
 
 // computeModelPickerStatus projects the desired config in its saved order.
 // It intentionally does not read Claude settings or infer whether policy has
 // filtered a row; the Claude adapter owns those file and runtime status axes.
-func computeModelPickerStatus(c config.Client) *modelPickerStatus {
+func computeModelPickerStatus(
+	c config.Client,
+	catalog *pricing.Snapshot,
+) *modelPickerStatus {
 	if c.ModelPicker == nil {
 		return nil
 	}
@@ -299,11 +303,16 @@ func computeModelPickerStatus(c config.Client) *modelPickerStatus {
 	}
 	for _, model := range c.ModelPicker.Models {
 		slug := c.ModelAliases[model.Alias]
+		var contextTokens int64
+		if record, ok := catalog.Model(pricing.ProviderBaseten, slug); ok {
+			contextTokens = record.ContextTokens
+		}
 		status.Models = append(status.Models, modelPickerStatusModel{
-			Alias:       model.Alias,
-			Slug:        slug,
-			Label:       modelmeta.ResolveBaseten(slug).DisplayName + " via Baseten",
-			Description: "Served by Baseten.",
+			Alias:         model.Alias,
+			Slug:          slug,
+			Label:         modelmeta.ResolveBaseten(slug).DisplayName + " via Baseten",
+			Description:   "Served by Baseten.",
+			ContextTokens: contextTokens,
 		})
 	}
 	return status
@@ -429,7 +438,11 @@ func (g *Gateway) policyAwareFallbackCooldown(rc resolvedClientConfig) (fallback
 	return state, active && cooldownEligible(rc.resolvedFallbackPolicy(), fallbackAllowLegacy, state)
 }
 
-func basetenModelFallbackStatus(rc resolvedClientConfig, desiredActiveMismatch bool) map[string]any {
+func basetenModelFallbackStatus(
+	rc resolvedClientConfig,
+	desiredActiveMismatch bool,
+	catalog *pricing.Snapshot,
+) map[string]any {
 	model := rc.NativeFallbackModel
 	providerReady := nativeFallbackProviderReady(rc)
 	ready := model != "" && providerReady && config.IsProtocolNativeModel(rc.ProtocolShape, model)
@@ -448,41 +461,188 @@ func basetenModelFallbackStatus(rc resolvedClientConfig, desiredActiveMismatch b
 	return map[string]any{
 		"configured_model": model,
 		"resolved_model":   model,
-		"display_name":     nativeFallbackDisplayName(model),
+		"display_name":     nativeFallbackCatalogDisplayName(catalog, model),
 		"provider_ready":   providerReady,
 		"ready":            ready,
 		"reason":           reason,
-		"available_models": nativeFallbackAvailableModels(rc),
+		"available_models": nativeFallbackAvailableModels(rc, catalog),
 	}
 }
 
-func nativeFallbackAvailableModels(rc resolvedClientConfig) []map[string]any {
-	candidates := make([]string, 0, 2+len(modelFamilySet))
-	candidates = append(
-		candidates,
-		rc.NativeFallbackModel,
-		config.DefaultClaudeNativeFallbackModel,
-	)
-	for _, family := range modelFamilySet {
-		candidates = append(candidates, familyRepresentativeIDs[family])
-	}
-
-	seen := make(map[string]struct{}, len(candidates))
-	models := make([]map[string]any, 0, len(candidates))
-	for _, model := range candidates {
+func nativeFallbackAvailableModels(
+	rc resolvedClientConfig,
+	catalog *pricing.Snapshot,
+) []map[string]any {
+	records := catalog.Models(pricing.ProviderAnthropic)
+	byFamily := make(map[string]nativeFallbackOption, len(modelFamilySet))
+	for _, record := range records {
+		model := record.CanonicalModelID
 		if !config.IsProtocolNativeModel(rc.ProtocolShape, model) {
 			continue
 		}
-		if _, duplicate := seen[model]; duplicate {
+		if !nativeFallbackFamilyAllowed(record.Family) {
 			continue
 		}
-		seen[model] = struct{}{}
+		candidate := nativeFallbackOption{
+			model:       model,
+			displayName: normalizeNativeFallbackDisplayName(record.DisplayName),
+			family:      record.Family,
+			releaseDate: record.ReleaseDate,
+			version:     nativeFallbackVersion(model, record.Family),
+		}
+		if existing, duplicate := byFamily[candidate.family]; !duplicate ||
+			preferNativeFallbackOption(candidate, existing) {
+			byFamily[candidate.family] = candidate
+		}
+	}
+
+	models := make([]map[string]any, 0, len(byFamily))
+	for _, family := range modelFamilySet {
+		option, ok := byFamily[family]
+		if !ok {
+			continue
+		}
 		models = append(models, map[string]any{
-			"model":        model,
-			"display_name": nativeFallbackDisplayName(model),
+			"model": option.model, "display_name": option.displayName,
 		})
 	}
 	return models
+}
+
+type nativeFallbackOption struct {
+	model       string
+	displayName string
+	family      string
+	releaseDate string
+	version     []uint64
+}
+
+func preferNativeFallbackOption(
+	candidate nativeFallbackOption,
+	existing nativeFallbackOption,
+) bool {
+	if candidate.releaseDate != existing.releaseDate {
+		if comparison := compareNativeFallbackReleaseDates(
+			candidate.releaseDate,
+			existing.releaseDate,
+		); comparison != 0 {
+			return comparison > 0
+		}
+	}
+	if comparison := compareNativeFallbackVersions(
+		candidate.version,
+		existing.version,
+	); comparison != 0 {
+		return comparison > 0
+	}
+	if len(candidate.model) != len(existing.model) {
+		return len(candidate.model) < len(existing.model)
+	}
+	return candidate.model < existing.model
+}
+
+// Canonical YYYY-MM and YYYY-MM-DD values sort chronologically as strings.
+// Within the same month, the documented day precision sorts after month-only
+// precision, providing a stable preference when the catalog mixes both forms.
+func compareNativeFallbackReleaseDates(left, right string) int {
+	if left == right {
+		return 0
+	}
+	if left == "" {
+		return -1
+	}
+	if right == "" {
+		return 1
+	}
+	if left < right {
+		return -1
+	}
+	return 1
+}
+
+func nativeFallbackFamilyAllowed(family string) bool {
+	for _, allowed := range modelFamilySet {
+		if family == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+// nativeFallbackVersion provides a deterministic fallback for provider cache
+// records written before release_date was retained. Anthropic has used both
+// claude-FAMILY-MAJOR-MINOR and claude-MAJOR-MINOR-FAMILY identifiers.
+func nativeFallbackVersion(model, family string) []uint64 {
+	parts := strings.Split(strings.TrimPrefix(model, "claude-"), "-")
+	familyIndex := -1
+	for index, part := range parts {
+		if part == family {
+			familyIndex = index
+			break
+		}
+	}
+	if familyIndex < 0 {
+		return nil
+	}
+	var versionParts []string
+	if familyIndex == 0 {
+		versionParts = parts[1:]
+	} else {
+		versionParts = parts[:familyIndex]
+	}
+	version := make([]uint64, 0, len(versionParts))
+	for _, part := range versionParts {
+		if part == "" || strings.IndexFunc(part, func(r rune) bool {
+			return r < '0' || r > '9'
+		}) >= 0 {
+			break
+		}
+		value, err := strconv.ParseUint(part, 10, 64)
+		if err != nil {
+			break
+		}
+		version = append(version, value)
+	}
+	if familyIndex == 0 && len(version) > 1 {
+		lastRaw := versionParts[len(version)-1]
+		if len(lastRaw) == 8 {
+			version = version[:len(version)-1]
+		}
+	}
+	if len(version) == 0 {
+		return nil
+	}
+	return version
+}
+
+func compareNativeFallbackVersions(left, right []uint64) int {
+	limit := min(len(left), len(right))
+	for index := 0; index < limit; index++ {
+		if left[index] < right[index] {
+			return -1
+		}
+		if left[index] > right[index] {
+			return 1
+		}
+	}
+	if len(left) < len(right) {
+		return -1
+	}
+	if len(left) > len(right) {
+		return 1
+	}
+	return 0
+}
+
+func normalizeNativeFallbackDisplayName(displayName string) string {
+	return strings.TrimSuffix(displayName, " (latest)")
+}
+
+func nativeFallbackCatalogDisplayName(catalog *pricing.Snapshot, model string) string {
+	if displayName, ok := catalog.DisplayName(pricing.ProviderAnthropic, model); ok {
+		return normalizeNativeFallbackDisplayName(displayName)
+	}
+	return normalizeNativeFallbackDisplayName(nativeFallbackDisplayName(model))
 }
 
 func nativeFallbackProviderReady(rc resolvedClientConfig) bool {
@@ -646,7 +806,7 @@ func (g *Gateway) adminStatus(w http.ResponseWriter, r *http.Request) {
 				"model_routes":       rcEff.ModelRoutes,
 				"families":           families,
 				"model_catalog":      computeModelCatalog(rcEff, catalogSnapshot),
-				"model_picker":       computeModelPickerStatus(c),
+				"model_picker":       computeModelPickerStatus(c, catalogSnapshot),
 				"model_options":      computeClientModelOptions(rcEff, catalogSnapshot),
 				"unmatched_native_model": map[string]any{
 					"configured_target": configuredTargetJSON,
@@ -656,7 +816,11 @@ func (g *Gateway) adminStatus(w http.ResponseWriter, r *http.Request) {
 				},
 			}
 			if c.Enabled && rcEff.ProtocolShape == "anthropic" {
-				clientStatus["baseten_model_fallback"] = basetenModelFallbackStatus(rcEff, desiredActiveMismatch)
+				clientStatus["baseten_model_fallback"] = basetenModelFallbackStatus(
+					rcEff,
+					desiredActiveMismatch,
+					catalogSnapshot,
+				)
 			}
 			clients = append(clients, clientStatus)
 		}
@@ -702,7 +866,11 @@ func (g *Gateway) adminStatus(w http.ResponseWriter, r *http.Request) {
 				},
 			}
 			if cl.cfg.ProtocolShape == "anthropic" {
-				clientStatus["baseten_model_fallback"] = basetenModelFallbackStatus(cl.cfg, desiredActiveMismatch)
+				clientStatus["baseten_model_fallback"] = basetenModelFallbackStatus(
+					cl.cfg,
+					desiredActiveMismatch,
+					catalogSnapshot,
+				)
 			}
 			clients = append(clients, clientStatus)
 		}

--- a/gateway/cmd/gateway/admin.go
+++ b/gateway/cmd/gateway/admin.go
@@ -407,10 +407,10 @@ func (g *Gateway) activeRoutingState() activeRoutingState {
 }
 
 func fallbackStatus(g *Gateway, rc resolvedClientConfig) map[string]any {
-	deadline, active := g.fallbackDeadline(rc.Name)
+	state, active := g.policyAwareFallbackCooldown(rc)
 	var retryAfter any
 	if active {
-		retryAfter = deadline.UTC().Format(time.RFC3339Nano)
+		retryAfter = state.Until.UTC().Format(time.RFC3339Nano)
 	}
 	cause := ""
 	served := ""
@@ -422,6 +422,86 @@ func fallbackStatus(g *Gateway, rc resolvedClientConfig) map[string]any {
 		"active": active, "served_route": served, "cause": cause,
 		"since": nil, "retry_after": retryAfter,
 	}
+}
+
+func (g *Gateway) policyAwareFallbackCooldown(rc resolvedClientConfig) (fallbackCooldownState, bool) {
+	state, active := g.activeFallbackCooldown(rc.Name)
+	return state, active && cooldownEligible(rc.resolvedFallbackPolicy(), fallbackAllowLegacy, state)
+}
+
+func basetenModelFallbackStatus(rc resolvedClientConfig, desiredActiveMismatch bool) map[string]any {
+	model := rc.NativeFallbackModel
+	providerReady := nativeFallbackProviderReady(rc)
+	ready := model != "" && providerReady && config.IsProtocolNativeModel(rc.ProtocolShape, model)
+	var reason any
+	switch {
+	case desiredActiveMismatch:
+		reason = "desired_active_mismatch"
+		ready = false
+	case model == "":
+		reason = "not_configured"
+	case !providerReady:
+		reason = "provider_auth_unavailable"
+	case !ready:
+		reason = "not_configured"
+	}
+	return map[string]any{
+		"configured_model": model,
+		"resolved_model":   model,
+		"display_name":     nativeFallbackDisplayName(model),
+		"provider_ready":   providerReady,
+		"ready":            ready,
+		"reason":           reason,
+		"available_models": nativeFallbackAvailableModels(rc),
+	}
+}
+
+func nativeFallbackAvailableModels(rc resolvedClientConfig) []map[string]any {
+	candidates := make([]string, 0, 2+len(modelFamilySet))
+	candidates = append(
+		candidates,
+		rc.NativeFallbackModel,
+		config.DefaultClaudeNativeFallbackModel,
+	)
+	for _, family := range modelFamilySet {
+		candidates = append(candidates, familyRepresentativeIDs[family])
+	}
+
+	seen := make(map[string]struct{}, len(candidates))
+	models := make([]map[string]any, 0, len(candidates))
+	for _, model := range candidates {
+		if !config.IsProtocolNativeModel(rc.ProtocolShape, model) {
+			continue
+		}
+		if _, duplicate := seen[model]; duplicate {
+			continue
+		}
+		seen[model] = struct{}{}
+		models = append(models, map[string]any{
+			"model":        model,
+			"display_name": nativeFallbackDisplayName(model),
+		})
+	}
+	return models
+}
+
+func nativeFallbackProviderReady(rc resolvedClientConfig) bool {
+	// Native attempts preserve per-request harness authentication. Readiness
+	// here therefore means the active client has a shape-compatible native
+	// route; process-level API-key environment is not authoritative.
+	return rc.FallbackRoute != "" && rc.FallbackRoute == config.NativeRoute(rc.ProtocolShape)
+}
+
+func nativeFallbackDisplayName(model string) string {
+	lower := strings.ToLower(model)
+	for _, family := range []struct{ token, label string }{
+		{"opus", "Opus"}, {"sonnet", "Sonnet"}, {"haiku", "Haiku"}, {"fable", "Fable"},
+	} {
+		if strings.Contains(lower, family.token) {
+			return family.label
+		}
+	}
+	return model
 }
 
 func providerDisplayName(provider string) string {
@@ -492,8 +572,11 @@ func resolvedStatusClient(f *config.File, c config.Client) resolvedClientConfig 
 		DefaultModel:         c.DefaultModel,
 		ModelAliases:         c.ModelAliases, SubagentModel: c.SubagentModel,
 		SubagentRouting: c.SubagentRouting, ModelRoutes: c.ModelRoutes,
-		ModelOptions:  cloneModelOptions(c.ModelOptions),
-		FallbackRoute: c.FallbackRoute, UpstreamShape: c.UpstreamShape,
+		ModelOptions:      cloneModelOptions(c.ModelOptions),
+		FallbackRoute:     c.FallbackRoute,
+		FallbackPolicy:    config.ResolveFallbackPolicy(f.Global.FallbackPolicy),
+		HasFallbackPolicy: true, NativeFallbackModel: c.NativeFallbackModel,
+		UpstreamShape: c.UpstreamShape,
 	}
 }
 
@@ -508,6 +591,11 @@ func (g *Gateway) adminStatus(w http.ResponseWriter, r *http.Request) {
 	runtimeCfg := g.runtimeConfig()
 	g.routingMu.RUnlock()
 	catalogSnapshot := g.pricing.Capture()
+	desiredHash := ""
+	if raw, err := os.ReadFile(g.activeConfigPath()); err == nil {
+		desiredHash = exactConfigHash(raw)
+	}
+	desiredActiveMismatch := desiredHash != "" && state.activeHash != "" && desiredHash != state.activeHash
 	runtimeByName := map[string]resolvedClientConfig{}
 	boundByName := map[string]bool{}
 	for _, cl := range runtimeClients {
@@ -540,7 +628,7 @@ func (g *Gateway) adminStatus(w http.ResponseWriter, r *http.Request) {
 			if configuredTarget != "" {
 				configuredTargetJSON = configuredTarget
 			}
-			clients = append(clients, map[string]any{
+			clientStatus := map[string]any{
 				"name":               c.Name,
 				"enabled":            c.Enabled,
 				"bind_addr":          c.BindAddr,
@@ -566,7 +654,11 @@ func (g *Gateway) adminStatus(w http.ResponseWriter, r *http.Request) {
 					"effective_model":   unmatched.model,
 					"effective_source":  unmatched.source,
 				},
-			})
+			}
+			if c.Enabled && rcEff.ProtocolShape == "anthropic" {
+				clientStatus["baseten_model_fallback"] = basetenModelFallbackStatus(rcEff, desiredActiveMismatch)
+			}
+			clients = append(clients, clientStatus)
 		}
 	} else {
 		// Embedders that construct New without a backing config still get
@@ -583,7 +675,7 @@ func (g *Gateway) adminStatus(w http.ResponseWriter, r *http.Request) {
 			if subagentEffective == "" || cl.cfg.SubagentRouting == "off" {
 				subagentEffective = "inherit"
 			}
-			clients = append(clients, map[string]any{
+			clientStatus := map[string]any{
 				"name":               cl.cfg.Name,
 				"bind_addr":          cl.Addr().String(),
 				"protocol_shape":     cl.cfg.ProtocolShape,
@@ -608,12 +700,12 @@ func (g *Gateway) adminStatus(w http.ResponseWriter, r *http.Request) {
 					"effective_model":   unmatched.model,
 					"effective_source":  unmatched.source,
 				},
-			})
+			}
+			if cl.cfg.ProtocolShape == "anthropic" {
+				clientStatus["baseten_model_fallback"] = basetenModelFallbackStatus(cl.cfg, desiredActiveMismatch)
+			}
+			clients = append(clients, clientStatus)
 		}
-	}
-	desiredHash := ""
-	if raw, err := os.ReadFile(g.activeConfigPath()); err == nil {
-		desiredHash = exactConfigHash(raw)
 	}
 	reloadState := "applied"
 	reloadErr := state.reloadErr
@@ -623,11 +715,13 @@ func (g *Gateway) adminStatus(w http.ResponseWriter, r *http.Request) {
 		reloadState = "pending"
 	}
 	globalEnabled := false
-	capabilities := []string{"global_routing"}
+	capabilities := []string{"global_routing", "fallback_policy"}
+	fallbackPolicy := config.ResolveFallbackPolicy(nil)
 	if state.file != nil {
 		if state.file.Global.RoutingEnabled != nil {
 			globalEnabled = *state.file.Global.RoutingEnabled
 		}
+		fallbackPolicy = config.ResolveFallbackPolicy(state.file.Global.FallbackPolicy)
 	}
 	signedIn, authType, fallbackInUse := g.authState()
 	ah := g.authHealth()
@@ -645,6 +739,7 @@ func (g *Gateway) adminStatus(w http.ResponseWriter, r *http.Request) {
 			"error": reloadErr,
 		},
 		"global_routing_enabled": globalEnabled,
+		"fallback_policy":        fallbackPolicy,
 		"uptime_seconds":         g.uptimeSeconds(),
 		"version":                version.Version,
 		// Mutation clients must target the exact file this process has

--- a/gateway/cmd/gateway/admin.go
+++ b/gateway/cmd/gateway/admin.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/modelmeta"
 	"github.com/basetenlabs/baseten-switch/gateway/internal/pidfile"
 	"github.com/basetenlabs/baseten-switch/gateway/internal/pricing"
 	"github.com/basetenlabs/baseten-switch/gateway/internal/telemetry"
@@ -273,6 +274,41 @@ type modelCatalogEntry struct {
 	Available     bool   `json:"available"`
 }
 
+type modelPickerStatus struct {
+	Enabled bool                     `json:"enabled"`
+	Models  []modelPickerStatusModel `json:"models"`
+}
+
+type modelPickerStatusModel struct {
+	Alias       string `json:"alias"`
+	Slug        string `json:"slug"`
+	Label       string `json:"label"`
+	Description string `json:"description,omitempty"`
+}
+
+// computeModelPickerStatus projects the desired config in its saved order.
+// It intentionally does not read Claude settings or infer whether policy has
+// filtered a row; the Claude adapter owns those file and runtime status axes.
+func computeModelPickerStatus(c config.Client) *modelPickerStatus {
+	if c.ModelPicker == nil {
+		return nil
+	}
+	status := &modelPickerStatus{
+		Enabled: c.ModelPicker.Enabled,
+		Models:  make([]modelPickerStatusModel, 0, len(c.ModelPicker.Models)),
+	}
+	for _, model := range c.ModelPicker.Models {
+		slug := c.ModelAliases[model.Alias]
+		status.Models = append(status.Models, modelPickerStatusModel{
+			Alias:       model.Alias,
+			Slug:        slug,
+			Label:       modelmeta.ResolveBaseten(slug).DisplayName + " via Baseten",
+			Description: "Served by Baseten.",
+		})
+	}
+	return status
+}
+
 // computeModelCatalog builds display metadata for one client's configured
 // Baseten targets: one entry per model_aliases entry, the default model when
 // not covered by an alias, and raw slugs saved in model_routes or
@@ -522,6 +558,7 @@ func (g *Gateway) adminStatus(w http.ResponseWriter, r *http.Request) {
 				"model_routes":       rcEff.ModelRoutes,
 				"families":           families,
 				"model_catalog":      computeModelCatalog(rcEff, catalogSnapshot),
+				"model_picker":       computeModelPickerStatus(c),
 				"model_options":      computeClientModelOptions(rcEff, catalogSnapshot),
 				"unmatched_native_model": map[string]any{
 					"configured_target": configuredTargetJSON,
@@ -563,6 +600,7 @@ func (g *Gateway) adminStatus(w http.ResponseWriter, r *http.Request) {
 				"model_routes":       cl.cfg.ModelRoutes,
 				"families":           families,
 				"model_catalog":      computeModelCatalog(cl.cfg, catalogSnapshot),
+				"model_picker":       nil,
 				"model_options":      computeClientModelOptions(cl.cfg, catalogSnapshot),
 				"unmatched_native_model": map[string]any{
 					"configured_target": configuredTargetJSON,

--- a/gateway/cmd/gateway/admin_fallback_policy_test.go
+++ b/gateway/cmd/gateway/admin_fallback_policy_test.go
@@ -2,11 +2,140 @@ package gateway
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/pricing"
 )
+
+const nativeFallbackCatalogFixture = `{
+  "anthropic": {
+    "id": "anthropic",
+    "models": {
+      "claude-fable-5": {
+        "id": "claude-fable-5",
+        "name": "Claude Fable 5",
+        "family": "claude-fable",
+        "release_date": "2026-06-07",
+        "cost": {"input": 5, "output": 25}
+      },
+      "claude-fable-5-1": {
+        "id": "claude-fable-5-1",
+        "name": "Claude Fable 5.1",
+        "family": "claude-fable",
+        "release_date": "2026-09",
+        "cost": {"input": 5, "output": 25}
+      },
+      "claude-opus-5": {
+        "id": "claude-opus-5",
+        "name": "Claude Opus 5 (latest)",
+        "family": "claude-opus",
+        "release_date": "2026-07-24",
+        "cost": {"input": 5, "output": 25}
+      },
+      "claude-opus-4-5": {
+        "id": "claude-opus-4-5",
+        "name": "Claude Opus 4.5 (latest)",
+        "family": "claude-opus",
+        "release_date": "2025-11-24",
+        "cost": {"input": 5, "output": 25}
+      },
+      "claude-opus-4-5-20251101": {
+        "id": "claude-opus-4-5-20251101",
+        "name": "Claude Opus 4.5",
+        "family": "claude-opus",
+        "release_date": "2025-11-24",
+        "cost": {"input": 5, "output": 25}
+      },
+      "claude-opus-4-8": {
+        "id": "claude-opus-4-8",
+        "name": "Claude Opus 4.8",
+        "family": "claude-opus",
+        "release_date": "2026-05-28",
+        "cost": {"input": 5, "output": 25}
+      },
+      "claude-sonnet-5": {
+        "id": "claude-sonnet-5",
+        "name": "Claude Sonnet 5",
+        "family": "claude-sonnet",
+        "release_date": "2026-06-29",
+        "cost": {"input": 2, "output": 10}
+      },
+      "claude-haiku-4-5": {
+        "id": "claude-haiku-4-5",
+        "name": "Claude Haiku 4.5 (latest)",
+        "family": "claude-haiku",
+        "release_date": "2025-10-15",
+        "cost": {"input": 1, "output": 5}
+      },
+      "claude-haiku-4-5-20251001": {
+        "id": "claude-haiku-4-5-20251001",
+        "name": "Claude Haiku 4.5",
+        "family": "claude-haiku",
+        "release_date": "2025-10-15",
+        "cost": {"input": 1, "output": 5}
+      },
+      "claude-haiku-5": {
+        "id": "claude-haiku-5",
+        "name": "Claude Haiku 5",
+        "family": "claude-haiku",
+        "release_date": "2026-08-01"
+      },
+      "claude-haiku-unpriced": {
+        "id": "claude-haiku-unpriced",
+        "name": "Claude Haiku Unpriced",
+        "family": "claude-haiku"
+      },
+      "claude-haiku-retired": {
+        "id": "claude-haiku-retired",
+        "name": "Claude Haiku Retired",
+        "family": "claude-haiku",
+        "status": "deprecated",
+        "cost": {"input": 1, "output": 5}
+      },
+      "claude-baseten-invalid": {
+        "id": "claude-baseten-invalid",
+        "name": "Invalid Gateway Alias",
+        "cost": {"input": 1, "output": 5}
+      }
+    }
+  },
+  "openai": {
+    "id": "openai",
+    "models": {
+      "gpt-test": {
+        "id": "gpt-test",
+        "name": "GPT Test",
+        "cost": {"input": 1, "output": 4}
+      }
+    }
+  },
+  "baseten": {
+    "id": "baseten",
+    "models": {
+      "example/Model": {
+        "id": "example/Model",
+        "name": "Example Model",
+        "cost": {"input": 1, "output": 4}
+      }
+    }
+  }
+}`
+
+func nativeFallbackCatalogSnapshot(t *testing.T) *pricing.Snapshot {
+	t.Helper()
+	catalog := pricing.New()
+	if err := catalog.ReplaceModelsDev(
+		[]byte(nativeFallbackCatalogFixture),
+		time.Date(2026, time.September, 3, 12, 0, 0, 0, time.UTC),
+		`"fallback-catalog"`,
+	); err != nil {
+		t.Fatal(err)
+	}
+	return catalog.Capture()
+}
 
 func TestBasetenModelFallbackStatusUsesNativeProviderReadiness(t *testing.T) {
 	rc := resolvedClientConfig{
@@ -16,21 +145,24 @@ func TestBasetenModelFallbackStatusUsesNativeProviderReadiness(t *testing.T) {
 	// Native fallback preserves harness authentication on each request, so
 	// process-level provider keys are not the readiness authority.
 	t.Setenv("ANTHROPIC_API_KEY", "")
-	status := basetenModelFallbackStatus(rc, false)
+	catalog := nativeFallbackCatalogSnapshot(t)
+	status := basetenModelFallbackStatus(rc, false, catalog)
 	if status["provider_ready"] != true || status["ready"] != true || status["reason"] != nil {
 		t.Fatalf("ready status=%#v", status)
 	}
+	if status["display_name"] != "Claude Opus 5" {
+		t.Fatalf("display_name=%q", status["display_name"])
+	}
 	if got := status["available_models"]; !reflect.DeepEqual(got, []map[string]any{
-		{"model": "claude-opus-5", "display_name": "Opus"},
-		{"model": "claude-fable-5", "display_name": "Fable"},
-		{"model": "claude-opus-4-8", "display_name": "Opus"},
-		{"model": "claude-sonnet-4-6", "display_name": "Sonnet"},
-		{"model": "claude-haiku-4-5", "display_name": "Haiku"},
+		{"model": "claude-fable-5-1", "display_name": "Claude Fable 5.1"},
+		{"model": "claude-opus-5", "display_name": "Claude Opus 5"},
+		{"model": "claude-sonnet-5", "display_name": "Claude Sonnet 5"},
+		{"model": "claude-haiku-5", "display_name": "Claude Haiku 5"},
 	}) {
 		t.Fatalf("available_models=%#v", got)
 	}
 	rc.FallbackRoute = ""
-	status = basetenModelFallbackStatus(rc, false)
+	status = basetenModelFallbackStatus(rc, false, catalog)
 	if status["provider_ready"] != false || status["ready"] != false || status["reason"] != "provider_auth_unavailable" {
 		t.Fatalf("unavailable status=%#v", status)
 	}
@@ -42,9 +174,15 @@ func TestNativeFallbackAvailableModelsIncludeValidCurrentTargetOnce(t *testing.T
 		FallbackRoute:       "anthropic",
 		NativeFallbackModel: "claude-sonnet-5",
 	}
-	models := nativeFallbackAvailableModels(rc)
-	if len(models) < 2 || models[0]["model"] != "claude-sonnet-5" {
-		t.Fatalf("available_models=%#v, want custom current target first and multiple choices", models)
+	catalog := nativeFallbackCatalogSnapshot(t)
+	models := nativeFallbackAvailableModels(rc, catalog)
+	if !reflect.DeepEqual(models, []map[string]any{
+		{"model": "claude-fable-5-1", "display_name": "Claude Fable 5.1"},
+		{"model": "claude-opus-5", "display_name": "Claude Opus 5"},
+		{"model": "claude-sonnet-5", "display_name": "Claude Sonnet 5"},
+		{"model": "claude-haiku-5", "display_name": "Claude Haiku 5"},
+	}) {
+		t.Fatalf("available_models=%#v", models)
 	}
 	seen := map[string]bool{}
 	for _, entry := range models {
@@ -59,9 +197,117 @@ func TestNativeFallbackAvailableModelsIncludeValidCurrentTargetOnce(t *testing.T
 	}
 
 	rc.NativeFallbackModel = "claude-baseten-invalid"
-	for _, entry := range nativeFallbackAvailableModels(rc) {
+	for _, entry := range nativeFallbackAvailableModels(rc, catalog) {
 		if entry["model"] == rc.NativeFallbackModel {
 			t.Fatalf("invalid current target leaked into available models")
+		}
+	}
+
+	rc.NativeFallbackModel = "claude-opus-5"
+	models = nativeFallbackAvailableModels(rc, catalog)
+	if len(models) != 4 || models[1]["model"] != "claude-opus-5" {
+		t.Fatalf("catalog current target was duplicated: %#v", models)
+	}
+}
+
+func TestNativeFallbackOptionsDoNotIncludeOlderCurrentModel(t *testing.T) {
+	rc := resolvedClientConfig{
+		ProtocolShape:       "anthropic",
+		NativeFallbackModel: "claude-opus-4-5-20251101",
+	}
+	models := nativeFallbackAvailableModels(rc, nativeFallbackCatalogSnapshot(t))
+	if !reflect.DeepEqual(models, []map[string]any{
+		{"model": "claude-fable-5-1", "display_name": "Claude Fable 5.1"},
+		{"model": "claude-opus-5", "display_name": "Claude Opus 5"},
+		{"model": "claude-sonnet-5", "display_name": "Claude Sonnet 5"},
+		{"model": "claude-haiku-5", "display_name": "Claude Haiku 5"},
+	}) {
+		t.Fatalf("available_models=%#v", models)
+	}
+}
+
+func TestNativeFallbackOptionsUseVersionForLegacyCacheWithoutReleaseDates(t *testing.T) {
+	fixture := nativeFallbackCatalogFixture
+	for _, releaseDate := range []string{
+		"2025-10-15",
+		"2025-11-24",
+		"2026-05-28",
+		"2026-06-07",
+		"2026-06-29",
+		"2026-07-24",
+		"2026-08-01",
+		"2026-09",
+	} {
+		fixture = strings.ReplaceAll(fixture, releaseDate, "")
+	}
+	catalog := pricing.New()
+	if err := catalog.ReplaceModelsDev(
+		[]byte(fixture), time.Now().UTC(), `"legacy-cache"`,
+	); err != nil {
+		t.Fatal(err)
+	}
+	models := nativeFallbackAvailableModels(
+		resolvedClientConfig{ProtocolShape: "anthropic"},
+		catalog.Capture(),
+	)
+	if !reflect.DeepEqual(models, []map[string]any{
+		{"model": "claude-fable-5-1", "display_name": "Claude Fable 5.1"},
+		{"model": "claude-opus-5", "display_name": "Claude Opus 5"},
+		{"model": "claude-sonnet-5", "display_name": "Claude Sonnet 5"},
+		{"model": "claude-haiku-5", "display_name": "Claude Haiku 5"},
+	}) {
+		t.Fatalf("available_models=%#v", models)
+	}
+}
+
+func TestNativeFallbackVersionSupportsCurrentAndLegacyIDOrders(t *testing.T) {
+	for _, test := range []struct {
+		model  string
+		family string
+		want   []uint64
+	}{
+		{"claude-fable-5-1", "fable", []uint64{5, 1}},
+		{"claude-haiku-4-5-20251001", "haiku", []uint64{4, 5}},
+		{"claude-3-7-sonnet-20250219", "sonnet", []uint64{3, 7}},
+		{"claude-opus-latest", "opus", nil},
+	} {
+		if got := nativeFallbackVersion(test.model, test.family); !reflect.DeepEqual(got, test.want) {
+			t.Errorf("nativeFallbackVersion(%q, %q)=%v, want %v", test.model, test.family, got, test.want)
+		}
+	}
+}
+
+func TestNativeFallbackReleaseDateComparisonSupportsMixedPrecision(t *testing.T) {
+	for _, test := range []struct {
+		left  string
+		right string
+		want  int
+	}{
+		{"2026-09", "2026-08-31", 1},
+		{"2026-09-01", "2026-09", 1},
+		{"2026-08-31", "2026-09", -1},
+		{"2026-09", "2026-09", 0},
+		{"", "2026-09", -1},
+		{"2026-09", "", 1},
+	} {
+		if got := compareNativeFallbackReleaseDates(test.left, test.right); got != test.want {
+			t.Errorf("compareNativeFallbackReleaseDates(%q, %q)=%d, want %d", test.left, test.right, got, test.want)
+		}
+	}
+}
+
+func TestNormalizeNativeFallbackDisplayNameRemovesOnlyExactTrailingSuffix(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		want string
+	}{
+		{"Claude Opus 5 (latest)", "Claude Opus 5"},
+		{"Claude (latest) Opus 5", "Claude (latest) Opus 5"},
+		{"Claude Opus 5 (Latest)", "Claude Opus 5 (Latest)"},
+		{"Claude Opus 5", "Claude Opus 5"},
+	} {
+		if got := normalizeNativeFallbackDisplayName(test.name); got != test.want {
+			t.Errorf("normalizeNativeFallbackDisplayName(%q)=%q, want %q", test.name, got, test.want)
 		}
 	}
 }
@@ -94,6 +340,13 @@ func TestAdminStatusProjectsResolvedFallbackPolicyAndClaudeTarget(t *testing.T) 
 	f.Global.FallbackPolicy = &config.FallbackPolicy{OnBaseten429: &policyOff}
 	g, stop := newGlobalRoutingGateway(t, f, baseten.URL, anthropic.URL)
 	defer stop()
+	if err := g.pricing.ReplaceModelsDev(
+		[]byte(nativeFallbackCatalogFixture),
+		time.Date(2026, time.September, 3, 12, 0, 0, 0, time.UTC),
+		`"fallback-catalog"`,
+	); err != nil {
+		t.Fatal(err)
+	}
 	status := adminStatusGet(t, g)
 	policy := status["fallback_policy"].(map[string]any)
 	if policy["on_baseten_429"] != false || policy["on_baseten_5xx"] != true {
@@ -103,7 +356,7 @@ func TestAdminStatusProjectsResolvedFallbackPolicyAndClaudeTarget(t *testing.T) 
 	projection := client["baseten_model_fallback"].(map[string]any)
 	if projection["configured_model"] != config.DefaultClaudeNativeFallbackModel ||
 		projection["resolved_model"] != config.DefaultClaudeNativeFallbackModel ||
-		projection["display_name"] != "Opus" || projection["provider_ready"] != true ||
+		projection["display_name"] != "Claude Opus 5" || projection["provider_ready"] != true ||
 		projection["ready"] != true || projection["reason"] != nil {
 		t.Fatalf("baseten_model_fallback=%#v", projection)
 	}

--- a/gateway/cmd/gateway/admin_fallback_policy_test.go
+++ b/gateway/cmd/gateway/admin_fallback_policy_test.go
@@ -1,0 +1,124 @@
+package gateway
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
+)
+
+func TestBasetenModelFallbackStatusUsesNativeProviderReadiness(t *testing.T) {
+	rc := resolvedClientConfig{
+		ProtocolShape: "anthropic", FallbackRoute: "anthropic",
+		NativeFallbackModel: config.DefaultClaudeNativeFallbackModel,
+	}
+	// Native fallback preserves harness authentication on each request, so
+	// process-level provider keys are not the readiness authority.
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	status := basetenModelFallbackStatus(rc, false)
+	if status["provider_ready"] != true || status["ready"] != true || status["reason"] != nil {
+		t.Fatalf("ready status=%#v", status)
+	}
+	if got := status["available_models"]; !reflect.DeepEqual(got, []map[string]any{
+		{"model": "claude-opus-5", "display_name": "Opus"},
+		{"model": "claude-fable-5", "display_name": "Fable"},
+		{"model": "claude-opus-4-8", "display_name": "Opus"},
+		{"model": "claude-sonnet-4-6", "display_name": "Sonnet"},
+		{"model": "claude-haiku-4-5", "display_name": "Haiku"},
+	}) {
+		t.Fatalf("available_models=%#v", got)
+	}
+	rc.FallbackRoute = ""
+	status = basetenModelFallbackStatus(rc, false)
+	if status["provider_ready"] != false || status["ready"] != false || status["reason"] != "provider_auth_unavailable" {
+		t.Fatalf("unavailable status=%#v", status)
+	}
+}
+
+func TestNativeFallbackAvailableModelsIncludeValidCurrentTargetOnce(t *testing.T) {
+	rc := resolvedClientConfig{
+		ProtocolShape:       "anthropic",
+		FallbackRoute:       "anthropic",
+		NativeFallbackModel: "claude-sonnet-5",
+	}
+	models := nativeFallbackAvailableModels(rc)
+	if len(models) < 2 || models[0]["model"] != "claude-sonnet-5" {
+		t.Fatalf("available_models=%#v, want custom current target first and multiple choices", models)
+	}
+	seen := map[string]bool{}
+	for _, entry := range models {
+		model := entry["model"].(string)
+		if seen[model] {
+			t.Fatalf("available_models contains duplicate %q: %#v", model, models)
+		}
+		seen[model] = true
+		if !config.IsProtocolNativeModel("anthropic", model) {
+			t.Fatalf("available model %q is not Anthropic-native", model)
+		}
+	}
+
+	rc.NativeFallbackModel = "claude-baseten-invalid"
+	for _, entry := range nativeFallbackAvailableModels(rc) {
+		if entry["model"] == rc.NativeFallbackModel {
+			t.Fatalf("invalid current target leaked into available models")
+		}
+	}
+}
+
+func TestFallbackAdminCooldownHonorsActivePolicy(t *testing.T) {
+	g := &Gateway{fallbackUntil: map[string]fallbackCooldownState{
+		"claude-code": {Until: time.Now().Add(time.Minute), Trigger: fallbackCooldownHTTP429},
+	}}
+	rc := resolvedClientConfig{
+		Name: "claude-code", FallbackRoute: "anthropic", HasFallbackPolicy: true,
+		FallbackPolicy: config.ResolvedFallbackPolicy{OnBaseten429: false, OnBaseten5xx: true},
+	}
+	if status := fallbackStatus(g, rc); status["active"] != false {
+		t.Fatalf("disabled 429 cooldown status=%#v", status)
+	}
+	g.fallbackUntil["claude-code"] = fallbackCooldownState{Until: time.Now().Add(time.Minute), Trigger: "transport_error"}
+	if status := fallbackStatus(g, rc); status["active"] != true {
+		t.Fatalf("unrelated cooldown status=%#v", status)
+	}
+}
+
+func TestAdminStatusProjectsResolvedFallbackPolicyAndClaudeTarget(t *testing.T) {
+	baseten := recordingStub(t, nil, "BASETEN")
+	defer baseten.Close()
+	anthropic := recordingStub(t, nil, "NATIVE")
+	defer anthropic.Close()
+	f := globalRoutingFile(true)
+	f.Clients[0].NativeFallbackModel = config.DefaultClaudeNativeFallbackModel
+	policyOff := false
+	f.Global.FallbackPolicy = &config.FallbackPolicy{OnBaseten429: &policyOff}
+	g, stop := newGlobalRoutingGateway(t, f, baseten.URL, anthropic.URL)
+	defer stop()
+	status := adminStatusGet(t, g)
+	policy := status["fallback_policy"].(map[string]any)
+	if policy["on_baseten_429"] != false || policy["on_baseten_5xx"] != true {
+		t.Fatalf("fallback_policy=%#v", policy)
+	}
+	client := status["clients"].([]any)[0].(map[string]any)
+	projection := client["baseten_model_fallback"].(map[string]any)
+	if projection["configured_model"] != config.DefaultClaudeNativeFallbackModel ||
+		projection["resolved_model"] != config.DefaultClaudeNativeFallbackModel ||
+		projection["display_name"] != "Opus" || projection["provider_ready"] != true ||
+		projection["ready"] != true || projection["reason"] != nil {
+		t.Fatalf("baseten_model_fallback=%#v", projection)
+	}
+	available := projection["available_models"].([]any)
+	if len(available) < 2 {
+		t.Fatalf("available_models=%#v, want multiple native choices", available)
+	}
+	for _, raw := range available {
+		entry := raw.(map[string]any)
+		model := entry["model"].(string)
+		if !config.IsProtocolNativeModel("anthropic", model) {
+			t.Fatalf("available model %q is not Anthropic-native", model)
+		}
+		if entry["display_name"] == "" {
+			t.Fatalf("available model %q has empty display name", model)
+		}
+	}
+}

--- a/gateway/cmd/gateway/admin_model_catalog.go
+++ b/gateway/cmd/gateway/admin_model_catalog.go
@@ -37,14 +37,21 @@ type modelCatalogResponse struct {
 	State           string              `json:"state"`
 	SignedOutReason string              `json:"signed_out_reason"`
 	Models          []modelCatalogModel `json:"models"`
+	ContextLimits   []modelContextLimit `json:"context_limits"`
 	FetchedAt       string              `json:"fetched_at"`
 	Error           string              `json:"error"`
 }
 
+type modelContextLimit struct {
+	Slug          string `json:"slug"`
+	ContextTokens int64  `json:"context_tokens"`
+}
+
 type modelCatalogModel struct {
-	Slug        string                 `json:"slug"`
-	DisplayName string                 `json:"display_name"`
-	Reasoning   *modelCatalogReasoning `json:"reasoning,omitempty"`
+	Slug          string                 `json:"slug"`
+	DisplayName   string                 `json:"display_name"`
+	ContextTokens int64                  `json:"context_tokens"`
+	Reasoning     *modelCatalogReasoning `json:"reasoning,omitempty"`
 }
 
 type modelCatalogReasoning struct {
@@ -62,6 +69,7 @@ func (g *Gateway) adminModelCatalog(w http.ResponseWriter, r *http.Request) {
 		g.reject(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
+	contextLimits := modelContextLimitsFromSnapshot(g.pricing.Capture())
 
 	// The live catalog belongs to the selected Baseten CLI profile. The
 	// environment fallback is intentionally excluded from this account view.
@@ -71,6 +79,7 @@ func (g *Gateway) adminModelCatalog(w http.ResponseWriter, r *http.Request) {
 			State:           "signed_out",
 			SignedOutReason: modelCatalogSignedOutReasonNotSignedIn,
 			Models:          []modelCatalogModel{},
+			ContextLimits:   contextLimits,
 		})
 		return
 	}
@@ -88,40 +97,59 @@ func (g *Gateway) adminModelCatalog(w http.ResponseWriter, r *http.Request) {
 				State:           "signed_out",
 				SignedOutReason: reason,
 				Models:          []modelCatalogModel{},
+				ContextLimits:   contextLimits,
 			})
 			return
 		}
 		if errors.Is(err, errModelCatalogForbidden) {
 			writeModelCatalogJSON(w, r.Method, modelCatalogResponse{
-				State:  "error",
-				Models: []modelCatalogModel{},
-				Error:  "The selected Baseten credential does not have access to the model catalog",
+				State:         "error",
+				Models:        []modelCatalogModel{},
+				ContextLimits: contextLimits,
+				Error:         "The selected Baseten credential does not have access to the model catalog",
 			})
 			return
 		}
 		writeModelCatalogJSON(w, r.Method, modelCatalogResponse{
-			State:  "error",
-			Models: []modelCatalogModel{},
-			Error:  modelCatalogPublicError(err),
+			State:         "error",
+			Models:        []modelCatalogModel{},
+			ContextLimits: contextLimits,
+			Error:         modelCatalogPublicError(err),
 		})
 		return
 	}
 	fetchedAt := modelCatalogNow().UTC()
 	if err := g.publishBasetenModelAPIAvailability(models, fetchedAt); err != nil {
 		writeModelCatalogJSON(w, r.Method, modelCatalogResponse{
-			State:  "error",
-			Models: []modelCatalogModel{},
-			Error:  modelCatalogPublicError(err),
+			State:         "error",
+			Models:        []modelCatalogModel{},
+			ContextLimits: contextLimits,
+			Error:         modelCatalogPublicError(err),
 		})
 		return
 	}
 	snapshot := g.pricing.Capture()
 	models = modelCatalogModelsFromSnapshot(snapshot, models)
 	writeModelCatalogJSON(w, r.Method, modelCatalogResponse{
-		State:     "ready",
-		Models:    models,
-		FetchedAt: fetchedAt.Format(time.RFC3339),
+		State:         "ready",
+		Models:        models,
+		ContextLimits: modelContextLimitsFromSnapshot(snapshot),
+		FetchedAt:     fetchedAt.Format(time.RFC3339),
 	})
+}
+
+func modelContextLimitsFromSnapshot(
+	snapshot *pricing.Snapshot,
+) []modelContextLimit {
+	records := snapshot.Models(pricing.ProviderBaseten)
+	limits := make([]modelContextLimit, 0, len(records))
+	for _, record := range records {
+		limits = append(limits, modelContextLimit{
+			Slug:          record.CanonicalModelID,
+			ContextTokens: record.ContextTokens,
+		})
+	}
+	return limits
 }
 
 func (g *Gateway) publishBasetenModelAPIAvailability(
@@ -174,9 +202,17 @@ func modelCatalogModelsFromSnapshot(
 	resolved := make([]modelCatalogModel, len(models))
 	now := modelCatalogNow().UTC()
 	for i, model := range models {
+		var contextTokens int64
+		if record, ok := snapshot.Model(
+			pricing.ProviderBaseten,
+			model.Slug,
+		); ok {
+			contextTokens = record.ContextTokens
+		}
 		resolved[i] = modelCatalogModel{
-			Slug:        model.Slug,
-			DisplayName: basetenModelDisplayName(snapshot, model.Slug),
+			Slug:          model.Slug,
+			DisplayName:   basetenModelDisplayName(snapshot, model.Slug),
+			ContextTokens: contextTokens,
 			Reasoning: modelCatalogReasoningFromSnapshot(
 				snapshot,
 				model.Slug,

--- a/gateway/cmd/gateway/admin_model_catalog_test.go
+++ b/gateway/cmd/gateway/admin_model_catalog_test.go
@@ -387,6 +387,10 @@ func TestModelCatalogReasoningProjectionUsesExactBasetenRecord(t *testing.T) {
 		t.Fatalf("projected models = %+v", projected)
 	}
 	reasoning := projected[0].Reasoning
+	if projected[0].ContextTokens != 1_048_576 {
+		t.Fatalf("exact context tokens = %d, want 1048576",
+			projected[0].ContextTokens)
+	}
 	if reasoning == nil || !reasoning.Supported ||
 		len(reasoning.Options) != 1 ||
 		reasoning.Options[0].Type != pricing.ReasoningToggle ||
@@ -397,9 +401,8 @@ func TestModelCatalogReasoningProjectionUsesExactBasetenRecord(t *testing.T) {
 		reasoning.Stale {
 		t.Fatalf("live reasoning projection = %+v", reasoning)
 	}
-	if projected[1].Reasoning != nil {
-		t.Fatalf("missing model reasoning = %+v",
-			projected[1].Reasoning)
+	if projected[1].Reasoning != nil || projected[1].ContextTokens != 0 {
+		t.Fatalf("missing model projection = %+v", projected[1])
 	}
 
 	freshAvailabilityAt := capturedAt.Add(72 * time.Hour)
@@ -443,6 +446,41 @@ func TestModelCatalogReasoningProjectionUsesExactBasetenRecord(t *testing.T) {
 	if stale == nil || !stale.Stale ||
 		stale.LoadedFrom != string(pricing.LoadedFromRuntimeCache) {
 		t.Fatalf("stale cache projection = %+v", stale)
+	}
+}
+
+func TestModelContextLimitsIncludeExactModelsAbsentFromLiveAccountCatalog(t *testing.T) {
+	p := pricing.New()
+	capturedAt := time.Date(2026, time.September, 3, 0, 0, 0, 0, time.UTC)
+	if err := p.ReplaceModelsDev(
+		[]byte(publicCatalogGatewayFixture),
+		capturedAt,
+		`"catalog-context-limits"`,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.ReplaceProviderAvailability(
+		pricing.ProviderBaseten,
+		[]pricing.AvailabilityModel{{
+			CanonicalModelID: "other-org/Live-Only",
+			DisplayName:      "Live Only",
+		}},
+		basetenModelAPIsAvailabilitySource,
+		capturedAt.Add(time.Minute),
+		"sha256:live-only",
+	); err != nil {
+		t.Fatal(err)
+	}
+	limits := modelContextLimitsFromSnapshot(p.Capture())
+	var found *modelContextLimit
+	for i := range limits {
+		if limits[i].Slug == "zai-org/GLM-Test" {
+			found = &limits[i]
+			break
+		}
+	}
+	if found == nil || found.ContextTokens != 1_048_576 {
+		t.Fatalf("exact context limits = %+v, want absent-live GLM-Test at 1048576", limits)
 	}
 }
 

--- a/gateway/cmd/gateway/admin_model_picker_test.go
+++ b/gateway/cmd/gateway/admin_model_picker_test.go
@@ -3,8 +3,10 @@ package gateway
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/pricing"
 )
 
 func TestModelPickerAdminStatusPreservesConfiguredOrder(t *testing.T) {
@@ -71,5 +73,44 @@ func TestModelPickerAdminStatusPreservesConfiguredOrder(t *testing.T) {
 		second["label"] != "GLM 5.2 via Baseten" ||
 		second["description"] != "Served by Baseten." {
 		t.Errorf("second picker row = %v", second)
+	}
+}
+
+func TestModelPickerAdminStatusProjectsExactBasetenContextTokens(t *testing.T) {
+	catalog := pricing.New()
+	if err := catalog.ReplaceModelsDev([]byte(`{
+		"anthropic":{"models":{"claude-test":{"id":"claude-test","name":"Claude Test","limit":{"context":200000,"output":1}}}},
+		"openai":{"models":{"gpt-test":{"id":"gpt-test","name":"GPT Test","limit":{"context":200000,"output":1}}}},
+		"baseten":{"models":{
+			"org/one-million":{"id":"org/one-million","name":"One Million","limit":{"context":1048576,"output":1}},
+			"org/two-hundred-thousand":{"id":"org/two-hundred-thousand","name":"Two Hundred Thousand","limit":{"context":200000,"output":1}}
+		}}
+	}`), time.Date(2026, time.September, 3, 0, 0, 0, 0, time.UTC), ""); err != nil {
+		t.Fatal(err)
+	}
+	client := config.Client{
+		ModelAliases: map[string]string{
+			"claude-baseten-million":  "org/one-million",
+			"claude-baseten-standard": "org/two-hundred-thousand",
+			"claude-baseten-unknown":  "org/not-in-models-dev",
+		},
+		ModelPicker: &config.ModelPicker{
+			Enabled: true,
+			Models: []config.ModelPickerModel{
+				{Alias: "claude-baseten-million"},
+				{Alias: "claude-baseten-standard"},
+				{Alias: "claude-baseten-unknown"},
+			},
+		},
+	}
+	status := computeModelPickerStatus(client, catalog.Capture())
+	if got := status.Models[0].ContextTokens; got != 1_048_576 {
+		t.Fatalf("one-million context_tokens = %d", got)
+	}
+	if got := status.Models[1].ContextTokens; got != 200_000 {
+		t.Fatalf("standard context_tokens = %d", got)
+	}
+	if got := status.Models[2].ContextTokens; got != 0 {
+		t.Fatalf("unknown context_tokens = %d, want 0", got)
 	}
 }

--- a/gateway/cmd/gateway/admin_model_picker_test.go
+++ b/gateway/cmd/gateway/admin_model_picker_test.go
@@ -1,0 +1,75 @@
+package gateway
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
+)
+
+func TestModelPickerAdminStatusPreservesConfiguredOrder(t *testing.T) {
+	basSrv := recordingStub(t, nil, "B")
+	defer basSrv.Close()
+	cfg := testConfig(t, basSrv.URL, basSrv.URL)
+	cfg.ConfigPath = filepath.Join(t.TempDir(), "gateway.yaml")
+	rc := modelRoutesClient(t, "baseten", nil)
+	writeModelRoutesYAML(t, cfg.ConfigPath, rc)
+	file, err := config.Load(cfg.ConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file.Clients[0].ModelPicker = &config.ModelPicker{
+		Enabled: true,
+		Models: []config.ModelPickerModel{
+			{
+				Alias: "claude-baseten-nemotron",
+			},
+			{
+				Alias: "claude-baseten-glm-5-2",
+			},
+		},
+	}
+	if err := config.Save(cfg.ConfigPath, file); err != nil {
+		t.Fatal(err)
+	}
+	cfgForLoad := cfg
+	loadedSnapshot, err := loadResolvedConfigSnapshot(&cfgForLoad)
+	if err != nil {
+		t.Fatalf("load config snapshot: %v", err)
+	}
+	g, adminL, _ := newGateway(t, cfg, loadedSnapshot.clients...)
+	defer adminL.Close()
+	stop := start(t, g)
+	defer stop()
+
+	status := adminStatusGet(t, g)
+	clients := status["clients"].([]any)
+	if len(clients) != 1 {
+		t.Fatalf("clients = %v, want one", clients)
+	}
+	picker, ok := clients[0].(map[string]any)["model_picker"].(map[string]any)
+	if !ok {
+		t.Fatalf("model_picker = %v, want object", clients[0].(map[string]any)["model_picker"])
+	}
+	if picker["enabled"] != true {
+		t.Errorf("model_picker.enabled = %v, want true", picker["enabled"])
+	}
+	models, ok := picker["models"].([]any)
+	if !ok || len(models) != 2 {
+		t.Fatalf("model_picker.models = %v, want two rows", picker["models"])
+	}
+	first := models[0].(map[string]any)
+	if first["alias"] != "claude-baseten-nemotron" ||
+		first["slug"] != "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B" ||
+		first["label"] != "NVIDIA Nemotron 3 Ultra 550B A55B via Baseten" ||
+		first["description"] != "Served by Baseten." {
+		t.Errorf("first picker row = %v", first)
+	}
+	second := models[1].(map[string]any)
+	if second["alias"] != "claude-baseten-glm-5-2" ||
+		second["slug"] != "zai-org/GLM-5.2" ||
+		second["label"] != "GLM 5.2 via Baseten" ||
+		second["description"] != "Served by Baseten." {
+		t.Errorf("second picker row = %v", second)
+	}
+}

--- a/gateway/cmd/gateway/admin_stats.go
+++ b/gateway/cmd/gateway/admin_stats.go
@@ -148,7 +148,7 @@ func (g *Gateway) adminStats(w http.ResponseWriter, r *http.Request) {
 
 	fallback := map[string]bool{}
 	for _, cl := range g.snapshotClients() {
-		fallback[cl.cfg.Name] = g.fallbackActive(cl.cfg.Name)
+		_, fallback[cl.cfg.Name] = g.policyAwareFallbackCooldown(cl.cfg)
 	}
 
 	tail := rows

--- a/gateway/cmd/gateway/fallback_policy_runtime_test.go
+++ b/gateway/cmd/gateway/fallback_policy_runtime_test.go
@@ -1,0 +1,600 @@
+package gateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/pricing"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/reasoning"
+)
+
+func TestFallbackStatusPolicyBoundaries(t *testing.T) {
+	policy := config.ResolvedFallbackPolicy{OnBaseten429: true, OnBaseten5xx: true}
+	for _, tc := range []struct {
+		status int
+		mask   fallbackTriggerMask
+		on     bool
+	}{
+		{http.StatusTooManyRequests, fallbackAllowHTTP429, true},
+		{499, 0, false},
+		{500, fallbackAllowHTTP5xx, true},
+		{599, fallbackAllowHTTP5xx, true},
+		{600, 0, false},
+	} {
+		if got := fallbackStatusMask(tc.status); got != tc.mask {
+			t.Errorf("status %d mask = %d, want %d", tc.status, got, tc.mask)
+		}
+		if got := statusFallbackEnabled(policy, tc.status); got != tc.on {
+			t.Errorf("status %d enabled = %t, want %t", tc.status, got, tc.on)
+		}
+	}
+	policy.OnBaseten429 = false
+	if statusFallbackEnabled(policy, http.StatusTooManyRequests) {
+		t.Fatal("429 remained enabled after its independent policy was disabled")
+	}
+	if !statusFallbackEnabled(policy, http.StatusInternalServerError) {
+		t.Fatal("disabling 429 changed the independent 5xx policy")
+	}
+	deadline := time.Now().Add(time.Minute)
+	if cooldownEligible(policy, fallbackAllowStatus, fallbackCooldownState{
+		Until: deadline, Trigger: fallbackCooldownHTTP429,
+	}) {
+		t.Fatal("disabled 429 policy still honored a 429-origin cooldown")
+	}
+	if !cooldownEligible(policy, fallbackAllowStatus, fallbackCooldownState{
+		Until: deadline, Trigger: fallbackCooldownHTTP5xx,
+	}) {
+		t.Fatal("disabling 429 invalidated an unrelated 5xx-origin cooldown")
+	}
+	if cooldownEligible(policy, fallbackAllowStatus, fallbackCooldownState{
+		Until: deadline, Trigger: "transport_error",
+	}) {
+		t.Fatal("status-only candidate honored a transport-origin cooldown")
+	}
+}
+
+func TestNativeOriginStatusPolicyMatrix(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		status     int
+		policy     config.ResolvedFallbackPolicy
+		fallback   bool
+		suppressed string
+	}{
+		{
+			name:     "429_on",
+			status:   http.StatusTooManyRequests,
+			policy:   config.ResolvedFallbackPolicy{OnBaseten429: true, OnBaseten5xx: false},
+			fallback: true,
+		},
+		{
+			name:       "429_off",
+			status:     http.StatusTooManyRequests,
+			policy:     config.ResolvedFallbackPolicy{OnBaseten429: false, OnBaseten5xx: true},
+			suppressed: "policy_disabled_http_429",
+		},
+		{
+			name:     "503_on",
+			status:   http.StatusServiceUnavailable,
+			policy:   config.ResolvedFallbackPolicy{OnBaseten429: false, OnBaseten5xx: true},
+			fallback: true,
+		},
+		{
+			name:       "503_off",
+			status:     http.StatusServiceUnavailable,
+			policy:     config.ResolvedFallbackPolicy{OnBaseten429: true, OnBaseten5xx: false},
+			suppressed: "policy_disabled_http_5xx",
+		},
+		{
+			name:   "499_is_not_429",
+			status: 499,
+			policy: config.ResolvedFallbackPolicy{OnBaseten429: true, OnBaseten5xx: true},
+		},
+		{
+			name:   "600_is_not_5xx",
+			status: 600,
+			policy: config.ResolvedFallbackPolicy{OnBaseten429: true, OnBaseten5xx: true},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Retry-After", "7")
+				w.WriteHeader(tc.status)
+				_, _ = io.WriteString(w, `{"type":"error","error":{"message":"primary"}}`)
+			}))
+			defer primary.Close()
+			var fallbackHits atomic.Int32
+			fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				fallbackHits.Add(1)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"id":"msg_native","type":"message","role":"assistant","content":[],"model":"claude-sonnet-5","usage":{"input_tokens":1,"output_tokens":1}}`)
+			}))
+			defer fallback.Close()
+
+			cfg := testConfig(t, primary.URL, fallback.URL)
+			rc := resolvedAnthropicBaseten(t)
+			rc.FallbackRoute = "anthropic"
+			rc.HasFallbackPolicy = true
+			rc.FallbackPolicy = tc.policy
+			g, adminL, _ := newGateway(t, cfg, rc)
+			defer adminL.Close()
+			stop := start(t, g)
+			defer stop()
+
+			resp, body := postMessages(t, g, "claude-sonnet-5")
+			if tc.fallback {
+				if resp.StatusCode != http.StatusOK || fallbackHits.Load() != 1 {
+					t.Fatalf("status/hits = %d/%d, body=%s, want 200/1", resp.StatusCode, fallbackHits.Load(), body)
+				}
+				if !g.fallbackActive("claude-code") {
+					t.Fatal("eligible status did not create a cooldown")
+				}
+			} else {
+				if resp.StatusCode != tc.status || fallbackHits.Load() != 0 {
+					t.Fatalf("status/hits = %d/%d, body=%s, want %d/0", resp.StatusCode, fallbackHits.Load(), body, tc.status)
+				}
+				if g.fallbackActive("claude-code") {
+					t.Fatal("terminal status created a cooldown")
+				}
+				if tc.status == http.StatusTooManyRequests && resp.Header.Get("Retry-After") != "7" {
+					t.Fatalf("Retry-After = %q, want 7", resp.Header.Get("Retry-After"))
+				}
+			}
+			row := waitForRows(t, cfg.TelemetryDir, 1, 2*time.Second)[0]
+			if got := valueOrZero(row.Fallback.SuppressedReason); got != tc.suppressed {
+				t.Fatalf("suppressed_reason = %q, want %q", got, tc.suppressed)
+			}
+			if row.Fallback.Attempted != tc.fallback {
+				t.Fatalf("fallback attempted = %t, want %t", row.Fallback.Attempted, tc.fallback)
+			}
+		})
+	}
+}
+
+func TestNativeOrigin429ReplaysExactIngressRequest(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer primary.Close()
+	nativeBody := make(chan []byte, 1)
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		nativeBody <- body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"msg_native","type":"message","role":"assistant","content":[],"model":"claude-sonnet-5","usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	defer fallback.Close()
+
+	cfg := testConfig(t, primary.URL, fallback.URL)
+	rc := resolvedAnthropicBaseten(t)
+	rc.FallbackRoute = "anthropic"
+	rc.NativeFallbackModel = config.DefaultClaudeNativeFallbackModel
+	g, adminL, _ := newGateway(t, cfg, rc)
+	defer adminL.Close()
+	stop := start(t, g)
+	defer stop()
+
+	ingress := []byte(`{ "model": "claude-sonnet-5", "stream": false, "messages": [{"role":"user","content":"ping"}] }`)
+	resp, body := postMessagesRaw(t, g, ingress, "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	select {
+	case got := <-nativeBody:
+		if !bytes.Equal(got, ingress) {
+			t.Fatalf("native fallback changed ingress bytes:\n got: %s\nwant: %s", got, ingress)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("native fallback request was not observed")
+	}
+	row := waitForRows(t, cfg.TelemetryDir, 1, 2*time.Second)[0]
+	if !row.Fallback.Attempted || valueOrZero(row.Fallback.Trigger) != "http_429" ||
+		valueOrZero(row.Fallback.ModelSource) != fallbackModelSourceOriginal {
+		t.Fatalf("fallback telemetry = %+v", row.Fallback)
+	}
+	if row.RequestedModel != "claude-sonnet-5" || row.ServedModel != "claude-sonnet-5" {
+		t.Fatalf("requested/served = %q/%q, want original Sonnet model", row.RequestedModel, row.ServedModel)
+	}
+}
+
+func TestNativeOrigin429ReplaysDecoratedIngressRequestExactly(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer primary.Close()
+	nativeBody := make(chan []byte, 1)
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		nativeBody <- body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"msg_native","type":"message","role":"assistant","content":[],"model":"claude-sonnet-5[1m]","usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	defer fallback.Close()
+
+	cfg := testConfig(t, primary.URL, fallback.URL)
+	rc := resolvedAnthropicBaseten(t)
+	rc.FallbackRoute = "anthropic"
+	rc.NativeFallbackModel = config.DefaultClaudeNativeFallbackModel
+	g, adminL, _ := newGateway(t, cfg, rc)
+	defer adminL.Close()
+	stop := start(t, g)
+	defer stop()
+
+	ingress := []byte(`{ "model": "claude-sonnet-5[1m]", "stream": false, "messages": [{"role":"user","content":"ping"}] }`)
+	resp, body := postMessagesRaw(t, g, ingress, "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	select {
+	case got := <-nativeBody:
+		if !bytes.Equal(got, ingress) {
+			t.Fatalf("decorated native fallback changed ingress bytes:\n got: %s\nwant: %s", got, ingress)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("decorated native fallback request was not observed")
+	}
+	row := waitForRows(t, cfg.TelemetryDir, 1, 2*time.Second)[0]
+	if !row.Fallback.Attempted ||
+		valueOrZero(row.Fallback.Trigger) != "http_429" ||
+		valueOrZero(row.Fallback.ModelSource) != fallbackModelSourceOriginal {
+		t.Fatalf("fallback telemetry = %+v", row.Fallback)
+	}
+	if row.RequestedModel != "claude-sonnet-5" ||
+		row.ServedModel != "claude-sonnet-5[1m]" {
+		t.Fatalf("requested/served = %q/%q, want canonical ingress attribution and exact decorated fallback model", row.RequestedModel, row.ServedModel)
+	}
+}
+
+func TestClaudeAlias599UsesConfiguredNativeTarget(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(599)
+	}))
+	defer primary.Close()
+	nativeBody := make(chan []byte, 1)
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		nativeBody <- body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"msg_native","type":"message","role":"assistant","content":[],"model":"claude-opus-5","usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	defer fallback.Close()
+
+	cfg := testConfig(t, primary.URL, fallback.URL)
+	rc := aliasedClient(t, "baseten")
+	rc.FallbackRoute = "anthropic"
+	rc.NativeFallbackModel = config.DefaultClaudeNativeFallbackModel
+	g, adminL, _ := newGateway(t, cfg, rc)
+	defer adminL.Close()
+	stop := start(t, g)
+	defer stop()
+
+	ingress := []byte(`{"model":"claude-baseten-glm-5-2","stream":false,"messages":[{"role":"user","content":"ping"}]}`)
+	resp, body := postMessagesRaw(t, g, ingress, "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	got := <-nativeBody
+	var before, after map[string]any
+	if err := json.Unmarshal(ingress, &before); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(got, &after); err != nil {
+		t.Fatal(err)
+	}
+	if after["model"] != config.DefaultClaudeNativeFallbackModel {
+		t.Fatalf("native model = %#v, want %q", after["model"], config.DefaultClaudeNativeFallbackModel)
+	}
+	delete(before, "model")
+	delete(after, "model")
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("fallback changed fields other than model: got %#v want %#v", after, before)
+	}
+	row := waitForRows(t, cfg.TelemetryDir, 1, 2*time.Second)[0]
+	if valueOrZero(row.Fallback.Trigger) != "http_599" ||
+		valueOrZero(row.Fallback.ModelSource) != fallbackModelSourceConfigured ||
+		row.RequestedModel != "claude-baseten-glm-5-2" ||
+		row.ServedModel != config.DefaultClaudeNativeFallbackModel {
+		t.Fatalf("alias fallback telemetry = %+v", row)
+	}
+}
+
+func TestClaudeAliasEnabledPolicyReportsMissingNativeTarget(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer primary.Close()
+	var fallbackHits atomic.Int32
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fallbackHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer fallback.Close()
+
+	cfg := testConfig(t, primary.URL, fallback.URL)
+	rc := aliasedClient(t, "baseten")
+	rc.FallbackRoute = "anthropic"
+	g, adminL, _ := newGateway(t, cfg, rc)
+	defer adminL.Close()
+	stop := start(t, g)
+	defer stop()
+
+	resp, _ := postMessages(t, g, "claude-baseten-glm-5-2")
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want terminal 429", resp.StatusCode)
+	}
+	if got := fallbackHits.Load(); got != 0 {
+		t.Fatalf("native fallback hits = %d, want 0", got)
+	}
+	row := waitForRows(t, cfg.TelemetryDir, 1, 2*time.Second)[0]
+	if row.Fallback.Attempted || row.Fallback.Trigger != nil ||
+		valueOrZero(row.Fallback.SuppressedReason) != "native_target_unconfigured" {
+		t.Fatalf("fallback telemetry = %+v", row.Fallback)
+	}
+}
+
+func TestClaudeAliasTransportFailureRemainsTerminal(t *testing.T) {
+	closed := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	primaryURL := closed.URL
+	closed.Close()
+	var fallbackHits atomic.Int32
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fallbackHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer fallback.Close()
+
+	cfg := testConfig(t, primaryURL, fallback.URL)
+	rc := aliasedClient(t, "baseten")
+	rc.FallbackRoute = "anthropic"
+	rc.NativeFallbackModel = config.DefaultClaudeNativeFallbackModel
+	g, adminL, _ := newGateway(t, cfg, rc)
+	defer adminL.Close()
+	stop := start(t, g)
+	defer stop()
+
+	resp, _ := postMessages(t, g, "claude-baseten-glm-5-2")
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want terminal 502", resp.StatusCode)
+	}
+	if got := fallbackHits.Load(); got != 0 {
+		t.Fatalf("native fallback hits = %d, want 0", got)
+	}
+	if g.fallbackActive("claude-code") {
+		t.Fatal("status-only alias candidate created transport cooldown")
+	}
+	row := waitForRows(t, cfg.TelemetryDir, 1, 2*time.Second)[0]
+	if row.Fallback.Attempted || row.Fallback.Trigger != nil ||
+		row.Fallback.SuppressedReason != nil || row.Fallback.ModelSource != nil {
+		t.Fatalf("fallback telemetry = %+v, want terminal transport failure", row.Fallback)
+	}
+}
+
+func TestClaudeAliasAndRawSlugAuthUnavailableRemainTerminal(t *testing.T) {
+	for _, model := range []string{
+		"claude-baseten-glm-5-2",
+		"zai-org/GLM-5.2",
+	} {
+		t.Run(model, func(t *testing.T) {
+			cfg := testConfig(t, "http://baseten.invalid", "http://anthropic.invalid")
+			cfg.BasetenKey = ""
+			cfg.APIKeyFallback = false
+			g := &Gateway{
+				cfg:     cfg,
+				pricing: pricing.New(),
+				client:  &http.Client{Transport: defaultTransport()},
+			}
+			rc := aliasedClient(t, "baseten")
+			rc.FallbackRoute = "anthropic"
+			rc.NativeFallbackModel = config.DefaultClaudeNativeFallbackModel
+			attempts, err := g.resolveAttempts(
+				&clientListener{cfg: rc},
+				httptest.NewRequest(http.MethodPost, "/v1/messages", nil),
+				[]byte(`{"model":"`+model+`","messages":[{"role":"user","content":"ping"}]}`),
+				"messages",
+			)
+			if !errors.Is(err, errNeedsLogin) {
+				t.Fatalf("error = %v, want errNeedsLogin", err)
+			}
+			if len(attempts) != 0 {
+				t.Fatalf("attempts = %d, want terminal preflight failure", len(attempts))
+			}
+		})
+	}
+}
+
+func TestClaudeAliasAndRawSlugImageTranslationFailureRemainsTerminal(t *testing.T) {
+	for _, model := range []string{
+		"claude-baseten-glm-5-2",
+		"zai-org/GLM-5.2",
+	} {
+		t.Run(model, func(t *testing.T) {
+			cfg := testConfig(t, "http://baseten.invalid", "http://anthropic.invalid")
+			g := &Gateway{
+				cfg:     cfg,
+				pricing: pricing.New(),
+				client:  &http.Client{Transport: defaultTransport()},
+			}
+			rc := aliasedClient(t, "baseten")
+			rc.UpstreamShape = "openai"
+			rc.FallbackRoute = "anthropic"
+			rc.NativeFallbackModel = config.DefaultClaudeNativeFallbackModel
+			// Leave reasoning unconfigured so the unknown catalog capability is
+			// internal passthrough and request translation reaches the image gate.
+			rc.ModelOptions = nil
+			attempts, err := g.resolveAttempts(
+				&clientListener{cfg: rc},
+				httptest.NewRequest(http.MethodPost, "/v1/messages", nil),
+				[]byte(`{"model":"`+model+`","messages":[{"role":"user","content":[{"type":"image","source":{"type":"base64"}}]}]}`),
+				"messages",
+			)
+			if !allowsImageTranslationFallback(err) {
+				t.Fatalf("error = %v, want image translation failure", err)
+			}
+			if len(attempts) != 0 {
+				t.Fatalf("attempts = %d, want terminal preflight failure", len(attempts))
+			}
+		})
+	}
+}
+
+func TestClaudeAliasAndRawSlugReasoningFailureRemainsTerminal(t *testing.T) {
+	for _, model := range []string{
+		"claude-baseten-glm-5-2",
+		"zai-org/GLM-5.2",
+	} {
+		t.Run(model, func(t *testing.T) {
+			cfg := testConfig(t, "http://baseten.invalid", "http://anthropic.invalid")
+			g := &Gateway{
+				cfg:     cfg,
+				pricing: pricing.New(),
+				client:  &http.Client{Transport: defaultTransport()},
+			}
+			rc := aliasedClient(t, "baseten")
+			rc.FallbackRoute = "anthropic"
+			rc.NativeFallbackModel = config.DefaultClaudeNativeFallbackModel
+			rc.ModelOptions = config.ModelOptions{
+				pricing.ProviderBaseten: {
+					"zai-org/GLM-5.2": {
+						Reasoning: &config.ReasoningPolicy{
+							Mode:   config.ReasoningFixed,
+							Effort: "high",
+						},
+					},
+				},
+			}
+			attempts, err := g.resolveAttempts(
+				&clientListener{cfg: rc},
+				httptest.NewRequest(http.MethodPost, "/v1/messages", nil),
+				[]byte(`{"model":"`+model+`","messages":[{"role":"user","content":"ping"}]}`),
+				"messages",
+			)
+			if !reasoning.AllowsFallback(err) {
+				t.Fatalf("error = %v, want fallback-eligible reasoning policy error", err)
+			}
+			if len(attempts) != 0 {
+				t.Fatalf("attempts = %d, want terminal preflight failure", len(attempts))
+			}
+		})
+	}
+}
+
+func TestStatusCooldownResolvesEachIngressIdentity(t *testing.T) {
+	var primaryHits atomic.Int32
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		primaryHits.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer primary.Close()
+	models := make(chan string, 3)
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		models <- proxyModel(t, body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"msg_native","type":"message","role":"assistant","content":[],"model":"claude-opus-5","usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	defer fallback.Close()
+
+	cfg := testConfig(t, primary.URL, fallback.URL)
+	rc := aliasedClient(t, "baseten")
+	rc.FallbackRoute = "anthropic"
+	rc.NativeFallbackModel = config.DefaultClaudeNativeFallbackModel
+	g, adminL, _ := newGateway(t, cfg, rc)
+	defer adminL.Close()
+	stop := start(t, g)
+	defer stop()
+
+	for _, model := range []string{
+		"claude-baseten-glm-5-2",
+		"claude-sonnet-5",
+		"anthropic-baseten-kimi",
+	} {
+		resp, body := postMessages(t, g, model)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("model %q status = %d, body = %s", model, resp.StatusCode, body)
+		}
+	}
+	if got := primaryHits.Load(); got != 1 {
+		t.Fatalf("primary hits = %d, want 1 before status cooldown", got)
+	}
+	want := []string{config.DefaultClaudeNativeFallbackModel, "claude-sonnet-5", config.DefaultClaudeNativeFallbackModel}
+	for i, expected := range want {
+		select {
+		case got := <-models:
+			if got != expected {
+				t.Fatalf("native model %d = %q, want %q", i, got, expected)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("native request %d not observed", i)
+		}
+	}
+	rows := waitForRows(t, cfg.TelemetryDir, 3, 2*time.Second)
+	wantSources := []string{fallbackModelSourceConfigured, fallbackModelSourceOriginal, fallbackModelSourceConfigured}
+	for i, source := range wantSources {
+		if got := valueOrZero(rows[i].Fallback.ModelSource); got != source {
+			t.Fatalf("row %d model_source = %q, want %q", i, got, source)
+		}
+	}
+}
+
+func TestSubagentBasetenIngressUsesConfiguredTarget(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer primary.Close()
+	nativeModels := make(chan string, 1)
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		nativeModels <- proxyModel(t, body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"msg_native","type":"message","role":"assistant","content":[],"model":"claude-opus-5","usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	defer fallback.Close()
+
+	cfg := testConfig(t, primary.URL, fallback.URL)
+	rc := subagentClient(t, "baseten", "claude-baseten-glm-5-2", "on")
+	rc.FallbackRoute = "anthropic"
+	rc.NativeFallbackModel = config.DefaultClaudeNativeFallbackModel
+	g, adminL, _ := newGateway(t, cfg, rc)
+	defer adminL.Close()
+	stop := start(t, g)
+	defer stop()
+
+	resp, body := postMessagesWithAgent(t, g, "anthropic-baseten-kimi", "agent-1")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	select {
+	case got := <-nativeModels:
+		if got != config.DefaultClaudeNativeFallbackModel {
+			t.Fatalf("native model = %q, want configured target", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("native fallback request not observed")
+	}
+	row := waitForRows(t, cfg.TelemetryDir, 1, 2*time.Second)[0]
+	if row.RequestedModel != "anthropic-baseten-kimi" ||
+		valueOrZero(row.SubagentModel) != "claude-baseten-glm-5-2" ||
+		valueOrZero(row.Fallback.ModelSource) != fallbackModelSourceConfigured {
+		t.Fatalf("subagent fallback telemetry = %+v", row)
+	}
+}
+
+func proxyModel(t *testing.T, body []byte) string {
+	t.Helper()
+	var envelope struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("decode upstream body: %v: %s", err, body)
+	}
+	return envelope.Model
+}

--- a/gateway/cmd/gateway/gateway.go
+++ b/gateway/cmd/gateway/gateway.go
@@ -187,7 +187,15 @@ type resolvedClientConfig struct {
 	ModelOptions    config.ModelOptions
 	SanitizeHistory bool
 	FallbackRoute   string // "" = no fallback
-	UpstreamShape   string // baseten route only; "" = listener shape
+	// FallbackPolicy is the resolved global status policy captured in this
+	// immutable listener generation. Missing config values resolve On.
+	FallbackPolicy    config.ResolvedFallbackPolicy
+	HasFallbackPolicy bool
+	// NativeFallbackModel is the client-level native target used only when an
+	// Anthropic-shape request enters with a configured alias or raw Baseten
+	// slug. Native-origin requests always preserve their ingress model.
+	NativeFallbackModel string
+	UpstreamShape       string // baseten route only; "" = listener shape
 	// ResponsesStripToolTypes lists tools[] entry types stripped from
 	// /v1/responses bodies on baseten-route attempts. Openai shape
 	// only; nil/empty = no strip. Config order from gateway.yaml is
@@ -235,6 +243,10 @@ func (r resolvedClientConfig) hash() string {
 	fmt.Fprintln(h, r.GlobalRoutingEnabled)
 	fmt.Fprintln(h, r.SanitizeHistory)
 	fmt.Fprintln(h, r.FallbackRoute)
+	fmt.Fprintln(h, r.FallbackPolicy.OnBaseten429)
+	fmt.Fprintln(h, r.FallbackPolicy.OnBaseten5xx)
+	fmt.Fprintln(h, r.HasFallbackPolicy)
+	fmt.Fprintln(h, r.NativeFallbackModel)
 	fmt.Fprintln(h, r.UpstreamShape)
 	fmt.Fprintln(h, r.TTFTTimeout)
 	fmt.Fprintln(h, r.DefaultModel)
@@ -597,11 +609,11 @@ type Gateway struct {
 	emailCached    string
 	emailFetchedAt time.Time
 
-	// Fallback cooldown state, keyed by listener name: until this
-	// deadline, requests go straight to the fallback route without
-	// re-trying the tripped primary.
+	// Fallback cooldown state, keyed by listener name. Trigger provenance is
+	// retained so a newly disabled status class stops bypassing Baseten
+	// immediately while unrelated cooldowns remain active.
 	fallbackMu    sync.Mutex
-	fallbackUntil map[string]time.Time
+	fallbackUntil map[string]fallbackCooldownState
 
 	// authUnavailableFallbackCount and its last-occurrence fields make the
 	// otherwise successful auth_unavailable fallback visible in admin status.
@@ -2126,6 +2138,21 @@ type upstreamAttempt struct {
 	// an earlier attempt failure, an active cooldown, or unavailable primary
 	// credentials. It flows into telemetry as fallback_trigger.
 	fallbackTrigger string
+	// fallbackAllowed is set on a native candidate and controls which failure
+	// classes on the immediately preceding Baseten attempt may advance to it.
+	// Explicit Claude aliases and raw slugs are status-only candidates.
+	fallbackAllowed fallbackTriggerMask
+	// fallbackModelSource distinguishes exact native-origin replay from a
+	// configured target substituted for a Baseten-specific ingress identity.
+	fallbackModelSource string
+	// fallbackSuppressedReason is set on the terminal Baseten attempt when an
+	// otherwise relevant status fallback was disabled or lacked a target.
+	fallbackSuppressedReason string
+	// statusFallbackPossible marks a Baseten primary that has a configured
+	// native route. It includes the missing-target case so policy suppression
+	// telemetry remains deterministic.
+	statusFallbackPossible      bool
+	statusFallbackMissingTarget bool
 	// primary retains the bounded primary-route outcome on the fallback that
 	// ultimately serves. It is nil for requests that never select fallback.
 	primary *telemetry.PrimaryV1
@@ -2180,12 +2207,83 @@ func (at upstreamAttempt) telStrippedToolTypes() string {
 // 429, or 5xx), so a dead upstream doesn't add per-request latency.
 const fallbackCooldown = 30 * time.Second
 
-func fallbackTriggerStatus(protocolShape string, code int) bool {
-	if protocolShape == "anthropic" &&
-		code == http.StatusTooManyRequests {
+type fallbackTriggerMask uint16
+
+const (
+	fallbackAllowHTTP429 fallbackTriggerMask = 1 << iota
+	fallbackAllowHTTP5xx
+	fallbackAllowTransport
+	fallbackAllowTTFT
+	fallbackAllowRequestBuild
+	fallbackAllowImage
+	fallbackAllowReasoning
+	fallbackAllowAuthUnavailable
+)
+
+const (
+	fallbackAllowStatus = fallbackAllowHTTP429 | fallbackAllowHTTP5xx
+	fallbackAllowLegacy = fallbackAllowStatus |
+		fallbackAllowTransport |
+		fallbackAllowTTFT |
+		fallbackAllowRequestBuild |
+		fallbackAllowImage |
+		fallbackAllowReasoning |
+		fallbackAllowAuthUnavailable
+)
+
+const (
+	fallbackCooldownHTTP429 = "http_429"
+	fallbackCooldownHTTP5xx = "http_5xx"
+)
+
+type fallbackCooldownState struct {
+	Until   time.Time
+	Trigger string
+}
+
+func fallbackStatusMask(code int) fallbackTriggerMask {
+	switch {
+	case code == http.StatusTooManyRequests:
+		return fallbackAllowHTTP429
+	case code >= 500 && code <= 599:
+		return fallbackAllowHTTP5xx
+	default:
+		return 0
+	}
+}
+
+func statusFallbackEnabled(policy config.ResolvedFallbackPolicy, code int) bool {
+	switch fallbackStatusMask(code) {
+	case fallbackAllowHTTP429:
+		return policy.OnBaseten429
+	case fallbackAllowHTTP5xx:
+		return policy.OnBaseten5xx
+	default:
 		return false
 	}
-	return code == 429 || code >= 500
+}
+
+func (r resolvedClientConfig) resolvedFallbackPolicy() config.ResolvedFallbackPolicy {
+	if r.HasFallbackPolicy {
+		return r.FallbackPolicy
+	}
+	// Direct in-process embedders and older focused tests construct resolved
+	// clients without a raw config. Preserve the product default in that path.
+	return config.ResolvedFallbackPolicy{
+		OnBaseten429: true,
+		OnBaseten5xx: true,
+	}
+}
+
+func statusSuppressedReason(code int) string {
+	switch fallbackStatusMask(code) {
+	case fallbackAllowHTTP429:
+		return "policy_disabled_http_429"
+	case fallbackAllowHTTP5xx:
+		return "policy_disabled_http_5xx"
+	default:
+		return ""
+	}
 }
 
 // fallbackTriggerTTFT is the telemetry fallback_trigger value for an
@@ -2257,25 +2355,85 @@ func awaitFirstByte(body io.Reader, deadline <-chan time.Time, cancel context.Ca
 }
 
 func (g *Gateway) fallbackActive(name string) bool {
-	g.fallbackMu.Lock()
-	defer g.fallbackMu.Unlock()
-	return time.Now().Before(g.fallbackUntil[name])
+	_, active := g.fallbackDeadline(name)
+	return active
 }
 
 func (g *Gateway) fallbackDeadline(name string) (time.Time, bool) {
-	g.fallbackMu.Lock()
-	defer g.fallbackMu.Unlock()
-	deadline := g.fallbackUntil[name]
-	return deadline, time.Now().Before(deadline)
+	state, active := g.activeFallbackCooldown(name)
+	if !active {
+		return state.Until, false
+	}
+	mask := cooldownTriggerMask(state.Trigger)
+	if mask != fallbackAllowHTTP429 && mask != fallbackAllowHTTP5xx {
+		return state.Until, true
+	}
+	g.mu.Lock()
+	cl := g.clients[name]
+	g.mu.Unlock()
+	if cl == nil || !cooldownEligible(
+		cl.cfg.resolvedFallbackPolicy(),
+		fallbackAllowStatus,
+		state,
+	) {
+		return state.Until, false
+	}
+	return state.Until, true
 }
 
-func (g *Gateway) tripFallback(name string) {
+func (g *Gateway) activeFallbackCooldown(name string) (fallbackCooldownState, bool) {
+	g.fallbackMu.Lock()
+	defer g.fallbackMu.Unlock()
+	state := g.fallbackUntil[name]
+	return state, time.Now().Before(state.Until)
+}
+
+func cooldownTriggerMask(trigger string) fallbackTriggerMask {
+	switch trigger {
+	case fallbackCooldownHTTP429:
+		return fallbackAllowHTTP429
+	case fallbackCooldownHTTP5xx:
+		return fallbackAllowHTTP5xx
+	case "transport_error":
+		return fallbackAllowTransport
+	case fallbackTriggerTTFT:
+		return fallbackAllowTTFT
+	case fallbackTriggerRequestBuild:
+		return fallbackAllowRequestBuild
+	default:
+		return 0
+	}
+}
+
+func cooldownEligible(
+	policy config.ResolvedFallbackPolicy,
+	allowed fallbackTriggerMask,
+	state fallbackCooldownState,
+) bool {
+	mask := cooldownTriggerMask(state.Trigger)
+	if allowed&mask == 0 {
+		return false
+	}
+	switch mask {
+	case fallbackAllowHTTP429:
+		return policy.OnBaseten429
+	case fallbackAllowHTTP5xx:
+		return policy.OnBaseten5xx
+	default:
+		return true
+	}
+}
+
+func (g *Gateway) tripFallback(name string, trigger string) {
 	g.fallbackMu.Lock()
 	defer g.fallbackMu.Unlock()
 	if g.fallbackUntil == nil {
-		g.fallbackUntil = map[string]time.Time{}
+		g.fallbackUntil = map[string]fallbackCooldownState{}
 	}
-	g.fallbackUntil[name] = time.Now().Add(fallbackCooldown)
+	g.fallbackUntil[name] = fallbackCooldownState{
+		Until:   time.Now().Add(fallbackCooldown),
+		Trigger: trigger,
+	}
 }
 
 const authUnavailableFallbackHeader = "X-Baseten-Switch-Fallback"
@@ -2362,6 +2520,7 @@ func (g *Gateway) buildAttempt(cl *clientListener, r *http.Request, body []byte,
 		kind,
 		"",
 		false,
+		false,
 	)
 }
 
@@ -2381,6 +2540,7 @@ func (g *Gateway) buildAttemptTarget(cl *clientListener, r *http.Request, body [
 		kind,
 		forcedModel,
 		forced,
+		false,
 	)
 }
 
@@ -2405,6 +2565,7 @@ func (g *Gateway) buildAttemptWithSnapshot(
 		kind,
 		"",
 		false,
+		false,
 	)
 }
 
@@ -2419,10 +2580,11 @@ func (g *Gateway) buildAttemptTargetWithSnapshot(
 	kind string,
 	forcedModel string,
 	forced bool,
+	preserveIngressBody bool,
 ) (upstreamAttempt, error) {
 	upShape := upstreamShapeFor(cl.cfg, rt)
 	needsTranslate := kind == "messages" && upShape == "openai"
-	if kind == "messages" {
+	if kind == "messages" && !preserveIngressBody {
 		profile := requestprofile.Inspect(body)
 		if profile.RawModel != "" && profile.CanonicalModel != profile.RawModel {
 			body = proxy.RewriteModelInBody(body, profile.CanonicalModel).NewBody
@@ -2592,11 +2754,118 @@ func unknownAliasError(rc resolvedClientConfig, id string) error {
 	return fmt.Errorf("unknown gateway model %q: configured model_aliases for client %q are [%s]. Fix: %s", id, rc.Name, strings.Join(sortedKeys(ids), ", "), fix)
 }
 
+const (
+	fallbackModelSourceOriginal   = "original_request"
+	fallbackModelSourceConfigured = "configured_target"
+)
+
+// fallbackPlan is immutable request-ingress provenance. It is resolved before
+// any subagent, family, default, alias, or provider-shape rewrite so later
+// primary selection cannot change which native model fallback is allowed to
+// send.
+type fallbackPlan struct {
+	nativeRoute   string
+	nativeBody    []byte
+	nativeModel   string
+	modelSource   string
+	allowed       fallbackTriggerMask
+	missingTarget bool
+}
+
+func resolveFallbackPlan(cl *clientListener, body []byte) fallbackPlan {
+	if cl == nil || cl.cfg.globalRoutingOff() || cl.cfg.FallbackRoute == "" {
+		return fallbackPlan{}
+	}
+	requested := proxy.RewriteModelInBody(body, "").RequestedModel
+	if requested == "" {
+		return fallbackPlan{}
+	}
+	_, configuredAlias := cl.cfg.ModelAliases[requested]
+	isRawSlug := strings.Contains(requested, "/")
+	if configuredAlias || isRawSlug {
+		// V1 defines a catch-all native target only for Claude-compatible
+		// Baseten identities. OpenAI raw slugs and the managed Codex sentinel
+		// remain terminal.
+		if cl.cfg.ProtocolShape != "anthropic" {
+			return fallbackPlan{}
+		}
+		plan := fallbackPlan{
+			nativeRoute: cl.cfg.FallbackRoute,
+			allowed:     fallbackAllowStatus,
+		}
+		if cl.cfg.NativeFallbackModel == "" {
+			plan.missingTarget = true
+			return plan
+		}
+		rewritten := proxy.RewriteModelInBody(body, cl.cfg.NativeFallbackModel)
+		if !rewritten.Parsed || rewritten.UpstreamModel == requested {
+			return fallbackPlan{}
+		}
+		plan.nativeBody = append([]byte(nil), rewritten.NewBody...)
+		plan.nativeModel = cl.cfg.NativeFallbackModel
+		plan.modelSource = fallbackModelSourceConfigured
+		return plan
+	}
+	if InAliasNamespace(requested) ||
+		(cl.cfg.ProtocolShape == "openai" && requested == CodexCompatibilityModel) {
+		return fallbackPlan{}
+	}
+	if !config.IsProtocolNativeModel(cl.cfg.ProtocolShape, normalizeModelID(requested)) {
+		return fallbackPlan{}
+	}
+	return fallbackPlan{
+		nativeRoute: cl.cfg.FallbackRoute,
+		nativeBody:  append([]byte(nil), body...),
+		nativeModel: requested,
+		modelSource: fallbackModelSourceOriginal,
+		allowed:     fallbackAllowLegacy,
+	}
+}
+
+func (plan fallbackPlan) configured() bool {
+	return plan.nativeRoute != "" && len(plan.nativeBody) > 0 &&
+		plan.nativeModel != "" && plan.allowed != 0
+}
+
+func (g *Gateway) buildFallbackAttemptWithSnapshot(
+	snapshot *pricing.Snapshot,
+	requestedReasoning reasoning.RequestedReasoning,
+	requestedObserved bool,
+	cl *clientListener,
+	r *http.Request,
+	kind string,
+	plan fallbackPlan,
+) (upstreamAttempt, error) {
+	if !plan.configured() {
+		return upstreamAttempt{}, errors.New("fallback plan is not configured")
+	}
+	at, err := g.buildAttemptTargetWithSnapshot(
+		snapshot,
+		requestedReasoning,
+		requestedObserved,
+		cl,
+		r,
+		plan.nativeBody,
+		plan.nativeRoute,
+		kind,
+		"",
+		false,
+		plan.modelSource == fallbackModelSourceOriginal,
+	)
+	if err != nil {
+		return upstreamAttempt{}, err
+	}
+	at.fallbackAllowed = plan.allowed
+	at.fallbackModelSource = plan.modelSource
+	return at, nil
+}
+
 // resolveExplicitModelAttempt implements explicit-choice-wins routing
 // (the model-discovery contract): configured aliases remain an Anthropic-shape
 // feature, while a raw Baseten slug (contains "/") is explicit on every
-// request shape. Both are single attempts with no fallback_route: silently
-// substituting a native provider would violate the user's model selection.
+// request shape. The explicit Baseten attempt is primary. Anthropic-shape
+// identities may carry a separate status-only native candidate when the
+// client has native_fallback_model; every non-status trigger remains terminal.
 // On Anthropic-shape listeners, an unrecognized
 // claude-baseten-*/anthropic-baseten-* id is a loud 400, never a default-model route.
 func (g *Gateway) resolveExplicitModelAttempt(cl *clientListener, r *http.Request, body []byte, kind string) (upstreamAttempt, bool, error) {
@@ -2648,6 +2917,7 @@ func (g *Gateway) resolveExplicitModelAttemptWithSnapshot(
 		kind,
 		target,
 		true,
+		false,
 	)
 	if err != nil {
 		return upstreamAttempt{}, false, err
@@ -2664,7 +2934,7 @@ func (g *Gateway) resolveExplicitModelAttemptWithSnapshot(
 // building the primary (e.g. untranslatable content) is returned to the
 // caller; fallback build errors just drop the fallback. Explicitly
 // chosen Baseten models (alias or raw slug) preempt all of this with a
-// single baseten attempt.
+// Baseten attempt with an optional status-only native candidate.
 //
 // Subagent gate (the subagent-routing contract): on an anthropic-shape
 // listener with subagent routing enabled, a request carrying a
@@ -2719,6 +2989,7 @@ func (g *Gateway) resolveAttemptsWithRequestedReasoning(
 		at.requestClassification = classification
 		return []upstreamAttempt{at}, nil
 	}
+	plan := resolveFallbackPlan(cl, body)
 	isSubagent := false
 	origRequested := ""
 	subagentModel := ""
@@ -2732,7 +3003,7 @@ func (g *Gateway) resolveAttemptsWithRequestedReasoning(
 			}
 		}
 	}
-	attempts, err := g.resolveAttemptsLadderWithSnapshot(
+	attempts, err := g.resolveAttemptsLadderWithPlan(
 		snapshot,
 		requested,
 		requestedObserved,
@@ -2740,6 +3011,7 @@ func (g *Gateway) resolveAttemptsWithRequestedReasoning(
 		r,
 		body,
 		kind,
+		plan,
 	)
 	if err != nil {
 		return nil, err
@@ -2783,6 +3055,28 @@ func (g *Gateway) resolveAttemptsLadderWithSnapshot(
 	body []byte,
 	kind string,
 ) ([]upstreamAttempt, error) {
+	return g.resolveAttemptsLadderWithPlan(
+		snapshot,
+		requestedReasoning,
+		requestedObserved,
+		cl,
+		r,
+		body,
+		kind,
+		resolveFallbackPlan(cl, body),
+	)
+}
+
+func (g *Gateway) resolveAttemptsLadderWithPlan(
+	snapshot *pricing.Snapshot,
+	requestedReasoning reasoning.RequestedReasoning,
+	requestedObserved bool,
+	cl *clientListener,
+	r *http.Request,
+	body []byte,
+	kind string,
+	plan fallbackPlan,
+) ([]upstreamAttempt, error) {
 	requested := proxy.RewriteModelInBody(body, "").RequestedModel
 	if cl.cfg.globalRoutingOff() {
 		// The global routing gate is terminal. Inspect the requested model only
@@ -2823,7 +3117,40 @@ func (g *Gateway) resolveAttemptsLadderWithSnapshot(
 	); err != nil {
 		return nil, err
 	} else if ok {
-		return []upstreamAttempt{at}, nil
+		at.statusFallbackPossible = plan.nativeRoute != ""
+		at.statusFallbackMissingTarget = plan.missingTarget
+		attempts := []upstreamAttempt{at}
+		if plan.configured() && at.route == pricing.ProviderBaseten &&
+			plan.nativeRoute != at.route {
+			if fba, ferr := g.buildFallbackAttemptWithSnapshot(
+				snapshot,
+				requestedReasoning,
+				requestedObserved,
+				cl,
+				r,
+				kind,
+				plan,
+			); ferr == nil {
+				if cooldown, active := g.activeFallbackCooldown(cl.cfg.Name); active && cooldownEligible(
+					cl.cfg.resolvedFallbackPolicy(),
+					fba.fallbackAllowed,
+					cooldown,
+				) {
+					fba.fallbackCount = 1
+					fba.fallbackTrigger = fallbackTriggerCooldown
+					fba.primary = primarySummary(
+						at,
+						false,
+						telemetry.PrimaryOutcomeCooldown,
+						nil,
+					)
+					attempts = []upstreamAttempt{fba}
+				} else {
+					attempts = append(attempts, fba)
+				}
+			}
+		}
+		return attempts, nil
 	}
 	// Model-route pin (config/schema.md): family entry for native
 	// claude-*/anthropic-* ids. When
@@ -2847,6 +3174,8 @@ func (g *Gateway) resolveAttemptsLadderWithSnapshot(
 	}
 	var attempts []upstreamAttempt
 	if perr == nil {
+		primary.statusFallbackPossible = plan.nativeRoute != ""
+		primary.statusFallbackMissingTarget = plan.missingTarget
 		attempts = append(attempts, primary)
 	}
 	// The managed Codex profile's compatibility model is an instruction to
@@ -2860,48 +3189,61 @@ func (g *Gateway) resolveAttemptsLadderWithSnapshot(
 		}
 		return nil, perr
 	}
-	if fb := cl.cfg.FallbackRoute; fb != "" {
+	if fb := cl.cfg.FallbackRoute; fb != "" && plan.configured() {
 		// Fallback inertness is decided here, per request, against the
 		// primary attempt's EFFECTIVE route rather than the configured
 		// route, because a model_routes pin can move the primary
 		// (config/schema.md, model route fallback semantics). A fallback
 		// equal to the effective primary is dormant for this request:
 		// no duplicate same-route retry, no spurious cooldown trip.
-		// When they differ the waterfall is live. A primary that failed to build
-		// (errNeedsLogin) keeps the fallback regardless.
+		// When they differ the waterfall is live. Pre-attempt failures advance
+		// only when the candidate allows that trigger class; alias and raw-slug
+		// candidates are status-only.
 		if perr == nil && fb == primary.route {
 			return attempts, nil
 		}
-		if fba, ferr := g.buildAttemptWithSnapshot(
+		if fba, ferr := g.buildFallbackAttemptWithSnapshot(
 			snapshot,
 			requestedReasoning,
 			requestedObserved,
 			cl,
 			r,
-			body,
-			fb,
 			kind,
+			plan,
 		); ferr == nil {
-			if perr == nil && g.fallbackActive(cl.cfg.Name) {
+			if cooldown, active := g.activeFallbackCooldown(cl.cfg.Name); perr == nil && active && cooldownEligible(
+				cl.cfg.resolvedFallbackPolicy(),
+				fba.fallbackAllowed,
+				cooldown,
+			) {
 				fba.fallbackCount = 1
 				fba.fallbackTrigger = fallbackTriggerCooldown
 				fba.primary = primarySummary(primary, false, telemetry.PrimaryOutcomeCooldown, nil)
 				attempts = []upstreamAttempt{fba}
 			} else {
-				if errors.Is(perr, errNeedsLogin) {
+				appendFallback := perr == nil
+				if errors.Is(perr, errNeedsLogin) &&
+					fba.fallbackAllowed&fallbackAllowAuthUnavailable != 0 {
 					fba.fallbackCount = 1
 					fba.fallbackTrigger = fallbackTriggerAuthUnavailable
 					fba.primary = primarySummary(primary, false, telemetry.PrimaryOutcomeAuthUnavailable, nil)
-				} else if allowsImageTranslationFallback(perr) {
+					appendFallback = true
+				} else if allowsImageTranslationFallback(perr) &&
+					fba.fallbackAllowed&fallbackAllowImage != 0 {
 					fba.fallbackCount = 1
 					fba.fallbackTrigger = fallbackTriggerImageUnsupported
 					fba.primary = primarySummary(primary, false, telemetry.PrimaryOutcomeImageInputUnsupported, nil)
-				} else if reasoning.AllowsFallback(perr) {
+					appendFallback = true
+				} else if reasoning.AllowsFallback(perr) &&
+					fba.fallbackAllowed&fallbackAllowReasoning != 0 {
 					fba.fallbackCount = 1
 					fba.fallbackTrigger = "reasoning_policy_error"
 					fba.primary = primarySummary(primary, false, telemetry.PrimaryOutcomeReasoningPolicyError, nil)
+					appendFallback = true
 				}
-				attempts = append(attempts, fba)
+				if appendFallback {
+					attempts = append(attempts, fba)
+				}
 			}
 		}
 	}
@@ -3105,6 +3447,7 @@ func (g *Gateway) resolveModelRoutePrimaryWithSnapshot(
 			kind,
 			decision.model,
 			true,
+			false,
 		)
 		if err != nil && planned.modelForCost != "" {
 			return planned, err
@@ -3189,12 +3532,12 @@ func ExpectedPrimaryRoute(c config.Client, globalRoutingEnabled bool, requestedI
 // response to the client (streaming or not), parses usage and writes
 // one telemetry row tagged with the listener name. A later attempt is
 // tried (and the fallback cooldown tripped) when an earlier one fails
-// to connect, returns an eligible 429 or 5xx, or exceeds the
+// to connect, returns a policy-enabled 429 or exact 500-599 status, or exceeds the
 // ttft_timeout first-byte deadline; nothing has been written to the
-// client at that point, so the retry is invisible. Anthropic-shape 429
-// responses are terminal and relay without fallback or cooldown. A
+// client at that point, so the retry is invisible. Disabled status classes
+// relay without fallback or cooldown. A
 // TTFT expiry on the final attempt (or on an explicit alias/slug
-// choice, which has no fallback) surfaces as a 504 naming the model
+// choice, which has no non-status fallback) surfaces as a 504 naming the model
 // and the deadline. Once the first response byte has arrived the
 // deadline is inert: a live stream is never truncated.
 func (g *Gateway) streamForward(
@@ -3351,32 +3694,41 @@ attemptLoop:
 				break
 			}
 
-			if !last &&
-				fallbackTriggerStatus(
-					cl.cfg.ProtocolShape,
-					resp.StatusCode,
-				) {
-				watch.stop()
-				fmt.Fprintf(os.Stderr,
-					"[gateway] fallback client=%s route=%s status=%d -> trying %s\n",
-					cl.cfg.Name, at.route, resp.StatusCode, attempts[i+1].route)
-				g.tripFallback(cl.cfg.Name)
-				_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64<<10))
-				resp.Body.Close()
-				watch.cancel()
-				if at.hasActiveResponsesCompatibility() {
-					attempts[i+1].responsesCompatibility =
-						at.responsesCompatibility
+			statusMask := fallbackStatusMask(resp.StatusCode)
+			if at.route == pricing.ProviderBaseten &&
+				statusMask != 0 && at.statusFallbackPossible {
+				policy := cl.cfg.resolvedFallbackPolicy()
+				if !statusFallbackEnabled(policy, resp.StatusCode) {
+					at.fallbackSuppressedReason = statusSuppressedReason(resp.StatusCode)
+				} else if at.statusFallbackMissingTarget {
+					at.fallbackSuppressedReason = "native_target_unconfigured"
+				} else if !last && attempts[i+1].fallbackAllowed&statusMask != 0 {
+					watch.stop()
+					fmt.Fprintf(os.Stderr,
+						"[gateway] fallback client=%s route=%s status=%d -> trying %s\n",
+						cl.cfg.Name, at.route, resp.StatusCode, attempts[i+1].route)
+					cooldownTrigger := fallbackCooldownHTTP5xx
+					if statusMask == fallbackAllowHTTP429 {
+						cooldownTrigger = fallbackCooldownHTTP429
+					}
+					g.tripFallback(cl.cfg.Name, cooldownTrigger)
+					_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64<<10))
+					resp.Body.Close()
+					watch.cancel()
+					if at.hasActiveResponsesCompatibility() {
+						attempts[i+1].responsesCompatibility =
+							at.responsesCompatibility
+					}
+					attempts[i+1].fallbackTrigger =
+						fmt.Sprintf("http_%d", resp.StatusCode)
+					attempts[i+1].primary = primarySummary(
+						at,
+						true,
+						telemetry.PrimaryOutcomeHTTPError,
+						&resp.StatusCode,
+					)
+					continue attemptLoop
 				}
-				attempts[i+1].fallbackTrigger =
-					fmt.Sprintf("http_%d", resp.StatusCode)
-				attempts[i+1].primary = primarySummary(
-					at,
-					true,
-					telemetry.PrimaryOutcomeHTTPError,
-					&resp.StatusCode,
-				)
-				continue attemptLoop
 			}
 
 			// Headers arrived but the harness only unfreezes on the first
@@ -3405,6 +3757,7 @@ attemptLoop:
 			// Cancel it only after relay completes.
 			defer watch.cancel()
 			if !last &&
+				attempts[i+1].fallbackAllowed&fallbackAllowImage != 0 &&
 				reactiveImageFallbackEligible(
 					cl,
 					at,
@@ -3486,17 +3839,19 @@ attemptLoop:
 			fmt.Fprintf(os.Stderr,
 				"[gateway] upstream err client=%s route=%s upstream=%s status=0 code=%d is_stream=%t dur=%s err=%v\n",
 				cl.cfg.Name, at.route, res.UpstreamModel, code, isStream, time.Since(start), err)
-			if !last {
-				g.tripFallback(cl.cfg.Name)
+			fallbackMask := fallbackAllowTransport
+			fallbackTrigger := "transport_error"
+			primaryOutcome := telemetry.PrimaryOutcomeTransportError
+			if !attemptDispatched {
+				fallbackMask = fallbackAllowRequestBuild
+				fallbackTrigger = fallbackTriggerRequestBuild
+				primaryOutcome = telemetry.PrimaryOutcomeRequestBuildError
+			}
+			if !last && attempts[i+1].fallbackAllowed&fallbackMask != 0 {
+				g.tripFallback(cl.cfg.Name, fallbackTrigger)
 				if at.hasActiveResponsesCompatibility() {
 					attempts[i+1].responsesCompatibility =
 						at.responsesCompatibility
-				}
-				fallbackTrigger := "transport_error"
-				primaryOutcome := telemetry.PrimaryOutcomeTransportError
-				if !attemptDispatched {
-					fallbackTrigger = fallbackTriggerRequestBuild
-					primaryOutcome = telemetry.PrimaryOutcomeRequestBuildError
 				}
 				attempts[i+1].fallbackTrigger = fallbackTrigger
 				attempts[i+1].primary = primarySummary(
@@ -3517,11 +3872,11 @@ attemptLoop:
 			return
 		}
 		if ttftExpired {
-			if !last {
+			if !last && attempts[i+1].fallbackAllowed&fallbackAllowTTFT != 0 {
 				fmt.Fprintf(os.Stderr,
 					"[gateway] fallback client=%s route=%s ttft_timeout=%s no first byte -> trying %s\n",
 					cl.cfg.Name, at.route, cl.cfg.TTFTTimeout, attempts[i+1].route)
-				g.tripFallback(cl.cfg.Name)
+				g.tripFallback(cl.cfg.Name, fallbackTriggerTTFT)
 				if at.hasActiveResponsesCompatibility() {
 					attempts[i+1].responsesCompatibility =
 						at.responsesCompatibility
@@ -4342,6 +4697,7 @@ func resolveFromFile(f *config.File) ([]resolvedClientConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+	fallbackPolicy := config.ResolveFallbackPolicy(f.Global.FallbackPolicy)
 	out := make([]resolvedClientConfig, 0, len(f.Clients))
 	claimed := map[string]string{} // bind_addr + shape -> owning client
 	for _, c := range f.Clients {
@@ -4434,6 +4790,9 @@ func resolveFromFile(f *config.File) ([]resolvedClientConfig, error) {
 			ModelOptions:            cloneModelOptions(c.ModelOptions),
 			SanitizeHistory:         sanitize,
 			FallbackRoute:           fb,
+			FallbackPolicy:          fallbackPolicy,
+			HasFallbackPolicy:       true,
+			NativeFallbackModel:     c.NativeFallbackModel,
 			UpstreamShape:           us,
 			ResponsesStripToolTypes: c.ResponsesStripToolTypes,
 			ResponsesCompatibility:  responsesCompatibility,

--- a/gateway/cmd/gateway/gateway.go
+++ b/gateway/cmd/gateway/gateway.go
@@ -2781,7 +2781,8 @@ func resolveFallbackPlan(cl *clientListener, body []byte) fallbackPlan {
 	if requested == "" {
 		return fallbackPlan{}
 	}
-	_, configuredAlias := cl.cfg.ModelAliases[requested]
+	canonicalRequested := normalizeModelID(requested)
+	_, configuredAlias := cl.cfg.ModelAliases[canonicalRequested]
 	isRawSlug := strings.Contains(requested, "/")
 	if configuredAlias || isRawSlug {
 		// V1 defines a catch-all native target only for Claude-compatible
@@ -2807,7 +2808,7 @@ func resolveFallbackPlan(cl *clientListener, body []byte) fallbackPlan {
 		plan.modelSource = fallbackModelSourceConfigured
 		return plan
 	}
-	if InAliasNamespace(requested) ||
+	if InAliasNamespace(canonicalRequested) ||
 		(cl.cfg.ProtocolShape == "openai" && requested == CodexCompatibilityModel) {
 		return fallbackPlan{}
 	}
@@ -2895,14 +2896,15 @@ func (g *Gateway) resolveExplicitModelAttemptWithSnapshot(
 	if requested == "" {
 		return upstreamAttempt{}, false, nil
 	}
+	canonicalRequested := normalizeModelID(requested)
 	target := ""
 	if strings.Contains(requested, "/") {
-		target = requested
+		target = canonicalRequested
 	} else if cl.cfg.ProtocolShape != "anthropic" {
 		return upstreamAttempt{}, false, nil
-	} else if slug, ok := cl.cfg.ModelAliases[requested]; ok {
+	} else if slug, ok := cl.cfg.ModelAliases[canonicalRequested]; ok {
 		target = slug
-	} else if InAliasNamespace(requested) {
+	} else if InAliasNamespace(canonicalRequested) {
 		return upstreamAttempt{}, false, unknownAliasError(cl.cfg, requested)
 	} else {
 		return upstreamAttempt{}, false, nil
@@ -3079,13 +3081,14 @@ func (g *Gateway) resolveAttemptsLadderWithPlan(
 	plan fallbackPlan,
 ) ([]upstreamAttempt, error) {
 	requested := proxy.RewriteModelInBody(body, "").RequestedModel
+	canonicalRequested := normalizeModelID(requested)
 	if cl.cfg.globalRoutingOff() {
 		// The global routing gate is terminal. Inspect the requested model only
 		// to reject explicit Baseten choices clearly; otherwise build one
 		// protocol-native attempt. Do not consult aliases, pins, subagent
 		// policy, fallback, cooldown, or Baseten credentials.
-		if _, alias := cl.cfg.ModelAliases[requested]; alias ||
-			InAliasNamespace(requested) ||
+		if _, alias := cl.cfg.ModelAliases[canonicalRequested]; alias ||
+			InAliasNamespace(canonicalRequested) ||
 			strings.Contains(requested, "/") ||
 			(cl.cfg.ProtocolShape == "openai" &&
 				requested == CodexCompatibilityModel) {
@@ -4816,18 +4819,19 @@ func discoveryPrefixOK(id string) bool {
 // are deliberately not pin families yet.
 var modelFamilySet = []string{"fable", "opus", "sonnet", "haiku"}
 
-// bracketSuffixRe matches one trailing harness context selection like [1m].
-// Claude Code normally removes this decoration before provider inference. If
-// it reaches the gateway, Baseten captures it separately and strips it from the
-// canonical provider model.
-var bracketSuffixRe = regexp.MustCompile(`\[[^\]]*\]$`)
+const oneMillionContextModelSuffix = "[1m]"
 
-// normalizeModelID strips one trailing bracketed suffix (for example
-// [1m]) from a model id. The suffix is not part of the provider model
-// identity, so routing, catalog lookup, and upstream inference use the
-// normalized form.
+// normalizeModelID strips only Claude Code's documented [1m] context
+// decoration, matched case-insensitively. Other bracketed suffixes are part of
+// the requested identifier and must not be generalized into routing syntax.
 func normalizeModelID(id string) string {
-	return bracketSuffixRe.ReplaceAllString(id, "")
+	if len(id) >= len(oneMillionContextModelSuffix) && strings.EqualFold(
+		id[len(id)-len(oneMillionContextModelSuffix):],
+		oneMillionContextModelSuffix,
+	) {
+		return id[:len(id)-len(oneMillionContextModelSuffix)]
+	}
+	return id
 }
 
 // familyOf returns the first family token from modelFamilySet contained

--- a/gateway/cmd/gateway/gateway_test.go
+++ b/gateway/cmd/gateway/gateway_test.go
@@ -1977,11 +1977,11 @@ func TestPostMessagesSanitizeHistory(t *testing.T) {
 	}
 }
 
-// TestAnthropic429RelaysWithoutFallbackOrCooldown verifies that a rate
-// limit is a terminal response for an Anthropic-shape request. The
-// original retry contract reaches the harness, and a later request
-// rechecks the configured primary instead of inheriting a cooldown.
-func TestAnthropic429RelaysWithoutFallbackOrCooldown(t *testing.T) {
+// TestAnthropic429RelaysWithoutFallbackOrCooldownWhenPolicyOff verifies that
+// the disabled 429 policy relays the original retry contract to the harness.
+// A later request rechecks the configured primary instead of inheriting a
+// cooldown.
+func TestAnthropic429RelaysWithoutFallbackOrCooldownWhenPolicyOff(t *testing.T) {
 	const rateLimitBody = `{"type":"error","error":{"type":"rate_limit_error","message":"try again later"}}`
 	var primaryHits atomic.Int32
 	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -2004,6 +2004,11 @@ func TestAnthropic429RelaysWithoutFallbackOrCooldown(t *testing.T) {
 	cfg := testConfig(t, primary.URL, fallback.URL)
 	rc := resolvedAnthropicBaseten(t)
 	rc.FallbackRoute = "anthropic"
+	rc.HasFallbackPolicy = true
+	rc.FallbackPolicy = config.ResolvedFallbackPolicy{
+		OnBaseten429: false,
+		OnBaseten5xx: true,
+	}
 	g, adminL, _ := newGateway(t, cfg, rc)
 	defer adminL.Close()
 	stop := start(t, g)
@@ -2073,14 +2078,17 @@ func TestAnthropic429RelaysWithoutFallbackOrCooldown(t *testing.T) {
 			row.Fallback.Trigger != nil {
 			t.Fatalf("row %d fallback = %+v, want no fallback", i, row.Fallback)
 		}
+		if valueOrZero(row.Fallback.SuppressedReason) != "policy_disabled_http_429" {
+			t.Fatalf("row %d suppressed_reason = %q, want policy_disabled_http_429", i, valueOrZero(row.Fallback.SuppressedReason))
+		}
 	}
 }
 
-// TestTranslatedAnthropic429PreservesRetryAfter verifies the terminal
-// rate-limit policy also applies when an Anthropic listener translates
-// its Baseten request through the OpenAI wire shape. The error envelope
-// keeps the existing translation behavior while response control
-// headers survive that body rewrite.
+// TestTranslatedAnthropic429PreservesRetryAfter verifies that the disabled
+// 429 policy also applies when an Anthropic listener translates its Baseten
+// request through the OpenAI wire shape. The error envelope keeps the existing
+// translation behavior while response control headers survive that body
+// rewrite.
 func TestTranslatedAnthropic429PreservesRetryAfter(t *testing.T) {
 	var primaryHits atomic.Int32
 	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -2109,6 +2117,11 @@ func TestTranslatedAnthropic429PreservesRetryAfter(t *testing.T) {
 	rc.DefaultModel = reasoningNeutralBasetenModel
 	rc.UpstreamShape = "openai"
 	rc.FallbackRoute = "anthropic"
+	rc.HasFallbackPolicy = true
+	rc.FallbackPolicy = config.ResolvedFallbackPolicy{
+		OnBaseten429: false,
+		OnBaseten5xx: true,
+	}
 	g, adminL, _ := newGateway(t, cfg, rc)
 	defer adminL.Close()
 	stop := start(t, g)
@@ -2174,7 +2187,8 @@ func TestTranslatedAnthropic429PreservesRetryAfter(t *testing.T) {
 		row.StatusCode() != http.StatusTooManyRequests ||
 		!row.IsHTTPError() ||
 		row.Fallback.Attempted ||
-		row.Fallback.Trigger != nil {
+		row.Fallback.Trigger != nil ||
+		valueOrZero(row.Fallback.SuppressedReason) != "policy_disabled_http_429" {
 		t.Fatalf(
 			"provider/status/error/fallback = %q/%d/%v/%+v, want baseten/429/true/none",
 			row.EffectiveProvider,

--- a/gateway/cmd/gateway/global_routing_test.go
+++ b/gateway/cmd/gateway/global_routing_test.go
@@ -121,7 +121,7 @@ func TestGlobalRoutingAbsoluteOffBypassesEveryBasetenPolicy(t *testing.T) {
 	}
 }
 
-func TestAnthropicShapeCodexSentinelRetainsNativeFallback(t *testing.T) {
+func TestAnthropicShapeCodexSentinelNeverFallsBackNatively(t *testing.T) {
 	baseten := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "retry natively", http.StatusInternalServerError)
 	}))
@@ -135,11 +135,14 @@ func TestAnthropicShapeCodexSentinelRetainsNativeFallback(t *testing.T) {
 	defer stop()
 
 	resp, body := postModelMessages(t, g, CodexCompatibilityModel, "")
-	if resp.StatusCode != http.StatusOK || !strings.Contains(body, "NATIVE") {
-		t.Fatalf("anthropic sentinel fallback status=%d body=%s", resp.StatusCode, body)
+	if resp.StatusCode != http.StatusInternalServerError ||
+		!strings.Contains(body, "retry natively") {
+		t.Fatalf("anthropic sentinel status=%d body=%s", resp.StatusCode, body)
 	}
-	if got := <-gotNativeModel; got != CodexCompatibilityModel {
-		t.Fatalf("native fallback model = %q, want %q", got, CodexCompatibilityModel)
+	select {
+	case got := <-gotNativeModel:
+		t.Fatalf("compatibility sentinel reached native provider as %q", got)
+	default:
 	}
 }
 
@@ -198,7 +201,7 @@ func TestGlobalRoutingStatusUsesActiveResolverAndExactByteHashes(t *testing.T) {
 		t.Fatalf("hashes active=%v desired=%v", status["active_config_hash"], status["desired_config_hash"])
 	}
 	caps := status["capabilities"].([]any)
-	if len(caps) != 1 || caps[0] != "global_routing" {
+	if len(caps) != 2 || caps[0] != "global_routing" || caps[1] != "fallback_policy" {
 		t.Fatalf("capabilities = %v", caps)
 	}
 	client := status["clients"].([]any)[0].(map[string]any)

--- a/gateway/cmd/gateway/model_routes_test.go
+++ b/gateway/cmd/gateway/model_routes_test.go
@@ -100,24 +100,57 @@ func recordingStub(t *testing.T, gotModel chan string, marker string) *httptest.
 	}))
 }
 
-// TestNormalizeModelID exercises normalizeModelID: one trailing
-// bracketed suffix is stripped, anything else is left untouched.
+// TestNormalizeModelID exercises normalizeModelID: only the documented [1m]
+// suffix is stripped, case-insensitively. Other decorations are identifiers.
 func TestNormalizeModelID(t *testing.T) {
 	for _, tc := range []struct {
 		in, want string
 	}{
 		{"claude-opus-4-8", "claude-opus-4-8"},
 		{"claude-opus-4-8[1m]", "claude-opus-4-8"},
+		{"claude-opus-4-8[1M]", "claude-opus-4-8"},
 		{"claude-fable-5[1m]", "claude-fable-5"},
 		{"claude-sonnet-4-6[1m]", "claude-sonnet-4-6"},
 		{"claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022"},
 		{"", ""},
 		{"[1m]", ""},
-		{"claude-opus-4-8[1m][extra]", "claude-opus-4-8[1m]"},
+		{"claude-opus-4-8[2m]", "claude-opus-4-8[2m]"},
+		{"claude-opus-4-8[extra]", "claude-opus-4-8[extra]"},
+		{"claude-opus-4-8[1m][extra]", "claude-opus-4-8[1m][extra]"},
 	} {
 		if got := normalizeModelID(tc.in); got != tc.want {
 			t.Errorf("normalizeModelID(%q) = %q, want %q", tc.in, got, tc.want)
 		}
+	}
+}
+
+func TestConfiguredAliasAcceptsOneMillionContextSuffix(t *testing.T) {
+	gotModel := make(chan string, 1)
+	basSrv := recordingStub(t, gotModel, "B")
+	defer basSrv.Close()
+	cfg := testConfig(t, basSrv.URL, basSrv.URL)
+	rc := modelRoutesClient(t, "baseten", nil)
+	g, adminL, _ := newGateway(t, cfg, rc)
+	defer adminL.Close()
+	stop := start(t, g)
+	defer stop()
+
+	resp, body := postModelMessages(
+		t,
+		g,
+		"claude-baseten-glm-5-2[1m]",
+		"",
+	)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got %d: %s", resp.StatusCode, body)
+	}
+	select {
+	case model := <-gotModel:
+		if model != "zai-org/GLM-5.2" {
+			t.Fatalf("upstream model = %q, want exact alias target", model)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("upstream never received the request")
 	}
 }
 

--- a/gateway/cmd/gateway/primary_telemetry_test.go
+++ b/gateway/cmd/gateway/primary_telemetry_test.go
@@ -178,7 +178,7 @@ func TestOpenAIHTTPFallbackRecordsPrimary(t *testing.T) {
 	}
 }
 
-func TestNonstandardServerErrorFallbackRetainsPrimaryTelemetry(t *testing.T) {
+func TestNonstandardServerErrorIsOutsideFallbackPolicy(t *testing.T) {
 	baseten := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(600)
 	}))
@@ -198,16 +198,11 @@ func TestNonstandardServerErrorFallbackRetainsPrimaryTelemetry(t *testing.T) {
 	defer stop()
 
 	resp, body := ttftPost(t, g, `{"model":"claude-opus-4-8","messages":[{"role":"user","content":"ping"}]}`)
-	if resp.StatusCode != http.StatusOK || !strings.Contains(body, "FALLBACK") {
+	if resp.StatusCode != 600 || strings.Contains(body, "FALLBACK") {
 		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
 	}
 	row := waitForRows(t, cfg.TelemetryDir, 1, 2*time.Second)[0]
-	if row.Primary == nil ||
-		row.Primary.Provider != "baseten" ||
-		row.Primary.Model != "zai-org/GLM-5.2" ||
-		!row.Primary.Attempted ||
-		row.Primary.Outcome != telemetry.PrimaryOutcomeHTTPError ||
-		row.Primary.Status == nil || *row.Primary.Status != 600 {
-		t.Fatalf("primary = %+v, want Baseten zai-org/GLM-5.2 HTTP 600", row.Primary)
+	if row.Primary != nil || row.Fallback.Attempted || row.Fallback.Trigger != nil {
+		t.Fatalf("primary/fallback = %+v/%+v, want terminal status 600", row.Primary, row.Fallback)
 	}
 }

--- a/gateway/cmd/gateway/public_catalog_refresh_test.go
+++ b/gateway/cmd/gateway/public_catalog_refresh_test.go
@@ -60,6 +60,7 @@ const publicCatalogGatewayFixture = `{
         "name": "GLM Test",
         "reasoning": true,
         "reasoning_options": [{"type": "toggle"}],
+		"limit": {"context": 1048576, "output": 65536},
         "cost": {"input": 0.3, "output": 0.75}
       }
     }

--- a/gateway/cmd/gateway/subagent_test.go
+++ b/gateway/cmd/gateway/subagent_test.go
@@ -328,15 +328,10 @@ func TestSubagentPassthroughByteIdentical(t *testing.T) {
 	}
 }
 
-// TestSubagentAliasNoSilentFallback extends TestAliasRequestNoSilentFallback:
-// an alias-target subagent rewrite is a single baseten attempt. It never
-// falls back to the configured fallback_route, and it bypasses an active
-// fallback cooldown. The cooldown is established between the two alias
-// requests by a native-model request (no agent-id header) that gets the
-// 503 from the primary and falls back, tripping the cooldown; the second
-// alias request then still goes to the primary (resolveAttemptsLadder
-// returns the explicit alias attempt before the fallbackActive check).
-func TestSubagentAliasNoSilentFallback(t *testing.T) {
+// TestSubagentNativeOriginAliasTargetFallback preserves request ingress
+// provenance: the alias target selects Baseten, while a status fallback and
+// later cooldown bypass replay the original native request model.
+func TestSubagentNativeOriginAliasTargetFallback(t *testing.T) {
 	var primaryHits, fbHits int32
 	basSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&primaryHits, 1)
@@ -358,35 +353,31 @@ func TestSubagentAliasNoSilentFallback(t *testing.T) {
 	stop := start(t, g)
 	defer stop()
 
-	// Subagent alias request: 503 relayed, no fallback.
-	resp, _ := postMessagesWithAgent(t, g, "claude-opus-4-8", "agent-1")
-	if resp.StatusCode != 503 {
-		t.Fatalf("subagent alias request got %d, want the relayed 503", resp.StatusCode)
+	// Subagent alias request: Baseten 503 falls back with the original model.
+	resp, rb := postMessagesWithAgent(t, g, "claude-opus-4-8", "agent-1")
+	if resp.StatusCode != 200 || !strings.Contains(rb, "FALLBACK") {
+		t.Fatalf("subagent alias request got %d: %s, want fallback 200", resp.StatusCode, rb)
 	}
-	if n := atomic.LoadInt32(&fbHits); n != 0 {
-		t.Fatalf("subagent alias request must not fall back; fallback hits = %d", n)
+	if n := atomic.LoadInt32(&fbHits); n != 1 {
+		t.Fatalf("subagent alias fallback hits = %d, want 1", n)
 	}
-	// Native model request (no agent-id header) keeps the fallback path
-	// and trips the cooldown: primary 503 -> fallback 200.
-	resp, rb := postMessagesWithAgent(t, g, "claude-opus-4-8", "")
+	// The status cooldown resolves the next native request independently.
+	resp, rb = postMessagesWithAgent(t, g, "claude-opus-4-8", "")
 	if resp.StatusCode != 200 || !strings.Contains(rb, "FALLBACK") {
 		t.Fatalf("native request got %d: %s, want fallback 200", resp.StatusCode, rb)
 	}
-	if n := atomic.LoadInt32(&fbHits); n != 1 {
-		t.Fatalf("native request should have fallen back once, got %d", n)
+	if n := atomic.LoadInt32(&fbHits); n != 2 {
+		t.Fatalf("fallback hits after native cooldown request = %d, want 2", n)
 	}
-	// Subagent alias request during the now-active cooldown still goes to
-	// baseten: the explicit alias attempt returns before the fallbackActive
-	// check in resolveAttemptsLadder, so the cooldown is bypassed.
-	resp, _ = postMessagesWithAgent(t, g, "claude-opus-4-8", "agent-1")
-	if resp.StatusCode != 503 {
-		t.Fatalf("subagent alias request during cooldown got %d, want 503", resp.StatusCode)
+	resp, rb = postMessagesWithAgent(t, g, "claude-opus-4-8", "agent-1")
+	if resp.StatusCode != 200 || !strings.Contains(rb, "FALLBACK") {
+		t.Fatalf("subagent alias cooldown request got %d: %s, want fallback 200", resp.StatusCode, rb)
 	}
-	if n := atomic.LoadInt32(&fbHits); n != 1 {
-		t.Fatalf("subagent alias during cooldown must not fall back; fallback hits = %d", n)
+	if n := atomic.LoadInt32(&fbHits); n != 3 {
+		t.Fatalf("fallback hits after subagent cooldown request = %d, want 3", n)
 	}
-	if n := atomic.LoadInt32(&primaryHits); n != 3 {
-		t.Fatalf("primary hits = %d, want 3 (two subagent alias + one native)", n)
+	if n := atomic.LoadInt32(&primaryHits); n != 1 {
+		t.Fatalf("primary hits = %d, want 1 before status cooldown", n)
 	}
 }
 

--- a/gateway/cmd/gateway/telemetry_v1_capture.go
+++ b/gateway/cmd/gateway/telemetry_v1_capture.go
@@ -76,6 +76,8 @@ type telemetryCompletionV1 struct {
 	providerStopReason       *string
 	fallbackCount            int
 	fallbackTrigger          *string
+	fallbackSuppressedReason *string
+	fallbackModelSource      *string
 	primary                  *telemetry.PrimaryV1
 	subagent                 bool
 	subagentModel            *string
@@ -363,9 +365,11 @@ func (request telemetryRequestCaptureV1) event(
 		ActualCost:               actual,
 		NativeCounterfactualCost: nativeCounterfactual,
 		Fallback: telemetry.FallbackV1{
-			Attempted: completion.fallbackCount > 0,
-			Count:     completion.fallbackCount,
-			Trigger:   cloneStringPointer(completion.fallbackTrigger),
+			Attempted:        completion.fallbackCount > 0,
+			Count:            completion.fallbackCount,
+			Trigger:          cloneStringPointer(completion.fallbackTrigger),
+			SuppressedReason: cloneStringPointer(completion.fallbackSuppressedReason),
+			ModelSource:      cloneStringPointer(completion.fallbackModelSource),
 		},
 		Primary:           clonePrimaryV1(completion.primary),
 		Subagent:          completion.subagent,
@@ -885,6 +889,12 @@ func (g *Gateway) recordTelemetryV1(
 	completion.fallbackCount = at.fallbackCount
 	if completion.fallbackTrigger == nil && at.fallbackTrigger != "" {
 		completion.fallbackTrigger = stringPointer(at.fallbackTrigger)
+	}
+	if completion.fallbackSuppressedReason == nil && at.fallbackSuppressedReason != "" {
+		completion.fallbackSuppressedReason = stringPointer(at.fallbackSuppressedReason)
+	}
+	if completion.fallbackModelSource == nil && at.fallbackModelSource != "" {
+		completion.fallbackModelSource = stringPointer(at.fallbackModelSource)
 	}
 	if completion.primary == nil {
 		completion.primary = at.primary

--- a/gateway/cmd/gateway/variant_profiles_test.go
+++ b/gateway/cmd/gateway/variant_profiles_test.go
@@ -167,8 +167,8 @@ func TestVariantProfileFallbackPreservesFastForNativeAnthropic(t *testing.T) {
 	assertVariantBetaTokens(t, primaryGot.headers, false)
 
 	fallbackGot := receiveVariantRequest(t, fallbackRequests)
-	if model := fmtString(fallbackGot.body["model"]); model != "claude-opus-5" {
-		t.Fatalf("fallback model = %q, want canonical claude-opus-5", model)
+	if model := fmtString(fallbackGot.body["model"]); model != "claude-opus-5[1m]" {
+		t.Fatalf("fallback model = %q, want exact decorated ingress model", model)
 	}
 	if speed := fmtString(fallbackGot.body["speed"]); speed != "fast" {
 		t.Fatalf("fallback speed = %q, want fast", speed)

--- a/gateway/internal/config/config.go
+++ b/gateway/internal/config/config.go
@@ -146,11 +146,15 @@ type Client struct {
 	// (strip empty text blocks, normalize tool_use ids). Default true;
 	// tri-state so an absent key is distinguishable from explicit false.
 	SanitizeHistory *bool `yaml:"sanitize_history,omitempty" json:"sanitize_history,omitempty"`
-	// FallbackRoute is tried when the primary route's upstream is
-	// unreachable, returns 5xx, or returns 429 for openai-shape traffic.
-	// Anthropic-shape 429 responses relay without fallback. The fallback
-	// must be the native route for protocol_shape.
+	// FallbackRoute is the optional protocol-native target for an eligible
+	// fallback attempt after Baseten. It must be the native route for
+	// protocol_shape.
 	FallbackRoute string `yaml:"fallback_route,omitempty" json:"fallback_route,omitempty"`
+	// NativeFallbackModel is the protocol-native model used only when an
+	// Anthropic-shape request starts with a Baseten-specific identity that the
+	// native provider cannot accept. Native-origin requests preserve their
+	// exact ingress model instead. Empty means no catch-all native target.
+	NativeFallbackModel string `yaml:"native_fallback_model,omitempty" json:"native_fallback_model,omitempty"`
 	// UpstreamShape overrides the wire shape used toward the upstream on
 	// the baseten route. Setting "openai" on an anthropic listener makes
 	// the gateway translate /v1/messages traffic to /v1/chat/completions
@@ -234,7 +238,10 @@ type ModelOptions map[string]map[string]ModelOption
 type Global struct {
 	// RoutingEnabled is intentionally a pointer so validation can
 	// distinguish an explicit false from an omitted required field.
-	RoutingEnabled *bool             `yaml:"routing_enabled,omitempty" json:"routing_enabled,omitempty"`
+	RoutingEnabled *bool `yaml:"routing_enabled,omitempty" json:"routing_enabled,omitempty"`
+	// FallbackPolicy independently controls Baseten HTTP 429 and HTTP 5xx
+	// transitions to a protocol-native fallback. Omitted fields default on.
+	FallbackPolicy *FallbackPolicy   `yaml:"fallback_policy,omitempty" json:"fallback_policy,omitempty"`
 	Auth           map[string]string `yaml:"auth" json:"auth"`
 	TelemetryDir   string            `yaml:"telemetry_dir" json:"telemetry_dir"`
 	// TelemetryEnabled is a pointer so an omitted value retains the
@@ -475,6 +482,9 @@ func ValidateRoutingPolicy(f *File) error {
 		if c.FallbackRoute != "" && c.FallbackRoute != NativeRoute(c.ProtocolShape) {
 			return fmt.Errorf("routing policy: client %q fallback_route %q must be its native route %q", c.Name, c.FallbackRoute, NativeRoute(c.ProtocolShape))
 		}
+		if err := ValidateNativeFallbackModel(c); err != nil {
+			return err
+		}
 		if !c.Enabled {
 			continue
 		}
@@ -658,6 +668,9 @@ func UnmarshalStrict(data []byte, out any) error {
 		if err := validateRawModelPickerNodes(data); err != nil {
 			return err
 		}
+		if err := validateRawFallbackPolicyNodes(data); err != nil {
+			return err
+		}
 	}
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	dec.KnownFields(true)
@@ -670,6 +683,72 @@ func UnmarshalStrict(data []byte, out any) error {
 			return fmt.Errorf("multiple YAML documents are not supported")
 		}
 		return err
+	}
+	return nil
+}
+
+// validateRawFallbackPolicyNodes preserves omission versus explicit null for
+// the optional block and its pointer-boolean children. yaml.v3 otherwise
+// decodes both states to nil, which would silently turn malformed saved intent
+// into the default-on policy.
+func validateRawFallbackPolicyNodes(data []byte) error {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return err
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) != 1 {
+		return nil
+	}
+	if err := validateRawNativeFallbackModelNodes(doc.Content[0]); err != nil {
+		return err
+	}
+	_, global := mappingEntry(doc.Content[0], "global")
+	if global == nil || global.Kind != yaml.MappingNode {
+		return nil
+	}
+	_, policy := mappingEntry(global, "fallback_policy")
+	if policy == nil {
+		return nil
+	}
+	if policy.Kind == yaml.ScalarNode && policy.Tag == "!!null" {
+		return fmt.Errorf("global.fallback_policy must be an object, not null")
+	}
+	if policy.Kind != yaml.MappingNode {
+		return nil
+	}
+	for _, key := range []string{"on_baseten_429", "on_baseten_5xx"} {
+		_, value := mappingEntry(policy, key)
+		if value != nil && value.Kind == yaml.ScalarNode && value.Tag == "!!null" {
+			return fmt.Errorf("global.fallback_policy.%s must be true or false, not null", key)
+		}
+	}
+	return nil
+}
+
+func validateRawNativeFallbackModelNodes(root *yaml.Node) error {
+	_, clients := mappingEntry(root, "clients")
+	if clients == nil || clients.Kind != yaml.SequenceNode {
+		return nil
+	}
+	for _, client := range clients.Content {
+		if client.Kind != yaml.MappingNode {
+			continue
+		}
+		_, nameNode := mappingEntry(client, "name")
+		name := "<unnamed>"
+		if nameNode != nil && nameNode.Kind == yaml.ScalarNode {
+			name = nameNode.Value
+		}
+		_, value := mappingEntry(client, "native_fallback_model")
+		if value == nil {
+			continue
+		}
+		if value.Kind == yaml.ScalarNode && value.Tag == "!!null" {
+			return fmt.Errorf("client %q native_fallback_model must be a full native model ID, not null", name)
+		}
+		if value.Kind == yaml.ScalarNode && strings.TrimSpace(value.Value) == "" {
+			return fmt.Errorf("client %q native_fallback_model must be a full native model ID, not empty", name)
+		}
 	}
 	return nil
 }

--- a/gateway/internal/config/config.go
+++ b/gateway/internal/config/config.go
@@ -106,8 +106,9 @@ type Client struct {
 	ProtocolShape string     `yaml:"protocol_shape,omitempty" json:"protocol_shape,omitempty"`
 	AuthToken     *AuthToken `yaml:"auth_token,omitempty" json:"auth_token,omitempty"`
 	DefaultModel  string     `yaml:"default_model,omitempty" json:"default_model,omitempty"`
-	// ModelAliases maps picker-visible model ids to Baseten slugs for
-	// Claude Code's gateway model discovery (the model-discovery contract).
+	// ModelAliases maps stable picker and request model ids to Baseten slugs.
+	// The gateway also publishes them through Claude Code gateway discovery for
+	// compatibility with older clients (the model-discovery contract).
 	// Anthropic-shape clients only. Alias ids must begin with "claude"
 	// or "anthropic" (the picker drops everything else before caching)
 	// and must not shadow real Anthropic model names;
@@ -115,6 +116,12 @@ type Client struct {
 	// request naming an alias is an explicit Baseten choice. While Off,
 	// the request fails locally without consulting Baseten.
 	ModelAliases map[string]string `yaml:"model_aliases,omitempty" json:"model_aliases,omitempty"`
+	// ModelPicker is the ordered set of configured aliases that Switch projects
+	// into Claude Code's user-level modelPicker setting. It is presentation
+	// state only: model_aliases remains the routing contract. A nil pointer means
+	// the integration has not been configured; a present disabled or empty block
+	// remains explicit saved intent.
+	ModelPicker *ModelPicker `yaml:"model_picker,omitempty" json:"model_picker,omitempty"`
 	// SubagentModel is the rewrite target for Claude Code sidechain
 	// (subagent) requests on an anthropic-shape client: a gateway alias
 	// (must exist in this client's model_aliases), a raw Baseten slug
@@ -166,6 +173,18 @@ type Client struct {
 	// Empty inherits the global value; "0" disables the deadline even
 	// when a global one is set.
 	TTFTTimeout string `yaml:"ttft_timeout,omitempty" json:"ttft_timeout,omitempty"`
+}
+
+// ModelPicker is the Switch-owned desired projection for Claude Code's
+// modelPicker setting.
+type ModelPicker struct {
+	Enabled bool               `yaml:"enabled" json:"enabled"`
+	Models  []ModelPickerModel `yaml:"models" json:"models"`
+}
+
+// ModelPickerModel identifies one picker row by its stable model_aliases key.
+type ModelPickerModel struct {
+	Alias string `yaml:"alias" json:"alias"`
 }
 
 // DoorPort is one harness-facing front-door port. The door forwards to
@@ -439,6 +458,9 @@ func ValidateRoutingPolicy(f *File) error {
 		); err != nil {
 			return err
 		}
+		if err := validateModelPicker(c); err != nil {
+			return err
+		}
 		if c.ResponsesCompatibility != nil && c.ProtocolShape != "openai" {
 			return fmt.Errorf("client %q: responses_compatibility requires protocol_shape openai (got %q)", c.Name, c.ProtocolShape)
 		}
@@ -460,6 +482,54 @@ func ValidateRoutingPolicy(f *File) error {
 		if target == "" || !strings.Contains(target, "/") {
 			return fmt.Errorf("routing policy: enabled client %q requires a Baseten default_model target", c.Name)
 		}
+	}
+	return nil
+}
+
+func validateModelPicker(c Client) error {
+	if c.ModelPicker == nil {
+		return nil
+	}
+	if c.ProtocolShape != "anthropic" {
+		return fmt.Errorf(
+			"client %q: model_picker requires protocol_shape anthropic (got %q)",
+			c.Name,
+			c.ProtocolShape,
+		)
+	}
+	seen := make(map[string]struct{}, len(c.ModelPicker.Models))
+	for i, model := range c.ModelPicker.Models {
+		alias := strings.TrimSpace(model.Alias)
+		if alias == "" {
+			return fmt.Errorf(
+				"client %q: model_picker.models[%d].alias must not be empty",
+				c.Name,
+				i,
+			)
+		}
+		if alias != model.Alias {
+			return fmt.Errorf(
+				"client %q: model_picker.models[%d].alias %q must not contain surrounding whitespace",
+				c.Name,
+				i,
+				model.Alias,
+			)
+		}
+		if _, ok := c.ModelAliases[alias]; !ok {
+			return fmt.Errorf(
+				"client %q: model_picker alias %q is missing from model_aliases",
+				c.Name,
+				alias,
+			)
+		}
+		if _, duplicate := seen[alias]; duplicate {
+			return fmt.Errorf(
+				"client %q: model_picker alias %q is duplicated",
+				c.Name,
+				alias,
+			)
+		}
+		seen[alias] = struct{}{}
 	}
 	return nil
 }
@@ -584,6 +654,11 @@ func Load(path string) (*File, error) {
 // UnmarshalStrict decodes one YAML document and rejects unknown struct
 // fields. This keeps removed schema fields from becoming silent no-ops.
 func UnmarshalStrict(data []byte, out any) error {
+	if _, ok := out.(*File); ok {
+		if err := validateRawModelPickerNodes(data); err != nil {
+			return err
+		}
+	}
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	dec.KnownFields(true)
 	if err := dec.Decode(out); err != nil {
@@ -595,6 +670,34 @@ func UnmarshalStrict(data []byte, out any) error {
 			return fmt.Errorf("multiple YAML documents are not supported")
 		}
 		return err
+	}
+	return nil
+}
+
+// validateRawModelPickerNodes preserves the distinction between an absent
+// model_picker and an explicitly null value. yaml.v3 otherwise decodes both
+// into a nil *ModelPicker, which would turn malformed saved intent into a
+// silent no-op.
+func validateRawModelPickerNodes(data []byte) error {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return err
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) != 1 {
+		return nil
+	}
+	_, clients := mappingEntry(doc.Content[0], "clients")
+	if clients == nil || clients.Kind != yaml.SequenceNode {
+		return nil
+	}
+	for i, client := range clients.Content {
+		_, picker := mappingEntry(client, "model_picker")
+		if picker == nil {
+			continue
+		}
+		if picker.Kind == yaml.ScalarNode && picker.Tag == "!!null" {
+			return fmt.Errorf("clients[%d].model_picker must be an object, not null", i)
+		}
 	}
 	return nil
 }

--- a/gateway/internal/config/edit.go
+++ b/gateway/internal/config/edit.go
@@ -181,6 +181,381 @@ func validateReasoningEditTarget(provider, modelID string) error {
 	return nil
 }
 
+// SetClientModelPicker replaces or removes one client's ordered model_picker
+// subtree while preserving every byte outside that subtree. Existing row
+// nodes are reused by alias so row-attached comments move with reordered rows.
+// A nil picker removes the subtree. The complete edited file is strictly
+// parsed and routing-validated before the original is atomically replaced.
+func SetClientModelPicker(path, clientName string, picker *ModelPicker) error {
+	if strings.TrimSpace(clientName) == "" {
+		return fmt.Errorf("model picker client name cannot be empty")
+	}
+	if picker != nil {
+		for i, model := range picker.Models {
+			if !scalarValueRe.MatchString(model.Alias) {
+				return fmt.Errorf(
+					"invalid model picker alias %q at index %d on client %q",
+					model.Alias,
+					i,
+					clientName,
+				)
+			}
+		}
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	st, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+	var parsed File
+	if err := UnmarshalStrict(b, &parsed); err != nil {
+		return fmt.Errorf("parse %s: %w", path, err)
+	}
+	if err := ValidateRoutingPolicy(&parsed); err != nil {
+		return fmt.Errorf("parse %s: %w", path, err)
+	}
+	client, ok := configClientByName(&parsed, clientName)
+	if !ok {
+		return fmt.Errorf("%s: no client named %q", path, clientName)
+	}
+	currentPicker := cloneModelPicker(client.ModelPicker)
+	client.ModelPicker = cloneModelPicker(picker)
+	if err := ValidateRoutingPolicy(&parsed); err != nil {
+		return fmt.Errorf("client %q model_picker: %w", clientName, err)
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(b, &doc); err != nil {
+		return fmt.Errorf("parse %s: %w", path, err)
+	}
+	item, nameKey, nameVal, err := clientMappingNode(&doc, clientName)
+	if err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	if item.Style == yaml.FlowStyle {
+		return fmt.Errorf(
+			"%s: client %q uses a flow-style mapping; edit model_picker by hand",
+			path,
+			clientName,
+		)
+	}
+	pickerKey, pickerValue := mappingEntry(item, "model_picker")
+	if pickerValue == nil && picker == nil {
+		return nil
+	}
+	if pickerValue != nil {
+		if pickerValue.Kind != yaml.MappingNode || pickerValue.Tag == "!!null" {
+			return fmt.Errorf(
+				"%s: client %q model_picker is not a block mapping",
+				path,
+				clientName,
+			)
+		}
+		if pickerValue.Style == yaml.FlowStyle {
+			return fmt.Errorf(
+				"%s: client %q model_picker is flow-style; edit it by hand",
+				path,
+				clientName,
+			)
+		}
+	}
+
+	var replacement []byte
+	if picker != nil {
+		replacement, err = renderClientModelPicker(pickerKey, pickerValue, picker)
+		if err != nil {
+			return fmt.Errorf("%s: client %q model_picker: %w", path, clientName, err)
+		}
+		if modelPickersEqual(currentPicker, picker) {
+			return nil
+		}
+	}
+	lines := bytes.SplitAfter(b, []byte("\n"))
+	var out []byte
+	if pickerValue == nil {
+		anchorKey, anchorLine := mapBlockAnchor(item, nameKey, nameVal)
+		indent := anchorKey.Column - 1
+		replacement = indentYAMLBlock(replacement, indent, lineEndingFor(lines[anchorLine-1]))
+		out, err = replaceYAMLLines(lines, anchorLine+1, anchorLine, replacement)
+	} else {
+		endLine := yamlNodeLastLine(pickerValue)
+		if endLine < pickerKey.Line {
+			endLine = pickerKey.Line
+		}
+		if picker != nil {
+			replacement = indentYAMLBlock(
+				replacement,
+				pickerKey.Column-1,
+				lineEndingFor(lines[pickerKey.Line-1]),
+			)
+		}
+		out, err = replaceYAMLLines(lines, pickerKey.Line, endLine, replacement)
+	}
+	if err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+
+	var check File
+	if err := UnmarshalStrict(out, &check); err != nil {
+		return fmt.Errorf(
+			"%s: edited config does not parse (edit aborted): %w",
+			path,
+			err,
+		)
+	}
+	if err := ValidateRoutingPolicy(&check); err != nil {
+		return fmt.Errorf(
+			"%s: edited config is invalid (edit aborted): %w",
+			path,
+			err,
+		)
+	}
+	checkClient, ok := configClientByName(&check, clientName)
+	if !ok || !modelPickersEqual(checkClient.ModelPicker, picker) {
+		return fmt.Errorf(
+			"%s: edited client %q model_picker does not match requested state (edit aborted)",
+			path,
+			clientName,
+		)
+	}
+	if bytes.Equal(out, b) {
+		return nil
+	}
+	return writeFileAtomic(path, out, st.Mode().Perm())
+}
+
+func cloneModelPicker(picker *ModelPicker) *ModelPicker {
+	if picker == nil {
+		return nil
+	}
+	clone := &ModelPicker{Enabled: picker.Enabled}
+	clone.Models = append([]ModelPickerModel(nil), picker.Models...)
+	return clone
+}
+
+func modelPickersEqual(a, b *ModelPicker) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	if a.Enabled != b.Enabled || len(a.Models) != len(b.Models) {
+		return false
+	}
+	for i := range a.Models {
+		if a.Models[i] != b.Models[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func clientMappingNode(doc *yaml.Node, clientName string) (*yaml.Node, *yaml.Node, *yaml.Node, error) {
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) != 1 {
+		return nil, nil, nil, fmt.Errorf("not a single-document YAML file")
+	}
+	_, clients := mappingEntry(doc.Content[0], "clients")
+	if clients == nil || clients.Kind != yaml.SequenceNode {
+		return nil, nil, nil, fmt.Errorf("no clients sequence")
+	}
+	for _, item := range clients.Content {
+		nameKey, nameVal := mappingEntry(item, "name")
+		if nameVal != nil && nameVal.Kind == yaml.ScalarNode && nameVal.Value == clientName {
+			return item, nameKey, nameVal, nil
+		}
+	}
+	return nil, nil, nil, fmt.Errorf("no client named %q", clientName)
+}
+
+func renderClientModelPicker(
+	pickerKey *yaml.Node,
+	pickerValue *yaml.Node,
+	picker *ModelPicker,
+) ([]byte, error) {
+	var key, value *yaml.Node
+	if pickerValue == nil {
+		key = yamlScalar("model_picker", "!!str")
+		value = &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	} else {
+		key = cloneYAMLNode(pickerKey)
+		// A comment immediately before model_picker belongs to the surrounding
+		// client block and lies outside the replaced line range.
+		key.HeadComment = ""
+		value = cloneYAMLNode(pickerValue)
+	}
+
+	enabledKey, enabledValue := mappingEntry(value, "enabled")
+	if enabledValue == nil {
+		enabledKey = yamlScalar("enabled", "!!str")
+		enabledValue = yamlScalar(strconv.FormatBool(picker.Enabled), "!!bool")
+	} else {
+		enabledValue.Kind = yaml.ScalarNode
+		enabledValue.Tag = "!!bool"
+		enabledValue.Style = 0
+		enabledValue.Value = strconv.FormatBool(picker.Enabled)
+	}
+
+	modelsKey, modelsValue := mappingEntry(value, "models")
+	if modelsValue == nil {
+		modelsKey = yamlScalar("models", "!!str")
+		modelsValue = &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+	} else if modelsValue.Kind != yaml.SequenceNode {
+		return nil, fmt.Errorf("models is not a sequence")
+	} else if modelsValue.Style == yaml.FlowStyle && len(modelsValue.Content) > 0 {
+		return nil, fmt.Errorf("models is a non-empty flow-style sequence")
+	}
+
+	existing := make(map[string]*yaml.Node, len(modelsValue.Content))
+	for i, row := range modelsValue.Content {
+		if row.Kind != yaml.MappingNode || row.Style == yaml.FlowStyle {
+			return nil, fmt.Errorf("models[%d] is not a block mapping", i)
+		}
+		_, aliasValue := mappingEntry(row, "alias")
+		if aliasValue == nil || aliasValue.Kind != yaml.ScalarNode {
+			return nil, fmt.Errorf("models[%d].alias is not a scalar", i)
+		}
+		if _, duplicate := existing[aliasValue.Value]; duplicate {
+			return nil, fmt.Errorf("alias %q is duplicated", aliasValue.Value)
+		}
+		existing[aliasValue.Value] = row
+	}
+
+	modelsValue.Content = nil
+	for _, model := range picker.Models {
+		row := cloneYAMLNode(existing[model.Alias])
+		if row == nil {
+			row = &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+		}
+		setYAMLMappingString(row, "alias", model.Alias, false)
+		modelsValue.Content = append(modelsValue.Content, row)
+	}
+	if len(modelsValue.Content) == 0 {
+		modelsValue.Style = yaml.FlowStyle
+	} else {
+		modelsValue.Style = 0
+	}
+
+	// The model_picker schema is intentionally narrow. Rebuild the pair order
+	// deterministically while retaining comments carried by existing nodes.
+	value.Content = []*yaml.Node{enabledKey, enabledValue, modelsKey, modelsValue}
+	root := &yaml.Node{
+		Kind: yaml.DocumentNode,
+		Content: []*yaml.Node{{
+			Kind:    yaml.MappingNode,
+			Tag:     "!!map",
+			Content: []*yaml.Node{key, value},
+		}},
+	}
+	var rendered bytes.Buffer
+	enc := yaml.NewEncoder(&rendered)
+	enc.SetIndent(2)
+	if err := enc.Encode(root); err != nil {
+		return nil, fmt.Errorf("render: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("render: %w", err)
+	}
+	return rendered.Bytes(), nil
+}
+
+func yamlScalar(value, tag string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: tag, Value: value}
+}
+
+func cloneYAMLNode(node *yaml.Node) *yaml.Node {
+	if node == nil {
+		return nil
+	}
+	clone := *node
+	clone.Content = make([]*yaml.Node, len(node.Content))
+	for i, child := range node.Content {
+		clone.Content[i] = cloneYAMLNode(child)
+	}
+	return &clone
+}
+
+func setYAMLMappingString(mapping *yaml.Node, key, value string, omitEmpty bool) {
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value != key {
+			continue
+		}
+		if omitEmpty && value == "" {
+			mapping.Content = append(mapping.Content[:i], mapping.Content[i+2:]...)
+			return
+		}
+		node := mapping.Content[i+1]
+		node.Kind = yaml.ScalarNode
+		node.Tag = "!!str"
+		node.Style = 0
+		node.Value = value
+		return
+	}
+	if omitEmpty && value == "" {
+		return
+	}
+	mapping.Content = append(
+		mapping.Content,
+		yamlScalar(key, "!!str"),
+		yamlScalar(value, "!!str"),
+	)
+}
+
+func yamlNodeLastLine(node *yaml.Node) int {
+	if node == nil {
+		return 0
+	}
+	last := node.Line
+	for _, child := range node.Content {
+		if childLast := yamlNodeLastLine(child); childLast > last {
+			last = childLast
+		}
+	}
+	return last
+}
+
+func lineEndingFor(line []byte) []byte {
+	if bytes.HasSuffix(line, []byte("\r\n")) {
+		return []byte("\r\n")
+	}
+	return []byte("\n")
+}
+
+func indentYAMLBlock(block []byte, spaces int, lineEnding []byte) []byte {
+	if len(block) == 0 {
+		return nil
+	}
+	block = bytes.ReplaceAll(block, []byte("\r\n"), []byte("\n"))
+	block = bytes.TrimSuffix(block, []byte("\n"))
+	indent := bytes.Repeat([]byte(" "), spaces)
+	rows := bytes.Split(block, []byte("\n"))
+	var out bytes.Buffer
+	for _, row := range rows {
+		out.Write(indent)
+		out.Write(row)
+		out.Write(lineEnding)
+	}
+	return out.Bytes()
+}
+
+// replaceYAMLLines replaces the inclusive 1-based range start..end. When end
+// is start-1 the replacement is inserted immediately before start.
+func replaceYAMLLines(lines [][]byte, start, end int, replacement []byte) ([]byte, error) {
+	if start < 1 || start > len(lines)+1 || end < start-1 || end > len(lines) {
+		return nil, fmt.Errorf("line range %d..%d is out of bounds", start, end)
+	}
+	var out bytes.Buffer
+	for _, line := range lines[:start-1] {
+		out.Write(line)
+	}
+	out.Write(replacement)
+	for _, line := range lines[end:] {
+		out.Write(line)
+	}
+	return out.Bytes(), nil
+}
+
 func editClientModelReasoningPolicy(
 	path string,
 	clientName string,
@@ -732,6 +1107,29 @@ func SetClientMapEntries(path, clientName, mapKey string, entries map[string]str
 			return fmt.Errorf("invalid value %q for key %q in map %q on client %q", v, k, mapKey, clientName)
 		}
 	}
+	return setClientMapEntries(path, clientName, mapKey, entries)
+}
+
+// SetClientModelAliases adds or replaces alias-to-slug entries in one
+// client's model_aliases mapping. Existing entries not named in entries are
+// preserved. Alias keys and slugs must be safe plain YAML scalars; the edit is
+// comment-preserving, post-validated, and atomically installed.
+func SetClientModelAliases(path, clientName string, entries map[string]string) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	for alias, slug := range entries {
+		if !scalarValueRe.MatchString(alias) {
+			return fmt.Errorf("invalid model alias %q on client %q", alias, clientName)
+		}
+		if !scalarValueRe.MatchString(slug) || !strings.Contains(slug, "/") {
+			return fmt.Errorf("invalid Baseten slug %q for alias %q on client %q", slug, alias, clientName)
+		}
+	}
+	return setClientMapEntries(path, clientName, "model_aliases", entries)
+}
+
+func setClientMapEntries(path, clientName, mapKey string, entries map[string]string) error {
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("read %s: %w", path, err)
@@ -870,6 +1268,8 @@ func mapEntriesVerify(c *Client, mapKey string, set map[string]string, remove ma
 // post-edit verify can read it back.
 func mapFieldValue(c *Client, key string) map[string]string {
 	switch key {
+	case "model_aliases":
+		return c.ModelAliases
 	case "model_routes":
 		return c.ModelRoutes
 	default:

--- a/gateway/internal/config/edit.go
+++ b/gateway/internal/config/edit.go
@@ -1305,6 +1305,8 @@ func scalarFieldValue(c *Client, key string) string {
 		return c.SubagentModel
 	case "subagent_routing":
 		return c.SubagentRouting
+	case "native_fallback_model":
+		return c.NativeFallbackModel
 	case "enabled":
 		// Bool field rendered back to the written token; never "", so
 		// the missing-value check in scalarVerify cannot false-fire.

--- a/gateway/internal/config/fallback_policy.go
+++ b/gateway/internal/config/fallback_policy.go
@@ -1,0 +1,97 @@
+package config
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	// DefaultClaudeNativeFallbackModel is written explicitly for new and
+	// migrated Claude Code configurations. It is not used as a hidden runtime
+	// default, so a later binary cannot silently change installed intent.
+	DefaultClaudeNativeFallbackModel = "claude-opus-5"
+
+	// ManagedCodexCompatibilityModel is a Baseten routing sentinel, never a
+	// protocol-native model. It is repeated here so config validation does not
+	// depend on the gateway command package.
+	ManagedCodexCompatibilityModel = "baseten-switch-compat-v1"
+)
+
+// FallbackPolicy is the optional raw global status policy. Pointer booleans
+// preserve omission, which resolves to true independently for each trigger.
+type FallbackPolicy struct {
+	OnBaseten429 *bool `yaml:"on_baseten_429,omitempty" json:"on_baseten_429,omitempty"`
+	OnBaseten5xx *bool `yaml:"on_baseten_5xx,omitempty" json:"on_baseten_5xx,omitempty"`
+}
+
+// ResolvedFallbackPolicy is the immutable effective status policy carried by
+// the router and projected through the administration status endpoint.
+type ResolvedFallbackPolicy struct {
+	OnBaseten429 bool `json:"on_baseten_429"`
+	OnBaseten5xx bool `json:"on_baseten_5xx"`
+}
+
+// ResolveFallbackPolicy applies the default-on contract independently to an
+// absent block and absent child fields.
+func ResolveFallbackPolicy(raw *FallbackPolicy) ResolvedFallbackPolicy {
+	resolved := ResolvedFallbackPolicy{OnBaseten429: true, OnBaseten5xx: true}
+	if raw == nil {
+		return resolved
+	}
+	if raw.OnBaseten429 != nil {
+		resolved.OnBaseten429 = *raw.OnBaseten429
+	}
+	if raw.OnBaseten5xx != nil {
+		resolved.OnBaseten5xx = *raw.OnBaseten5xx
+	}
+	return resolved
+}
+
+var anthropicNativeModelID = regexp.MustCompile(`^claude-([0-9]|opus|sonnet|haiku|instant|fable|mythos)[A-Za-z0-9._-]*$`)
+
+// IsProtocolNativeModel reports whether a model identifier is safe to send to
+// the protocol-native provider. Anthropic has a stable namespace. OpenAI's
+// namespace is intentionally open, so validation excludes known Baseten and
+// managed identities instead of maintaining a stale closed catalog.
+func IsProtocolNativeModel(protocolShape, model string) bool {
+	if model == "" || model != strings.TrimSpace(model) || strings.Contains(model, "/") {
+		return false
+	}
+	if model == ManagedCodexCompatibilityModel || inGatewayAliasNamespace(model) {
+		return false
+	}
+	if protocolShape == "anthropic" {
+		return anthropicNativeModelID.MatchString(model)
+	}
+	return protocolShape == "openai"
+}
+
+func inGatewayAliasNamespace(model string) bool {
+	return strings.HasPrefix(model, "claude-baseten-") ||
+		strings.HasPrefix(model, "anthropic-baseten-")
+}
+
+// ValidateNativeFallbackModel validates the optional client catch-all target.
+func ValidateNativeFallbackModel(client Client) error {
+	model := client.NativeFallbackModel
+	if model == "" {
+		return nil
+	}
+	if client.FallbackRoute == "" {
+		return fmt.Errorf("routing policy: client %q native_fallback_model requires fallback_route", client.Name)
+	}
+	if client.ProtocolShape != "anthropic" {
+		return fmt.Errorf("routing policy: client %q native_fallback_model is supported only for anthropic-shape clients", client.Name)
+	}
+	if model != strings.TrimSpace(model) {
+		return fmt.Errorf("routing policy: client %q native_fallback_model %q must not contain surrounding whitespace", client.Name, model)
+	}
+	if _, alias := client.ModelAliases[model]; alias {
+		return fmt.Errorf("routing policy: client %q native_fallback_model %q is a configured Baseten alias, not a native model", client.Name, model)
+	}
+	if !IsProtocolNativeModel(client.ProtocolShape, model) {
+		return fmt.Errorf("routing policy: client %q native_fallback_model %q must be a full %s-native model ID", client.Name, model, client.ProtocolShape)
+	}
+	return nil
+}

--- a/gateway/internal/config/fallback_policy_edit.go
+++ b/gateway/internal/config/fallback_policy_edit.go
@@ -1,0 +1,119 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// SetFallbackPolicyTrigger changes one global status trigger while preserving
+// every byte outside the selected scalar or newly inserted policy subtree.
+func SetFallbackPolicyTrigger(path, trigger string, enabled bool) error {
+	key, err := fallbackPolicyKey(trigger)
+	if err != nil {
+		return err
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(b, &doc); err != nil {
+		return fmt.Errorf("parse %s: %w", path, err)
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) != 1 {
+		return fmt.Errorf("%s: not a single-document YAML file", path)
+	}
+	_, global := mappingEntry(doc.Content[0], "global")
+	if global == nil || global.Kind != yaml.MappingNode || global.Style == yaml.FlowStyle {
+		return fmt.Errorf("%s: global must be an editable block mapping", path)
+	}
+	lines := bytes.SplitAfter(b, []byte("\n"))
+	want := "false"
+	if enabled {
+		want = "true"
+	}
+	_, policy := mappingEntry(global, "fallback_policy")
+	var edits []yamlEdit
+	switch {
+	case policy == nil:
+		routingKey, routing := mappingEntry(global, "routing_enabled")
+		anchorLine := global.Line
+		indent := strings.Repeat(" ", global.Column-1+2)
+		if routing != nil {
+			anchorLine = maxNodeLine(routing)
+			indent = strings.Repeat(" ", routingKey.Column-1)
+		}
+		edits = []yamlEdit{{
+			line: anchorLine, insert: true,
+			text: indent + "fallback_policy:\n" + indent + "  " + key + ": " + want,
+		}}
+	case policy.Kind != yaml.MappingNode || policy.Style == yaml.FlowStyle:
+		return fmt.Errorf("%s: global.fallback_policy must be an editable block mapping", path)
+	default:
+		_, value := mappingEntry(policy, key)
+		if value == nil {
+			anchorLine, indent := mappingAppendAnchor(policy)
+			edits = []yamlEdit{{line: anchorLine, insert: true, text: indent + key + ": " + want}}
+		} else {
+			n, lengthErr := scalarTokenLength(lines, value)
+			if lengthErr != nil {
+				return fmt.Errorf("%s: global.fallback_policy.%s: %w", path, key, lengthErr)
+			}
+			edits = []yamlEdit{{line: value.Line, col: value.Column, oldLen: n, text: want}}
+		}
+	}
+	out, err := applyEdits(b, edits)
+	if err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	var check File
+	if err := UnmarshalStrict(out, &check); err != nil {
+		return fmt.Errorf("%s: edited config does not parse (edit aborted): %w", path, err)
+	}
+	resolved := ResolveFallbackPolicy(check.Global.FallbackPolicy)
+	if key == "on_baseten_429" && resolved.OnBaseten429 != enabled ||
+		key == "on_baseten_5xx" && resolved.OnBaseten5xx != enabled {
+		return fmt.Errorf("%s: edited fallback policy did not set %s to %t (edit aborted)", path, key, enabled)
+	}
+	return writeFileAtomic(path, out, info.Mode().Perm())
+}
+
+func fallbackPolicyKey(trigger string) (string, error) {
+	switch trigger {
+	case "429":
+		return "on_baseten_429", nil
+	case "5xx":
+		return "on_baseten_5xx", nil
+	default:
+		return "", fmt.Errorf("unsupported fallback trigger %q (allowed: 429, 5xx)", trigger)
+	}
+}
+
+// SetClientNativeFallbackModel updates one client's Baseten-specific native
+// target through the generic comment-preserving scalar editor.
+func SetClientNativeFallbackModel(path, clientName, model string) error {
+	file, err := Load(path)
+	if err != nil {
+		return err
+	}
+	client, ok := configClientByName(file, clientName)
+	if !ok {
+		return fmt.Errorf("%s: no client named %q", path, clientName)
+	}
+	check := *client
+	check.NativeFallbackModel = model
+	if err := ValidateNativeFallbackModel(check); err != nil {
+		return err
+	}
+	return SetClientScalars(path, clientName, map[string]string{
+		"native_fallback_model": model,
+	})
+}

--- a/gateway/internal/config/fallback_policy_edit_test.go
+++ b/gateway/internal/config/fallback_policy_edit_test.go
@@ -1,0 +1,106 @@
+package config
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func fallbackEditFixture() []byte {
+	return []byte(`# header
+global:
+  routing_enabled: true # keep
+  auth: {}
+clients:
+  - name: claude-code
+    enabled: false
+    protocol_shape: anthropic
+    fallback_route: anthropic # route
+# footer
+`)
+}
+
+func TestSetFallbackPolicyTriggerCreatesAndUpdatesOneField(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gateway.yaml")
+	original := fallbackEditFixture()
+	if err := os.WriteFile(path, original, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := SetFallbackPolicyTrigger(path, "429", false); err != nil {
+		t.Fatal(err)
+	}
+	first, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(first, []byte("  fallback_policy:\n    on_baseten_429: false\n")) {
+		t.Fatalf("created policy is missing:\n%s", first)
+	}
+	if !bytes.Contains(first, []byte("routing_enabled: true # keep")) || !bytes.HasSuffix(first, []byte("# footer\n")) {
+		t.Fatalf("unrelated bytes changed:\n%s", first)
+	}
+	if err := SetFallbackPolicyTrigger(path, "5xx", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := SetFallbackPolicyTrigger(path, "429", true); err != nil {
+		t.Fatal(err)
+	}
+	file, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved := ResolveFallbackPolicy(file.Global.FallbackPolicy)
+	if !resolved.OnBaseten429 || resolved.OnBaseten5xx {
+		t.Fatalf("resolved policy = %+v, want 429 on and 5xx off", resolved)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o640 {
+		t.Fatalf("mode = %o, want 640", info.Mode().Perm())
+	}
+}
+
+func TestSetFallbackPolicyTriggerRejectsInvalidTriggerAndFlowStyle(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gateway.yaml")
+	if err := os.WriteFile(path, fallbackEditFixture(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := SetFallbackPolicyTrigger(path, "500", true); err == nil || !strings.Contains(err.Error(), "allowed: 429, 5xx") {
+		t.Fatalf("invalid trigger error = %v", err)
+	}
+	flow := bytes.Replace(fallbackEditFixture(), []byte("  auth: {}"), []byte("  fallback_policy: {on_baseten_429: true}"), 1)
+	if err := os.WriteFile(path, flow, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := SetFallbackPolicyTrigger(path, "429", false); err == nil || !strings.Contains(err.Error(), "editable block mapping") {
+		t.Fatalf("flow-style error = %v", err)
+	}
+}
+
+func TestSetClientNativeFallbackModelPreservesOtherBytes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gateway.yaml")
+	original := fallbackEditFixture()
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := SetClientNativeFallbackModel(path, "claude-code", DefaultClaudeNativeFallbackModel); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(got, []byte("    native_fallback_model: claude-opus-5\n")) {
+		t.Fatalf("native target was not inserted:\n%s", got)
+	}
+	if !bytes.Contains(got, []byte("fallback_route: anthropic # route")) || !bytes.HasSuffix(got, []byte("# footer\n")) {
+		t.Fatalf("unrelated bytes changed:\n%s", got)
+	}
+	if err := SetClientNativeFallbackModel(path, "claude-code", "opus"); err == nil || !strings.Contains(err.Error(), "full anthropic-native model ID") {
+		t.Fatalf("invalid model error = %v", err)
+	}
+}

--- a/gateway/internal/config/fallback_policy_test.go
+++ b/gateway/internal/config/fallback_policy_test.go
@@ -1,0 +1,130 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func boolPointer(value bool) *bool { return &value }
+
+func TestResolveFallbackPolicyDefaultsIndependently(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  *FallbackPolicy
+		want ResolvedFallbackPolicy
+	}{
+		{"absent", nil, ResolvedFallbackPolicy{OnBaseten429: true, OnBaseten5xx: true}},
+		{"empty", &FallbackPolicy{}, ResolvedFallbackPolicy{OnBaseten429: true, OnBaseten5xx: true}},
+		{"429 off", &FallbackPolicy{OnBaseten429: boolPointer(false)}, ResolvedFallbackPolicy{OnBaseten429: false, OnBaseten5xx: true}},
+		{"5xx off", &FallbackPolicy{OnBaseten5xx: boolPointer(false)}, ResolvedFallbackPolicy{OnBaseten429: true, OnBaseten5xx: false}},
+		{"both off", &FallbackPolicy{OnBaseten429: boolPointer(false), OnBaseten5xx: boolPointer(false)}, ResolvedFallbackPolicy{}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := ResolveFallbackPolicy(test.raw); got != test.want {
+				t.Fatalf("ResolveFallbackPolicy() = %+v, want %+v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestFallbackPolicyRejectsNullAndUnknownValues(t *testing.T) {
+	prefix := "global:\n  routing_enabled: true\n"
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{"null block", prefix + "  fallback_policy: null\n", "must be an object, not null"},
+		{"null 429", prefix + "  fallback_policy:\n    on_baseten_429: null\n", "on_baseten_429 must be true or false, not null"},
+		{"null 5xx", prefix + "  fallback_policy:\n    on_baseten_5xx: null\n", "on_baseten_5xx must be true or false, not null"},
+		{"unknown", prefix + "  fallback_policy:\n    on_timeout: true\n", "field on_timeout not found"},
+		{"wrong type", prefix + "  fallback_policy:\n    on_baseten_429: yes-please\n", "cannot unmarshal"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var file File
+			err := UnmarshalStrict([]byte(test.yaml), &file)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("UnmarshalStrict() error = %v, want containing %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestValidateNativeFallbackModel(t *testing.T) {
+	base := Client{
+		Name:          "claude-code",
+		ProtocolShape: "anthropic",
+		FallbackRoute: "anthropic",
+		ModelAliases: map[string]string{
+			"claude-baseten-glm": "example/GLM",
+		},
+	}
+	tests := []struct {
+		name  string
+		model string
+		alter func(*Client)
+		want  string
+	}{
+		{"valid opus", DefaultClaudeNativeFallbackModel, nil, ""},
+		{"empty optional", "", nil, ""},
+		{"bare family", "opus", nil, "full anthropic-native model ID"},
+		{"raw slug", "example/GLM", nil, "full anthropic-native model ID"},
+		{"configured alias", "claude-baseten-glm", nil, "configured Baseten alias"},
+		{"unknown alias namespace", "claude-baseten-removed", nil, "full anthropic-native model ID"},
+		{"compatibility sentinel", ManagedCodexCompatibilityModel, nil, "full anthropic-native model ID"},
+		{"leading whitespace", " claude-opus-5", nil, "surrounding whitespace"},
+		{"missing route", DefaultClaudeNativeFallbackModel, func(client *Client) { client.FallbackRoute = "" }, "requires fallback_route"},
+		{"wrong native namespace", "gpt-5.6", nil, "full anthropic-native model ID"},
+		{"openai unsupported", "gpt-5.6", func(client *Client) {
+			client.ProtocolShape = "openai"
+			client.FallbackRoute = "openai"
+		}, "supported only for anthropic-shape"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := base
+			client.NativeFallbackModel = test.model
+			if test.alter != nil {
+				test.alter(&client)
+			}
+			err := ValidateNativeFallbackModel(client)
+			if test.want == "" {
+				if err != nil {
+					t.Fatalf("ValidateNativeFallbackModel() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("ValidateNativeFallbackModel() error = %v, want containing %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestNativeFallbackModelRejectsExplicitNullOrEmpty(t *testing.T) {
+	prefix := `global:
+  routing_enabled: true
+clients:
+  - name: claude-code
+    enabled: false
+    protocol_shape: anthropic
+    fallback_route: anthropic
+`
+	for _, test := range []struct {
+		name, value, want string
+	}{
+		{"null", "null", "not null"},
+		{"empty", `""`, "not empty"},
+		{"blank", `"   "`, "not empty"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var file File
+			err := UnmarshalStrict([]byte(prefix+"    native_fallback_model: "+test.value+"\n"), &file)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("UnmarshalStrict() error=%v want containing %q", err, test.want)
+			}
+		})
+	}
+}

--- a/gateway/internal/config/gateway.example.yaml
+++ b/gateway/internal/config/gateway.example.yaml
@@ -57,6 +57,13 @@ clients:
       claude-baseten-glm-5-2:   zai-org/GLM-5.2
       claude-baseten-kimi-k2-7: moonshotai/Kimi-K2.7-Code
       claude-baseten-nemotron:  nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B
+    # Ordered Baseten rows appended to Claude Code's native /model choices.
+    model_picker:
+      enabled: true
+      models:
+        - alias: claude-baseten-glm-5-2
+        - alias: claude-baseten-kimi-k2-7
+        - alias: claude-baseten-nemotron
     # Route Claude Code subagent (sidechain) traffic to a model; toggle with 'baseten-switch claude subagents'. See the subagent-routing contract.
     # subagent_model: claude-baseten-glm-5-2
     # subagent_routing: on

--- a/gateway/internal/config/gateway.example.yaml
+++ b/gateway/internal/config/gateway.example.yaml
@@ -7,6 +7,11 @@ global:
   # One global switch. Off is absolute native passthrough; On applies saved routing policy.
   routing_enabled: true
 
+  # Independent status classes that may transition a Baseten attempt to the native provider.
+  fallback_policy:
+    on_baseten_429: true
+    on_baseten_5xx: true
+
   # The selected Baseten CLI profile supplies OAuth or API-key auth automatically.
   # baseten below is only the explicit environment fallback; see schema.md.
   auth:
@@ -67,9 +72,11 @@ clients:
     # Route Claude Code subagent (sidechain) traffic to a model; toggle with 'baseten-switch claude subagents'. See the subagent-routing contract.
     # subagent_model: claude-baseten-glm-5-2
     # subagent_routing: on
-    # Tried when baseten is unreachable, returns 5xx, or ttft_timeout expires (30s cooldown).
-    # Anthropic 429 responses relay to the harness without fallback or cooldown.
+    # Native provider used after an eligible Baseten attempt fails.
     fallback_route: anthropic
+    # Used only when a Claude request starts with a Baseten alias or raw slug.
+    # Native-origin requests retain the exact model Claude requested.
+    native_fallback_model: claude-opus-5
 
   # codex ships parked (enabled: false; no listener bound); 'baseten-switch codex on' offers to
   # enable it, or set enabled: true and SIGHUP the router yourself.

--- a/gateway/internal/config/inittemplate.go
+++ b/gateway/internal/config/inittemplate.go
@@ -6,7 +6,8 @@ import _ "embed"
 // config init': the single-port door topology (front door on
 // 127.0.0.1:45271 forwarding to the shared router listener on
 // 127.0.0.1:45272, one global routing gate, Claude Code defaulting
-// every model family to GLM-5.2, and a native fallback).
+// every model family to GLM-5.2, an enabled Claude Code model picker, and a
+// native fallback).
 //
 // The embedded file is a byte-for-byte copy of the repo-level
 // config/gateway.example.yaml. go:embed cannot reference files outside

--- a/gateway/internal/config/inittemplate_test.go
+++ b/gateway/internal/config/inittemplate_test.go
@@ -37,6 +37,11 @@ func TestInitTemplateLoads(t *testing.T) {
 	if f.Global.RoutingEnabled == nil || !*f.Global.RoutingEnabled {
 		t.Errorf("global.routing_enabled = %v, want explicit true", f.Global.RoutingEnabled)
 	}
+	if f.Global.FallbackPolicy == nil ||
+		f.Global.FallbackPolicy.OnBaseten429 == nil || !*f.Global.FallbackPolicy.OnBaseten429 ||
+		f.Global.FallbackPolicy.OnBaseten5xx == nil || !*f.Global.FallbackPolicy.OnBaseten5xx {
+		t.Errorf("global.fallback_policy = %+v, want both triggers explicitly true", f.Global.FallbackPolicy)
+	}
 	if f.Global.Auth["baseten"] != "${BASETEN_API_KEY}" {
 		t.Errorf("global.auth.baseten = %q, want ${BASETEN_API_KEY} reference", f.Global.Auth["baseten"])
 	}
@@ -60,6 +65,9 @@ func TestInitTemplateLoads(t *testing.T) {
 	if cc.FallbackRoute != "anthropic" {
 		t.Errorf("fallback route %q, want anthropic", cc.FallbackRoute)
 	}
+	if cc.NativeFallbackModel != DefaultClaudeNativeFallbackModel {
+		t.Errorf("native_fallback_model %q, want %q", cc.NativeFallbackModel, DefaultClaudeNativeFallbackModel)
+	}
 	if !cc.Enabled {
 		t.Errorf("enabled %t, want true", cc.Enabled)
 	}
@@ -81,6 +89,9 @@ func TestInitTemplateLoads(t *testing.T) {
 	}
 	if cx.FallbackRoute != "openai" {
 		t.Errorf("codex fallback route %q, want openai", cx.FallbackRoute)
+	}
+	if cx.NativeFallbackModel != "" {
+		t.Errorf("codex native_fallback_model %q, want empty", cx.NativeFallbackModel)
 	}
 	if cx.DefaultModel != "zai-org/GLM-5.2" {
 		t.Errorf("codex default_model = %q, want zai-org/GLM-5.2", cx.DefaultModel)

--- a/gateway/internal/config/inittemplate_test.go
+++ b/gateway/internal/config/inittemplate_test.go
@@ -107,8 +107,8 @@ func TestInitTemplateLoads(t *testing.T) {
 			t.Errorf("CollectPlaceholders includes CODEX_AUTH_TOKEN from the parked codex client; disabled clients must be exempt from the scan")
 		}
 	}
-	// The canonical configuration keeps the supported gateway-discovery
-	// aliases live.
+	// The canonical configuration keeps stable routing aliases live for the
+	// picker and compatibility discovery paths.
 	wantAliases := map[string]string{
 		"claude-baseten-glm-5-2":   "zai-org/GLM-5.2",
 		"claude-baseten-kimi-k2-7": "moonshotai/Kimi-K2.7-Code",
@@ -120,6 +120,25 @@ func TestInitTemplateLoads(t *testing.T) {
 	for alias, slug := range wantAliases {
 		if cc.ModelAliases[alias] != slug {
 			t.Errorf("model_aliases[%s] = %q, want %q", alias, cc.ModelAliases[alias], slug)
+		}
+	}
+	if cc.ModelPicker == nil || !cc.ModelPicker.Enabled {
+		t.Fatalf("claude-code model_picker = %#v, want explicit enabled picker", cc.ModelPicker)
+	}
+	wantPicker := []ModelPickerModel{
+		{Alias: "claude-baseten-glm-5-2"},
+		{Alias: "claude-baseten-kimi-k2-7"},
+		{Alias: "claude-baseten-nemotron"},
+	}
+	if len(cc.ModelPicker.Models) != len(wantPicker) {
+		t.Fatalf("model_picker.models = %#v, want %#v", cc.ModelPicker.Models, wantPicker)
+	}
+	for i := range wantPicker {
+		if cc.ModelPicker.Models[i] != wantPicker[i] {
+			t.Errorf("model_picker.models[%d] = %#v, want %#v", i, cc.ModelPicker.Models[i], wantPicker[i])
+		}
+		if _, ok := cc.ModelAliases[cc.ModelPicker.Models[i].Alias]; !ok {
+			t.Errorf("model_picker.models[%d].alias %q is absent from model_aliases", i, cc.ModelPicker.Models[i].Alias)
 		}
 	}
 	// subagent_model/subagent_routing ship commented out next to

--- a/gateway/internal/config/model_picker_edit_test.go
+++ b/gateway/internal/config/model_picker_edit_test.go
@@ -1,0 +1,266 @@
+package config
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+const modelPickerEditFixture = `# outside-before
+global:
+  routing_enabled: true
+clients:
+  - name: claude-code
+    enabled: false
+    protocol_shape: anthropic
+    model_aliases:
+      claude-baseten-alpha: example/Alpha
+      claude-baseten-beta: example/Beta
+    model_picker:
+      enabled: true # enabled-comment
+      models:
+        # alpha-comment
+        - alias: claude-baseten-alpha # alpha-inline
+        # beta-comment
+        - alias: claude-baseten-beta # beta-inline
+    fallback_route: anthropic
+# outside-after
+`
+
+func TestSetClientModelPickerReordersRowsWithComments(t *testing.T) {
+	path := writeEditFixture(t, modelPickerEditFixture, 0o640)
+	want := &ModelPicker{
+		Enabled: false,
+		Models: []ModelPickerModel{
+			{Alias: "claude-baseten-beta"},
+			{Alias: "claude-baseten-alpha"},
+		},
+	}
+	if err := SetClientModelPicker(path, "claude-code", want); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.HasPrefix(got, []byte("# outside-before\nglobal:\n")) ||
+		!bytes.HasSuffix(got, []byte("    fallback_route: anthropic\n# outside-after\n")) {
+		t.Fatalf("bytes outside model_picker changed:\n%s", got)
+	}
+	text := string(got)
+	betaComment := strings.Index(text, "# beta-comment")
+	betaRow := strings.Index(text, "alias: claude-baseten-beta")
+	alphaComment := strings.Index(text, "# alpha-comment")
+	alphaRow := strings.Index(text, "alias: claude-baseten-alpha")
+	if betaComment < 0 || betaRow < betaComment || alphaComment < betaRow || alphaRow < alphaComment {
+		t.Fatalf("row comments did not move with reordered rows:\n%s", got)
+	}
+	if !strings.Contains(text, "enabled: false # enabled-comment") {
+		t.Fatalf("enabled inline comment was not preserved:\n%s", got)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateRoutingPolicy(loaded); err != nil {
+		t.Fatal(err)
+	}
+	if !modelPickersEqual(loaded.Clients[0].ModelPicker, want) {
+		t.Fatalf("model_picker = %#v, want %#v", loaded.Clients[0].ModelPicker, want)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o640 {
+		t.Fatalf("mode = %o, want 640", info.Mode().Perm())
+	}
+
+	before := append([]byte(nil), got...)
+	if err := SetClientModelPicker(path, "claude-code", want); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatalf("unchanged picker was not byte-stable\n--- before ---\n%s\n--- after ---\n%s", before, after)
+	}
+}
+
+func TestSetClientModelPickerUnchangedIsByteStable(t *testing.T) {
+	path := writeEditFixture(t, modelPickerEditFixture, 0o600)
+	picker := &ModelPicker{
+		Enabled: true,
+		Models: []ModelPickerModel{
+			{Alias: "claude-baseten-alpha"},
+			{Alias: "claude-baseten-beta"},
+		},
+	}
+	if err := SetClientModelPicker(path, "claude-code", picker); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, []byte(modelPickerEditFixture)) {
+		t.Fatalf("unchanged picker was rewritten\n--- got ---\n%s", got)
+	}
+}
+
+func TestSetClientModelPickerCreatesAndRemovesBlock(t *testing.T) {
+	const fixture = `# keep-before
+global:
+  routing_enabled: true
+clients:
+  - name: claude-code
+    enabled: false
+    protocol_shape: anthropic
+    model_aliases:
+      claude-baseten-alpha: example/Alpha
+    fallback_route: anthropic
+# keep-after
+`
+	path := writeEditFixture(t, fixture, 0o600)
+	picker := &ModelPicker{Enabled: true, Models: []ModelPickerModel{{
+		Alias: "claude-baseten-alpha",
+	}}}
+	if err := SetClientModelPicker(path, "claude-code", picker); err != nil {
+		t.Fatal(err)
+	}
+	created, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(created), "model_picker:\n      enabled: true\n      models:\n        - alias: claude-baseten-alpha") {
+		t.Fatalf("model_picker block not created after model_aliases:\n%s", created)
+	}
+	if err := SetClientModelPicker(path, "claude-code", nil); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(removed, []byte(fixture)) {
+		t.Fatalf("create/remove did not restore fixture byte-for-byte\n--- got ---\n%s\n--- want ---\n%s", removed, fixture)
+	}
+}
+
+func TestSetClientModelPickerRejectsUnsafeStateWithoutWrite(t *testing.T) {
+	cases := []struct {
+		name    string
+		fixture string
+		picker  *ModelPicker
+		want    string
+	}{
+		{
+			name: "flow style picker",
+			fixture: strings.Replace(modelPickerEditFixture,
+				"    model_picker:\n      enabled: true # enabled-comment\n      models:\n        # alpha-comment\n        - alias: claude-baseten-alpha # alpha-inline\n        # beta-comment\n        - alias: claude-baseten-beta # beta-inline\n",
+				"    model_picker: {enabled: true, models: [{alias: claude-baseten-alpha}]}\n", 1),
+			picker: &ModelPicker{Enabled: true, Models: []ModelPickerModel{{Alias: "claude-baseten-alpha"}}},
+			want:   "flow-style",
+		},
+		{
+			name:    "alias not configured",
+			fixture: modelPickerEditFixture,
+			picker: &ModelPicker{Enabled: true, Models: []ModelPickerModel{{
+				Alias: "claude-baseten-missing",
+			}}},
+			want: "missing from model_aliases",
+		},
+		{
+			name:    "unsafe alias scalar",
+			fixture: modelPickerEditFixture,
+			picker: &ModelPicker{Enabled: true, Models: []ModelPickerModel{{
+				Alias: "claude baseten alpha",
+			}}},
+			want: "invalid model picker alias",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeEditFixture(t, tc.fixture, 0o600)
+			before, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = SetClientModelPicker(path, "claude-code", tc.picker)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("SetClientModelPicker() error = %v, want substring %q", err, tc.want)
+			}
+			after, readErr := os.ReadFile(path)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if !bytes.Equal(before, after) {
+				t.Fatalf("file changed on error\n--- before ---\n%s\n--- after ---\n%s", before, after)
+			}
+		})
+	}
+}
+
+func TestSetClientModelAliasesAddsEntryWithoutRewritingExistingMap(t *testing.T) {
+	const fixture = `# keep
+global:
+  routing_enabled: true
+clients:
+  - name: claude-code
+    enabled: false
+    protocol_shape: anthropic
+    model_aliases:
+      claude-baseten-alpha: example/Alpha # keep-inline
+    fallback_route: anthropic
+`
+	path := writeEditFixture(t, fixture, 0o600)
+	if err := SetClientModelAliases(path, "claude-code", map[string]string{
+		"claude-baseten-beta": "example/Beta",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := strings.Replace(
+		fixture,
+		"      claude-baseten-alpha: example/Alpha # keep-inline\n",
+		"      claude-baseten-alpha: example/Alpha # keep-inline\n      claude-baseten-beta: example/Beta\n",
+		1,
+	)
+	if string(got) != want {
+		t.Fatalf("file mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Clients[0].ModelAliases["claude-baseten-beta"] != "example/Beta" {
+		t.Fatalf("model_aliases = %v", loaded.Clients[0].ModelAliases)
+	}
+}
+
+func TestSetClientModelAliasesRejectsUnsafeEntryWithoutWrite(t *testing.T) {
+	path := writeEditFixture(t, modelPickerEditFixture, 0o600)
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = SetClientModelAliases(path, "claude-code", map[string]string{
+		"claude baseten unsafe": "example/Beta",
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid model alias") {
+		t.Fatalf("SetClientModelAliases() error = %v", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("file changed on rejected alias")
+	}
+}

--- a/gateway/internal/config/model_picker_test.go
+++ b/gateway/internal/config/model_picker_test.go
@@ -1,0 +1,124 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func modelPickerPolicyClient(shape string) Client {
+	return Client{
+		Name:          "claude-code",
+		ProtocolShape: shape,
+		ModelAliases: map[string]string{
+			"claude-baseten-alpha": "example/Alpha",
+			"claude-baseten-beta":  "example/Beta",
+		},
+		ModelPicker: &ModelPicker{
+			Enabled: true,
+			Models: []ModelPickerModel{
+				{Alias: "claude-baseten-alpha"},
+				{Alias: "claude-baseten-beta"},
+			},
+		},
+	}
+}
+
+func TestValidateModelPicker(t *testing.T) {
+	enabled := true
+	base := func() *File {
+		return &File{
+			Global:  Global{RoutingEnabled: &enabled},
+			Clients: []Client{modelPickerPolicyClient("anthropic")},
+		}
+	}
+
+	t.Run("valid ordered rows", func(t *testing.T) {
+		if err := ValidateRoutingPolicy(base()); err != nil {
+			t.Fatalf("ValidateRoutingPolicy() error = %v", err)
+		}
+	})
+
+	cases := []struct {
+		name string
+		edit func(*Client)
+		want string
+	}{
+		{
+			name: "wrong protocol shape",
+			edit: func(c *Client) { c.ProtocolShape = "openai" },
+			want: "requires protocol_shape anthropic",
+		},
+		{
+			name: "missing alias",
+			edit: func(c *Client) { c.ModelPicker.Models[0].Alias = "claude-baseten-missing" },
+			want: "missing from model_aliases",
+		},
+		{
+			name: "duplicate alias",
+			edit: func(c *Client) { c.ModelPicker.Models[1].Alias = c.ModelPicker.Models[0].Alias },
+			want: "is duplicated",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			file := base()
+			tc.edit(&file.Clients[0])
+			err := ValidateRoutingPolicy(file)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("ValidateRoutingPolicy() error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestModelPickerStrictParsing(t *testing.T) {
+	const prefix = `global:
+  routing_enabled: true
+clients:
+  - name: claude-code
+    enabled: false
+    protocol_shape: anthropic
+    model_aliases:
+      claude-baseten-alpha: example/Alpha
+`
+	cases := []struct {
+		name string
+		tail string
+		want string
+	}{
+		{
+			name: "null subtree",
+			tail: "    model_picker: null\n",
+			want: "model_picker must be an object, not null",
+		},
+		{
+			name: "unknown row field",
+			tail: "    model_picker:\n      enabled: true\n      models:\n        - alias: claude-baseten-alpha\n          custom_label: no\n",
+			want: "field custom_label not found",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var file File
+			err := UnmarshalStrict([]byte(prefix+tc.tail), &file)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("UnmarshalStrict() error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+
+	var absent File
+	if err := UnmarshalStrict([]byte(prefix), &absent); err != nil {
+		t.Fatal(err)
+	}
+	if absent.Clients[0].ModelPicker != nil {
+		t.Fatalf("absent model_picker parsed as %#v", absent.Clients[0].ModelPicker)
+	}
+	var disabled File
+	if err := UnmarshalStrict([]byte(prefix+"    model_picker:\n      enabled: false\n      models: []\n"), &disabled); err != nil {
+		t.Fatal(err)
+	}
+	if disabled.Clients[0].ModelPicker == nil || disabled.Clients[0].ModelPicker.Enabled {
+		t.Fatalf("explicit disabled model_picker parsed as %#v", disabled.Clients[0].ModelPicker)
+	}
+}

--- a/gateway/internal/pricing/catalog.go
+++ b/gateway/internal/pricing/catalog.go
@@ -147,6 +147,7 @@ type ModelRecord struct {
 	CanonicalModelID string                                 `json:"canonical_model_id"`
 	DisplayName      string                                 `json:"display_name"`
 	Family           string                                 `json:"family,omitempty"`
+	ReleaseDate      string                                 `json:"release_date,omitempty"`
 	ContextTokens    int64                                  `json:"context_tokens,omitempty"`
 	MaxOutputTokens  int64                                  `json:"max_output_tokens,omitempty"`
 	Availability     ModelAvailability                      `json:"availability"`
@@ -232,6 +233,11 @@ func validateModelRecord(record ModelRecord) error {
 		sanitizeCatalogFamily(record.Family) != record.Family {
 		return fmt.Errorf("family %q is invalid", record.Family)
 	}
+	if record.ReleaseDate != "" {
+		if !validModelReleaseDate(record.ReleaseDate) {
+			return fmt.Errorf("release_date %q is invalid", record.ReleaseDate)
+		}
+	}
 	if record.ContextTokens < 0 || record.MaxOutputTokens < 0 {
 		return fmt.Errorf("model limits must be nonnegative")
 	}
@@ -304,6 +310,16 @@ func validateModelRecord(record ModelRecord) error {
 		}
 	}
 	return nil
+}
+
+func validModelReleaseDate(value string) bool {
+	for _, layout := range []string{time.DateOnly, "2006-01"} {
+		parsed, err := time.Parse(layout, value)
+		if err == nil && parsed.Format(layout) == value {
+			return true
+		}
+	}
+	return false
 }
 
 func validateModelModalities(modalities ModelModalities) error {
@@ -743,6 +759,7 @@ func cloneModelRecord(record ModelRecord) ModelRecord {
 	out.CanonicalModelID = strings.Clone(record.CanonicalModelID)
 	out.DisplayName = strings.Clone(record.DisplayName)
 	out.Family = strings.Clone(record.Family)
+	out.ReleaseDate = strings.Clone(record.ReleaseDate)
 	out.Provenance = cloneProvenance(record.Provenance)
 	if record.Availability.Public != nil {
 		evidence := *record.Availability.Public
@@ -1043,6 +1060,9 @@ func mergeModelRecord(lower, higher ModelRecord) ModelRecord {
 		if preferFamilyMetadata(lower.Provenance, higher.Provenance) {
 			out.Family = higher.Family
 		}
+	}
+	if higher.ReleaseDate != "" {
+		out.ReleaseDate = higher.ReleaseDate
 	}
 	if higher.ContextTokens != 0 && providerMetadataWins {
 		out.ContextTokens = higher.ContextTokens

--- a/gateway/internal/pricing/modelsdev.go
+++ b/gateway/internal/pricing/modelsdev.go
@@ -31,6 +31,7 @@ type modelsDevModel struct {
 	ID               string          `json:"id"`
 	Name             string          `json:"name"`
 	Family           string          `json:"family"`
+	ReleaseDate      string          `json:"release_date"`
 	Status           string          `json:"status"`
 	Reasoning        json.RawMessage `json:"reasoning"`
 	ReasoningOptions json.RawMessage `json:"reasoning_options"`
@@ -122,8 +123,11 @@ func withoutCachedModelsDev(catalog providerCatalog) (providerCatalog, bool) {
 			record.Modalities = nil
 		}
 		// Family currently has record-level rather than field-level provenance.
-		// models.dev is the only runtime-cache source that supplies it.
+		// Family and release date currently have record-level rather than
+		// field-level provenance. models.dev is the only runtime-cache source
+		// that supplies them.
 		record.Family = ""
+		record.ReleaseDate = ""
 		catalog.models[id] = record
 	}
 	if len(catalog.models) == 0 {
@@ -364,6 +368,7 @@ func parseModelsDevModel(
 	record := ModelRecord{
 		Provider: provider, CanonicalModelID: id, DisplayName: name,
 		Family:        normalizeModelsDevFamily(provider, source.Family, id),
+		ReleaseDate:   strings.TrimSpace(source.ReleaseDate),
 		ContextTokens: source.Limit.Context, MaxOutputTokens: source.Limit.Output,
 		Availability: ModelAvailability{
 			Public: &AvailabilityEvidence{

--- a/gateway/internal/pricing/modelsdev_test.go
+++ b/gateway/internal/pricing/modelsdev_test.go
@@ -16,6 +16,7 @@ const modelsDevFixture = `{
         "id": "claude-opus-5",
         "name": "Claude Opus 5",
         "family": "claude-opus",
+        "release_date": "2026-07-24",
         "limit": {"context": 1000000, "output": 128000},
         "cost": {"input": 5, "output": 25, "cache_read": 0.5, "cache_write": 6.25},
         "experimental": {
@@ -34,6 +35,7 @@ const modelsDevFixture = `{
         "id": "claude-sonnet-5",
         "name": "Claude Sonnet 5",
         "family": "claude-sonnet",
+        "release_date": "2026-06-29",
         "limit": {"context": 1000000, "output": 128000},
         "cost": {"input": 2, "output": 10, "cache_read": 0.2, "cache_write": 2.5}
       }
@@ -162,7 +164,8 @@ func TestReplaceModelsDevPublishesProviderScopedProfiles(t *testing.T) {
 	if !ok {
 		t.Fatal("Opus record missing")
 	}
-	if record.Family != "opus" || record.ContextTokens != 1_000_000 ||
+	if record.Family != "opus" || record.ReleaseDate != "2026-07-24" ||
+		record.ContextTokens != 1_000_000 ||
 		record.MaxOutputTokens != 128_000 {
 		t.Fatalf("Opus metadata = %+v", record)
 	}
@@ -1013,6 +1016,42 @@ func TestModelsDevInvalidCandidateRetainsLastKnownGood(t *testing.T) {
 	}
 }
 
+func TestModelsDevRejectsInvalidReleaseDate(t *testing.T) {
+	bad := strings.Replace(
+		modelsDevFixture,
+		`"release_date": "2026-07-24"`,
+		`"release_date": "2026-7-24"`,
+		1,
+	)
+	if err := New().ReplaceModelsDev(
+		[]byte(bad), time.Now().UTC(), "",
+	); err == nil || !strings.Contains(err.Error(), "release_date") {
+		t.Fatalf("invalid release date error = %v", err)
+	}
+}
+
+func TestModelsDevAcceptsMonthReleaseDate(t *testing.T) {
+	fixture := strings.Replace(
+		modelsDevFixture,
+		`"release_date": "2026-07-24"`,
+		`"release_date": "2026-07"`,
+		1,
+	)
+	catalog := New()
+	if err := catalog.ReplaceModelsDev(
+		[]byte(fixture), time.Now().UTC(), "",
+	); err != nil {
+		t.Fatal(err)
+	}
+	record, ok := catalog.Capture().Model(
+		ProviderAnthropic,
+		"claude-opus-5",
+	)
+	if !ok || record.ReleaseDate != "2026-07" {
+		t.Fatalf("month-precision release date = %q, found=%t", record.ReleaseDate, ok)
+	}
+}
+
 func TestModelsDevAnthropicFamilyNormalizationAdaptsToNewFamilies(t *testing.T) {
 	tests := []struct {
 		family string
@@ -1124,7 +1163,8 @@ func TestProviderCacheRoundTripAndLivePrecedence(t *testing.T) {
 		t.Fatalf("restored account availability = %+v, found=%t", record, ok)
 	}
 	if record.ContextTokens != 900_000 ||
-		record.DisplayName != "Account Opus" {
+		record.DisplayName != "Account Opus" ||
+		record.ReleaseDate != "2026-07-24" {
 		t.Fatalf("restored provider metadata authority = %+v", record)
 	}
 	if err := restored.ReplaceProviderAvailability(

--- a/gateway/internal/telemetry/event_v1.go
+++ b/gateway/internal/telemetry/event_v1.go
@@ -236,9 +236,11 @@ type CostSnapshotV1 struct {
 }
 
 type FallbackV1 struct {
-	Attempted bool    `json:"attempted"`
-	Count     int     `json:"count"`
-	Trigger   *string `json:"trigger"`
+	Attempted        bool    `json:"attempted"`
+	Count            int     `json:"count"`
+	Trigger          *string `json:"trigger"`
+	SuppressedReason *string `json:"suppressed_reason,omitempty"`
+	ModelSource      *string `json:"model_source,omitempty"`
 }
 
 // PrimaryV1 preserves the bounded outcome of the planned primary route when
@@ -317,6 +319,19 @@ func (e EventV1) Validate() error {
 		return errors.New("telemetry fallback count must be nonnegative")
 	case !e.Fallback.Attempted && e.Fallback.Count != 0:
 		return errors.New("telemetry fallback count requires attempted=true")
+	case e.Fallback.Attempted && e.Fallback.SuppressedReason != nil:
+		return errors.New("telemetry attempted fallback cannot record a suppression reason")
+	case !e.Fallback.Attempted && e.Fallback.ModelSource != nil:
+		return errors.New("telemetry fallback model source requires attempted=true")
+	case e.Fallback.SuppressedReason != nil &&
+		*e.Fallback.SuppressedReason != "policy_disabled_http_429" &&
+		*e.Fallback.SuppressedReason != "policy_disabled_http_5xx" &&
+		*e.Fallback.SuppressedReason != "native_target_unconfigured":
+		return fmt.Errorf("telemetry fallback suppressed_reason = %q is invalid", *e.Fallback.SuppressedReason)
+	case e.Fallback.ModelSource != nil &&
+		*e.Fallback.ModelSource != "original_request" &&
+		*e.Fallback.ModelSource != "configured_target":
+		return fmt.Errorf("telemetry fallback model_source = %q is invalid", *e.Fallback.ModelSource)
 	case e.Primary != nil && !e.Fallback.Attempted:
 		return errors.New("telemetry primary summary requires fallback attempted=true")
 	case e.ToolCalls < 0:
@@ -337,7 +352,9 @@ func (e EventV1) Validate() error {
 		switch {
 		case e.EffectiveProvider != "anthropic":
 			return errors.New("telemetry classified Auto request requires effective_provider=anthropic")
-		case e.Fallback.Attempted || e.Fallback.Count != 0 || e.Fallback.Trigger != nil:
+		case e.Fallback.Attempted || e.Fallback.Count != 0 ||
+			e.Fallback.Trigger != nil || e.Fallback.SuppressedReason != nil ||
+			e.Fallback.ModelSource != nil:
 			return errors.New("telemetry classified Auto request cannot record fallback")
 		case e.Primary != nil:
 			return errors.New("telemetry classified Auto request cannot record a primary attempt")

--- a/gateway/internal/telemetry/event_v1_test.go
+++ b/gateway/internal/telemetry/event_v1_test.go
@@ -9,6 +9,8 @@ import (
 
 func int64Pointer(value int64) *int64 { return &value }
 
+func stringPointer(value string) *string { return &value }
+
 func TestNewEventID(t *testing.T) {
 	first, err := NewEventID()
 	if err != nil {
@@ -704,6 +706,38 @@ func TestEventV1Validation(t *testing.T) {
 				event.Fallback.Count = 1
 			},
 			wantErr: "requires attempted",
+		},
+		{
+			name: "attempted fallback with suppression",
+			mutate: func(event *EventV1) {
+				event.Fallback.Attempted = true
+				event.Fallback.Count = 1
+				event.Fallback.SuppressedReason = stringPointer("policy_disabled_http_429")
+			},
+			wantErr: "cannot record a suppression reason",
+		},
+		{
+			name: "model source without attempted fallback",
+			mutate: func(event *EventV1) {
+				event.Fallback.ModelSource = stringPointer("original_request")
+			},
+			wantErr: "model source requires attempted=true",
+		},
+		{
+			name: "invalid fallback suppression reason",
+			mutate: func(event *EventV1) {
+				event.Fallback.SuppressedReason = stringPointer("disabled")
+			},
+			wantErr: "suppressed_reason",
+		},
+		{
+			name: "invalid fallback model source",
+			mutate: func(event *EventV1) {
+				event.Fallback.Attempted = true
+				event.Fallback.Count = 1
+				event.Fallback.ModelSource = stringPointer("rewritten")
+			},
+			wantErr: "model_source",
 		},
 		{
 			name: "zero context budget",

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/AXHierarchyFixtures.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/AXHierarchyFixtures.swift
@@ -24,6 +24,8 @@ struct AXHierarchyFixtureView: View {
     let level: AXHierarchyFixtureLevel
     @State private var selection: String? = "overview"
     @State private var enabled = true
+    @State private var rateLimitsEnabled = true
+    @State private var serverErrorsEnabled = true
     @State private var model = "GLM-5.2"
 
     @ViewBuilder
@@ -134,6 +136,14 @@ struct AXHierarchyFixtureView: View {
             } detail: {
                 Form {
                     Toggle("Global Routing", isOn: $enabled)
+                    Toggle(
+                        "Rate limits (HTTP 429)",
+                        isOn: $rateLimitsEnabled)
+                        .accessibilityIdentifier("fallback-policy-429")
+                    Toggle(
+                        "Server errors (HTTP 5xx)",
+                        isOn: $serverErrorsEnabled)
+                        .accessibilityIdentifier("fallback-policy-5xx")
                     Picker("Model", selection: $model) {
                         Text("GLM-5.2").tag("GLM-5.2")
                         Text("Native Provider").tag("native")

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/BasetenSwitchState.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/BasetenSwitchState.swift
@@ -101,6 +101,14 @@ final class BasetenSwitchState: ObservableObject {
     @Published private(set) var pendingCodexRoute: PendingControlMutation?
     @Published private(set) var pendingSubagents: [String: PendingControlMutation] = [:]
     @Published private(set) var pendingReasoning: PendingReasoningMutation?
+    @Published private(set) var pendingClaudeModelPicker:
+        PendingClaudeModelPickerMutation?
+    @Published private(set) var claudeModelPickerNotice: String?
+    @Published private(set) var claudeModelPickerWarnings: [String] = []
+    @Published private(set) var claudeModelPickerDiagnostics:
+        ClaudeModelPickerDiagnostics?
+    @Published private(set) var claudeModelPickerDiagnosticsLoading = false
+    @Published private(set) var claudeModelPickerDiagnosticsError: String?
     @Published private(set) var reasoningWarnings: [String: String] = [:]
     @Published private(set) var mutationRecoveryState: MutationRecoveryState
 
@@ -121,6 +129,7 @@ final class BasetenSwitchState: ObservableObject {
     private var clientPageRefreshTask: Task<Void, Never>?
     private var clientPageRefreshPending = false
     private var modelCatalogTask: Task<Void, Never>?
+    private var claudeModelPickerDiagnosticsTask: Task<Void, Never>?
     private var modelCatalogGeneration: UInt64 = 0
     private var refreshingModelCatalog: [LiveModelCatalogEntry]?
     private var automaticCatalogRecoveryGeneration: UInt64?
@@ -272,6 +281,8 @@ final class BasetenSwitchState: ObservableObject {
         clientPageRefreshTask = nil
         clientPageRefreshPending = false
         invalidateModelCatalog()
+        claudeModelPickerDiagnosticsTask?.cancel()
+        claudeModelPickerDiagnosticsTask = nil
         mutationRecoveryTask?.cancel()
         mutationRecoveryTask = nil
         Task { await pollCoordinator?.stop() }
@@ -626,6 +637,45 @@ final class BasetenSwitchState: ObservableObject {
     func ensureModelCatalogLoaded() {
         guard case .idle = liveModelCatalogState else { return }
         requestModelCatalogRefresh()
+    }
+
+    func ensureClaudeModelPickerDiagnosticsLoaded() {
+        guard claudeModelPickerDiagnostics == nil,
+              !claudeModelPickerDiagnosticsLoading else { return }
+        requestClaudeModelPickerDiagnosticsRefresh()
+    }
+
+    func requestClaudeModelPickerDiagnosticsRefresh() {
+        guard claudeModelPickerDiagnosticsTask == nil else { return }
+        claudeModelPickerDiagnosticsLoading = true
+        claudeModelPickerDiagnosticsError = nil
+        claudeModelPickerDiagnosticsTask = Task { [weak self] in
+            await self?.refreshClaudeModelPickerDiagnostics()
+            self?.claudeModelPickerDiagnosticsTask = nil
+        }
+    }
+
+    func waitForClaudeModelPickerDiagnosticsRefresh() async {
+        await claudeModelPickerDiagnosticsTask?.value
+    }
+
+    private func refreshClaudeModelPickerDiagnostics() async {
+        let result = await executeCLI(
+            ["claude", "picker", "status", "--json"],
+            timeout: 10)
+        guard !result.timedOut,
+              result.status == 0 || result.status == 3,
+              let diagnostics = ClaudeModelPickerDiagnostics(
+                json: result.standardOutput) else {
+            claudeModelPickerDiagnosticsLoading = false
+            claudeModelPickerDiagnosticsError = result.timedOut
+                ? "Checking the Claude picker status timed out."
+                : "Switch could not read the Claude picker status."
+            return
+        }
+        claudeModelPickerDiagnostics = diagnostics
+        claudeModelPickerDiagnosticsLoading = false
+        claudeModelPickerDiagnosticsError = nil
     }
 
     func routerWindowDidClose() {
@@ -1224,6 +1274,292 @@ final class BasetenSwitchState: ObservableObject {
         await setSubagents(client, choice: choice)
     }
 
+    // MARK: - Claude model picker
+
+    func claudeModelPickerProjection(
+        for client: ClientStatus
+    ) -> ClaudeModelPickerProjection {
+        projectClaudeModelPicker(
+            status: client.modelPicker,
+            liveState: liveModelCatalogState)
+    }
+
+    var canMutateClaudeModelPicker: Bool {
+        guard gatewayUp,
+              canMutate,
+              mutationRecoveryAllowsRouting,
+              let snapshot = routingSnapshot else { return false }
+        return snapshot.token.isAuthoritative
+            && snapshot.token.activeGeneration > 0
+            && snapshot.desiredMatchesActive
+    }
+
+    var claudeModelPickerMutationDisabledReason: String? {
+        if let pendingClaudeModelPicker {
+            return "\(pendingClaudeModelPicker.kind.progressLabel) is still in progress."
+        }
+        guard gatewayUp else { return "The local gateway is unavailable." }
+        guard canMutate else { return runtimeTrustError }
+        if let recoveryReason = mutationRecoveryDisabledReason {
+            return recoveryReason
+        }
+        guard let snapshot = routingSnapshot,
+              snapshot.token.isAuthoritative,
+              snapshot.token.activeGeneration > 0 else {
+            return "Update the local gateway before changing the model picker."
+        }
+        guard snapshot.desiredMatchesActive else {
+            return "The saved and active configurations differ. Resolve the reload error first."
+        }
+        return nil
+    }
+
+    func previewClaudeModelPickerAdd(
+        slug: String,
+        alias: String? = nil
+    ) async -> ClaudeModelPickerAddPreviewOutcome? {
+        guard canMutateClaudeModelPicker,
+              modelCatalogAllowsMutation,
+              pendingClaudeModelPicker == nil else {
+            return nil
+        }
+        var arguments = [
+            "claude", "picker", "add", slug,
+            "--dry-run", "--json",
+        ]
+        if let alias {
+            arguments += ["--alias", alias]
+        }
+        let result = await executeCLI(arguments, timeout: 10)
+        guard let outcome = ClaudeModelPickerAddPreviewOutcome(
+            json: result.standardOutput,
+            status: result.status,
+            explicitAlias: alias) else {
+            lastError = result.timedOut
+                ? "The model picker preview timed out."
+                : "Switch could not generate a safe model picker preview."
+            return nil
+        }
+        if case .preview(let preview, _) = outcome,
+           preview.slug != slug {
+            lastError = "Switch returned a model picker preview for a different model."
+            return nil
+        }
+        lastError = nil
+        return outcome
+    }
+
+    func previewClaudeModelPickerEnable()
+        async -> ClaudeModelPickerEnablePreview? {
+        guard canMutateClaudeModelPicker,
+              pendingClaudeModelPicker == nil else {
+            return nil
+        }
+        let result = await executeCLI(
+            [
+                "claude", "picker", "enable",
+                "--dry-run", "--json",
+            ],
+            timeout: 10)
+        guard result.succeeded,
+              let preview = ClaudeModelPickerEnablePreview(
+                json: result.standardOutput) else {
+            lastError = result.timedOut
+                ? "The model picker setup preview timed out."
+                : "Switch could not generate a safe model picker setup preview."
+            return nil
+        }
+        lastError = nil
+        return preview
+    }
+
+    func requestClaudeModelPicker(
+        _ kind: ClaudeModelPickerMutationKind
+    ) {
+        guard beginClaudeModelPickerMutation(kind) else { return }
+        Task { await finishClaudeModelPickerMutation(kind) }
+    }
+
+    func setClaudeModelPicker(
+        _ kind: ClaudeModelPickerMutationKind
+    ) async {
+        guard beginClaudeModelPickerMutation(kind) else { return }
+        await finishClaudeModelPickerMutation(kind)
+    }
+
+    private func beginClaudeModelPickerMutation(
+        _ kind: ClaudeModelPickerMutationKind
+    ) -> Bool {
+        guard canMutateClaudeModelPicker,
+              pendingClaudeModelPicker == nil else { return false }
+        if case .add = kind, !modelCatalogAllowsMutation {
+            lastError = "Refresh the Baseten model catalog before adding a model."
+            return false
+        }
+        let operationID = UUID().uuidString.lowercased()
+        pendingClaudeModelPicker = PendingClaudeModelPickerMutation(
+            operationID: operationID,
+            kind: kind,
+            phase: .applying)
+        claudeModelPickerNotice = nil
+        claudeModelPickerWarnings = []
+        scheduleReconciling(
+            key: "claude-model-picker",
+            operationID: operationID)
+        return true
+    }
+
+    private func finishClaudeModelPickerMutation(
+        _ kind: ClaudeModelPickerMutationKind
+    ) async {
+        guard let pending = pendingClaudeModelPicker,
+              pending.kind == kind,
+              let snapshot = routingSnapshot else { return }
+        let arguments = mutationArguments(
+            operationID: pending.operationID,
+            snapshot: snapshot,
+            command: kind.command)
+        let primaryResult = await executeCLI(arguments, timeout: 30)
+        let primaryReceipt = GlobalMutationReceipt(
+            json: primaryResult.standardOutput)
+        let primaryIdentityMatches = claudeModelPickerReceiptMatches(
+            primaryReceipt,
+            operationID: pending.operationID,
+            kind: kind)
+
+        var finalResult = primaryResult
+        var finalReceipt = primaryReceipt
+        var finalReceiptIdentityMatches = primaryIdentityMatches
+        var settingsSyncRecovered = false
+        let reconciliationAction = primaryReceipt?.reconciliationAction ?? ""
+        let manualResolutionRequired = primaryIdentityMatches
+            && primaryReceipt?.reconciliationRequired == true
+            && (
+                reconciliationAction == "manual_claude_settings_resolution"
+                    || reconciliationAction
+                        == "mutation_reconcile_then_manual_claude_settings_resolution"
+            )
+        var routerReconciledBeforeManualResolution = false
+        if manualResolutionRequired,
+           reconciliationAction
+            == "mutation_reconcile_then_manual_claude_settings_resolution" {
+            markReconciling(operationID: pending.operationID)
+            let reconciled = await executeCLI(
+                [
+                    "--json", "mutation", "reconcile",
+                    pending.operationID,
+                ],
+                timeout: 10)
+            let reconciledReceipt = GlobalMutationReceipt(
+                json: reconciled.standardOutput)
+            routerReconciledBeforeManualResolution = reconciled.succeeded
+                && primaryReceipt?.identityStrength == "exact"
+                && reconciledReceipt?.identityStrength == "exact"
+                && isValidMutationRequestFingerprint(
+                    primaryReceipt?.requestFingerprint ?? "")
+                && primaryReceipt?.requestFingerprint
+                    == reconciledReceipt?.requestFingerprint
+                && claudeModelPickerReceiptMatches(
+                    reconciledReceipt,
+                    operationID: pending.operationID,
+                    kind: kind)
+                && reconciledReceipt?.ok == true
+                && reconciledReceipt?.reconciliationRequired == false
+                && reconciledReceipt?.cleanupPending == false
+            if routerReconciledBeforeManualResolution {
+                await refreshAfterMutation()
+            } else {
+                retainMutationRecoveryGate(
+                    reconciledReceipt ?? primaryReceipt)
+            }
+        } else if primaryIdentityMatches,
+           primaryReceipt?.applied == true,
+           primaryReceipt?.reconciliationRequired == true,
+           reconciliationAction == "claude_picker_sync",
+           primaryReceipt?.errorCode == "settings_sync_failed" {
+            markReconciling(operationID: pending.operationID)
+            await refreshAfterMutation()
+            if let updatedSnapshot = routingSnapshot,
+               !snapshotIsStale,
+               claudeModelPickerMutationConfirmed(
+                    kind,
+                    status: clients.first(where: {
+                        $0.name == "claude-code"
+                    })?.modelPicker) {
+                let syncOperationID = UUID().uuidString.lowercased()
+                let syncArguments = mutationArguments(
+                    operationID: syncOperationID,
+                    snapshot: updatedSnapshot,
+                    command: ClaudeModelPickerMutationKind.sync(
+                        convertReplacementMode:
+                            kind.convertsReplacementMode).command)
+                finalResult = await executeCLI(
+                    syncArguments,
+                    timeout: 30)
+                finalReceipt = GlobalMutationReceipt(
+                    json: finalResult.standardOutput)
+                finalReceiptIdentityMatches = claudeModelPickerReceiptMatches(
+                    finalReceipt,
+                    operationID: syncOperationID,
+                    kind: .sync(
+                        convertReplacementMode:
+                            kind.convertsReplacementMode))
+                settingsSyncRecovered = finalReceiptIdentityMatches
+                    && finalReceipt?.ok == true
+                    && finalReceipt?.applied == true
+                    && finalReceipt?.reconciliationRequired == false
+            }
+        }
+        await refreshAfterMutation()
+        await refreshClaudeModelPickerDiagnostics()
+
+        let receipt = finalReceipt
+        let updatedPicker = clients.first(where: {
+            $0.name == "claude-code"
+        })?.modelPicker
+        let primarySucceeded = primaryResult.succeeded
+            && primaryReceipt?.ok == true
+            && primaryReceipt?.applied == true
+            && primaryReceipt?.reconciliationRequired == false
+            && primaryIdentityMatches
+        let operationSucceeded = primarySucceeded || settingsSyncRecovered
+        let hashesMatch = kind.isSync || hashesConfirm(receipt)
+        let confirmed = !snapshotIsStale
+            && finalResult.succeeded
+            && operationSucceeded
+            && hashesMatch
+            && claudeModelPickerMutationConfirmed(
+                kind,
+                status: updatedPicker)
+        claudeModelPickerWarnings = finalReceiptIdentityMatches
+            ? receipt?.warnings ?? []
+            : []
+        if manualResolutionRequired {
+            claudeModelPickerNotice = nil
+            if reconciliationAction
+                == "mutation_reconcile_then_manual_claude_settings_resolution",
+               !routerReconciledBeforeManualResolution {
+                lastError = "Router configuration reconciliation is still pending. Resolve it before manually repairing Claude Code's model picker settings."
+            } else {
+                lastError = "The routing configuration is current, but Claude Code's model picker settings need manual resolution. Resolve the settings conflict, then refresh."
+            }
+        } else if confirmed {
+            lastError = nil
+            claudeModelPickerNotice = claudeModelPickerSuccessMessage(kind)
+        } else {
+            claudeModelPickerNotice = nil
+            lastError = primaryResult.timedOut
+                ? "The Claude Code model picker change timed out and could not be confirmed."
+                : mutationFailureMessage(
+                    receipt,
+                    fallback: "The Claude Code model picker change was not confirmed in the active configuration.")
+        }
+        clearPending(
+            key: "claude-model-picker",
+            operationID: pending.operationID)
+        pendingClaudeModelPicker = nil
+    }
+
     // MARK: - Client reasoning configuration
 
     var canMutateReasoning: Bool {
@@ -1669,6 +2005,9 @@ final class BasetenSwitchState: ObservableObject {
         if pendingReasoning?.operationID == operationID {
             pendingReasoning?.phase = .reconciling
         }
+        if pendingClaudeModelPicker?.operationID == operationID {
+            pendingClaudeModelPicker?.phase = .reconciling
+        }
     }
 
     private func mutationFailureMessage(
@@ -1840,6 +2179,9 @@ final class BasetenSwitchState: ObservableObject {
             } else if key == "reasoning",
                       self.pendingReasoning?.operationID == operationID {
                 self.pendingReasoning?.phase = .reconciling
+            } else if key == "claude-model-picker",
+                      self.pendingClaudeModelPicker?.operationID == operationID {
+                self.pendingClaudeModelPicker?.phase = .reconciling
             }
         }
     }

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/BasetenSwitchState.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/BasetenSwitchState.swift
@@ -29,6 +29,25 @@ struct PendingGlobalRouting: Equatable, Sendable {
     var phase: MutationPhase
 }
 
+enum FallbackPolicyTrigger: String, Equatable, Sendable {
+    case http429 = "429"
+    case http5xx = "5xx"
+}
+
+struct PendingFallbackPolicyMutation: Equatable, Sendable {
+    let operationID: String
+    let trigger: FallbackPolicyTrigger
+    let requested: Bool
+    var phase: MutationPhase
+}
+
+struct PendingBasetenModelFallbackMutation: Equatable, Sendable {
+    let operationID: String
+    let client: String
+    let requestedModel: String
+    var phase: MutationPhase
+}
+
 struct PendingControlMutation: Equatable, Sendable {
     let operationID: String
     let requestedTarget: String
@@ -97,6 +116,10 @@ final class BasetenSwitchState: ObservableObject {
     @Published private(set) var reauthenticating = false
     @Published private(set) var runtimeTrust: RuntimeTrust
     @Published private(set) var pendingGlobalRouting: PendingGlobalRouting?
+    @Published private(set) var pendingFallbackPolicy:
+        PendingFallbackPolicyMutation?
+    @Published private(set) var pendingBasetenModelFallback:
+        PendingBasetenModelFallbackMutation?
     @Published private(set) var pendingFamilyRoutes: [String: PendingControlMutation] = [:]
     @Published private(set) var pendingCodexRoute: PendingControlMutation?
     @Published private(set) var pendingSubagents: [String: PendingControlMutation] = [:]
@@ -157,6 +180,40 @@ final class BasetenSwitchState: ObservableObject {
     }
     var globalMutationPhase: MutationPhase? {
         pendingGlobalRouting?.phase
+    }
+    var confirmedFallbackPolicy: FallbackPolicyStatus? {
+        routingSnapshot?.fallbackPolicy
+    }
+    var displayedFallback429: Bool {
+        if pendingFallbackPolicy?.trigger == .http429 {
+            return pendingFallbackPolicy?.requested ?? false
+        }
+        return confirmedFallbackPolicy?.onBaseten429 ?? false
+    }
+    var displayedFallback5xx: Bool {
+        if pendingFallbackPolicy?.trigger == .http5xx {
+            return pendingFallbackPolicy?.requested ?? false
+        }
+        return confirmedFallbackPolicy?.onBaseten5xx ?? false
+    }
+    var fallbackPolicyWarningVisible: Bool {
+        displayedFallback429 || displayedFallback5xx
+    }
+    var fallbackPolicyUnavailableMessage: String? {
+        automaticFallbackUnavailableMessage(
+            supportsFallbackPolicy:
+                routingSnapshot?.supportsFallbackPolicy == true,
+            policy: routingSnapshot?.fallbackPolicy)
+    }
+    var hasAnyConfigMutation: Bool {
+        pendingGlobalRouting != nil
+            || pendingFallbackPolicy != nil
+            || pendingBasetenModelFallback != nil
+            || !pendingFamilyRoutes.isEmpty
+            || pendingCodexRoute != nil
+            || !pendingSubagents.isEmpty
+            || pendingReasoning != nil
+            || pendingClaudeModelPicker != nil
     }
     var hasFallback: Bool {
         clients.contains { $0.enabled && $0.fallbackActive }
@@ -260,6 +317,10 @@ final class BasetenSwitchState: ObservableObject {
                 version: fixture.routerVersion,
                 uptimeSeconds: fixture.uptimeSeconds,
                 globalRoutingEnabled: globalRoutingState(fixture.clients) != .off,
+                capabilities: ["global_routing", "fallback_policy"],
+                fallbackPolicy: FallbackPolicyStatus(
+                    onBaseten429: true,
+                    onBaseten5xx: true),
                 auth: fixture.auth,
                 clients: fixture.clients)
         } else {
@@ -869,10 +930,233 @@ final class BasetenSwitchState: ObservableObject {
               canMutate,
               mutationRecoveryAllowsRouting,
               let snapshot = routingSnapshot else { return false }
-        return snapshot.supportsGlobalRouting
+        return pendingFallbackPolicy == nil
+            && pendingBasetenModelFallback == nil
+            && snapshot.supportsGlobalRouting
             && snapshot.token.isAuthoritative
             && snapshot.token.activeGeneration > 0
             && snapshot.desiredMatchesActive
+    }
+
+    // MARK: - Automatic fallback
+
+    var canMutateFallbackSettings: Bool {
+        guard gatewayUp,
+              canMutate,
+              mutationRecoveryAllowsRouting,
+              !hasAnyConfigMutation,
+              let snapshot = routingSnapshot else { return false }
+        return snapshot.supportsFallbackPolicy
+            && snapshot.fallbackPolicy != nil
+            && snapshot.token.isAuthoritative
+            && snapshot.token.activeGeneration > 0
+            && snapshot.desiredMatchesActive
+    }
+
+    var fallbackPolicyMutationDisabledReason: String? {
+        if let pendingFallbackPolicy {
+            let state = pendingFallbackPolicy.requested ? "On" : "Off"
+            return "Waiting for the gateway to confirm the "
+                + pendingFallbackPolicy.trigger.rawValue
+                + " setting as " + state + "."
+        }
+        if pendingBasetenModelFallback != nil || hasAnyConfigMutation {
+            return "Another configuration change is still in progress."
+        }
+        guard gatewayUp else { return "The local gateway is unavailable." }
+        guard canMutate else { return runtimeTrustError }
+        if let recoveryReason = mutationRecoveryDisabledReason {
+            return recoveryReason
+        }
+        guard let snapshot = routingSnapshot,
+              snapshot.supportsFallbackPolicy,
+              snapshot.fallbackPolicy != nil else {
+            return "Update the local gateway to configure automatic fallback."
+        }
+        guard snapshot.desiredMatchesActive else {
+            return "The saved and active configurations differ. Resolve the reload error first."
+        }
+        return nil
+    }
+
+    func requestFallbackPolicy(
+        _ trigger: FallbackPolicyTrigger,
+        enabled: Bool
+    ) {
+        Task { await setFallbackPolicy(trigger, enabled: enabled) }
+    }
+
+    func setFallbackPolicy(
+        _ trigger: FallbackPolicyTrigger,
+        enabled: Bool
+    ) async {
+        guard canMutateFallbackSettings else { return }
+        let confirmed = trigger == .http429
+            ? confirmedFallbackPolicy?.onBaseten429
+            : confirmedFallbackPolicy?.onBaseten5xx
+        guard confirmed != enabled else { return }
+        let operationID = UUID().uuidString.lowercased()
+        pendingFallbackPolicy = PendingFallbackPolicyMutation(
+            operationID: operationID,
+            trigger: trigger,
+            requested: enabled,
+            phase: .applying)
+        scheduleReconciling(
+            key: "fallback-policy",
+            operationID: operationID)
+
+        // A fresh read barrier prevents two quick changes from reusing stale
+        // active-token and config-hash preconditions.
+        await refreshAfterMutation()
+        guard pendingFallbackPolicy?.operationID == operationID,
+              let snapshot = routingSnapshot,
+              !snapshotIsStale,
+              snapshot.supportsFallbackPolicy,
+              snapshot.desiredMatchesActive else {
+            lastError = "Automatic fallback settings changed before this request could start. Refresh and try again."
+            clearFallbackPolicyMutation(operationID: operationID)
+            return
+        }
+        let requestedTarget = enabled ? "on" : "off"
+        let arguments = mutationArguments(
+            operationID: operationID,
+            snapshot: snapshot,
+            command: fallbackPolicyDispatchArgs(
+                trigger: trigger,
+                enabled: enabled))
+        let attempt = await executePolicyMutation(
+            arguments,
+            operationID: operationID,
+            requestIdentity: PolicyMutationRequestIdentity(
+                operation: "set_fallback_policy",
+                client: "",
+                key: trigger.rawValue,
+                requestedTarget: requestedTarget))
+        await refreshAfterMutation()
+        let policy = routingSnapshot?.fallbackPolicy
+        let activeValue = trigger == .http429
+            ? policy?.onBaseten429
+            : policy?.onBaseten5xx
+        let receipt = attempt.receipt
+        let confirmedMutation = !snapshotIsStale
+            && attempt.result.succeeded
+            && receipt?.ok == true
+            && receipt?.operationID == operationID
+            && receipt?.operation == "set_fallback_policy"
+            && receiptRequestIdentityConfirms(
+                receipt,
+                key: trigger.rawValue,
+                requestedTarget: requestedTarget,
+                verifiedTerminalReplay: attempt.verifiedTerminalReplay)
+            && receipt?.requested == enabled
+            && receipt?.applied == true
+            && activeValue == enabled
+            && hashesConfirm(receipt)
+        if confirmedMutation {
+            lastError = nil
+        } else {
+            lastError = attempt.primaryTimedOut
+                ? "The automatic fallback change timed out and could not be confirmed."
+                : mutationFailureMessage(
+                    receipt,
+                    fallback: "The automatic fallback change was not present in the active gateway state.")
+        }
+        clearFallbackPolicyMutation(operationID: operationID)
+    }
+
+    private func clearFallbackPolicyMutation(operationID: String) {
+        guard pendingFallbackPolicy?.operationID == operationID else { return }
+        clearPending(key: "fallback-policy", operationID: operationID)
+        pendingFallbackPolicy = nil
+    }
+
+    func requestBasetenModelFallback(
+        client: String,
+        model: String
+    ) {
+        Task { await setBasetenModelFallback(client: client, model: model) }
+    }
+
+    func setBasetenModelFallback(
+        client: String,
+        model: String
+    ) async {
+        let trimmed = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard canMutateFallbackSettings,
+              client == "claude-code",
+              isAcceptedClaudeNativeModelID(trimmed),
+              clients.first(where: { $0.name == client })?
+                .basetenModelFallback?.resolvedModel != trimmed else { return }
+        let operationID = UUID().uuidString.lowercased()
+        pendingBasetenModelFallback = PendingBasetenModelFallbackMutation(
+            operationID: operationID,
+            client: client,
+            requestedModel: trimmed,
+            phase: .applying)
+        scheduleReconciling(
+            key: "baseten-model-fallback",
+            operationID: operationID)
+        await refreshAfterMutation()
+        guard pendingBasetenModelFallback?.operationID == operationID,
+              let snapshot = routingSnapshot,
+              !snapshotIsStale,
+              snapshot.supportsFallbackPolicy,
+              snapshot.desiredMatchesActive else {
+            lastError = "The fallback target changed before this request could start. Refresh and try again."
+            clearBasetenModelFallbackMutation(operationID: operationID)
+            return
+        }
+        let arguments = mutationArguments(
+            operationID: operationID,
+            snapshot: snapshot,
+            command: basetenModelFallbackDispatchArgs(
+                client: client,
+                model: trimmed))
+        let attempt = await executePolicyMutation(
+            arguments,
+            operationID: operationID,
+            requestIdentity: PolicyMutationRequestIdentity(
+                operation: "set_native_fallback_model",
+                client: client,
+                key: "native_fallback_model",
+                requestedTarget: trimmed))
+        await refreshAfterMutation()
+        let receipt = attempt.receipt
+        let confirmedMutation = !snapshotIsStale
+            && attempt.result.succeeded
+            && receipt?.ok == true
+            && receipt?.operationID == operationID
+            && receipt?.operation == "set_native_fallback_model"
+            && receipt?.client == client
+            && receiptRequestIdentityConfirms(
+                receipt,
+                key: "native_fallback_model",
+                requestedTarget: trimmed,
+                verifiedTerminalReplay: attempt.verifiedTerminalReplay)
+            && receipt?.applied == true
+            && hashesConfirm(receipt)
+            && clients.first(where: { $0.name == client })?
+                .basetenModelFallback?.resolvedModel == trimmed
+        if confirmedMutation {
+            lastError = nil
+        } else {
+            lastError = attempt.primaryTimedOut
+                ? "The fallback target change timed out and could not be confirmed."
+                : mutationFailureMessage(
+                    receipt,
+                    fallback: "The fallback target was not present in the active gateway state.")
+        }
+        clearBasetenModelFallbackMutation(operationID: operationID)
+    }
+
+    private func clearBasetenModelFallbackMutation(operationID: String) {
+        guard pendingBasetenModelFallback?.operationID == operationID else {
+            return
+        }
+        clearPending(
+            key: "baseten-model-fallback",
+            operationID: operationID)
+        pendingBasetenModelFallback = nil
     }
 
     var routingMutationDisabledReason: String? {
@@ -1289,7 +1573,9 @@ final class BasetenSwitchState: ObservableObject {
               canMutate,
               mutationRecoveryAllowsRouting,
               let snapshot = routingSnapshot else { return false }
-        return snapshot.token.isAuthoritative
+        return pendingFallbackPolicy == nil
+            && pendingBasetenModelFallback == nil
+            && snapshot.token.isAuthoritative
             && snapshot.token.activeGeneration > 0
             && snapshot.desiredMatchesActive
     }
@@ -1567,7 +1853,9 @@ final class BasetenSwitchState: ObservableObject {
               canMutate,
               mutationRecoveryAllowsRouting,
               let snapshot = routingSnapshot else { return false }
-        return snapshot.token.isAuthoritative
+        return pendingFallbackPolicy == nil
+            && pendingBasetenModelFallback == nil
+            && snapshot.token.isAuthoritative
             && snapshot.token.activeGeneration > 0
             && snapshot.desiredMatchesActive
     }
@@ -1991,6 +2279,12 @@ final class BasetenSwitchState: ObservableObject {
         if pendingGlobalRouting?.operationID == operationID {
             pendingGlobalRouting?.phase = .reconciling
         }
+        if pendingFallbackPolicy?.operationID == operationID {
+            pendingFallbackPolicy?.phase = .reconciling
+        }
+        if pendingBasetenModelFallback?.operationID == operationID {
+            pendingBasetenModelFallback?.phase = .reconciling
+        }
         for key in pendingFamilyRoutes.keys
         where pendingFamilyRoutes[key]?.operationID == operationID {
             pendingFamilyRoutes[key]?.phase = .reconciling
@@ -2165,6 +2459,12 @@ final class BasetenSwitchState: ObservableObject {
             if key == "global",
                self.pendingGlobalRouting?.operationID == operationID {
                 self.pendingGlobalRouting?.phase = .reconciling
+            } else if key == "fallback-policy",
+                      self.pendingFallbackPolicy?.operationID == operationID {
+                self.pendingFallbackPolicy?.phase = .reconciling
+            } else if key == "baseten-model-fallback",
+                      self.pendingBasetenModelFallback?.operationID == operationID {
+                self.pendingBasetenModelFallback?.phase = .reconciling
             } else if key.hasPrefix("family:"),
                       self.pendingFamilyRoutes[key]?.operationID == operationID {
                 self.pendingFamilyRoutes[key]?.phase = .reconciling
@@ -2295,9 +2595,56 @@ func routingPresentationEqual(_ lhs: RoutingSnapshot,
         && lhs.configPath == rhs.configPath
         && lhs.capabilities == rhs.capabilities
         && lhs.globalRoutingEnabled == rhs.globalRoutingEnabled
+        && lhs.fallbackPolicy == rhs.fallbackPolicy
         && lhs.reload == rhs.reload
         && lhs.auth == rhs.auth
         && lhs.clients == rhs.clients
+}
+
+func isAcceptedClaudeNativeModelID(_ model: String) -> Bool {
+    guard model == model.trimmingCharacters(in: .whitespacesAndNewlines),
+          model.hasPrefix("claude-") else { return false }
+    let suffix = String(model.dropFirst("claude-".count))
+    guard let first = suffix.unicodeScalars.first else { return false }
+    let startsWithAllowedFamily = [
+        "opus", "sonnet", "haiku", "instant", "fable", "mythos",
+    ].contains(where: suffix.hasPrefix)
+    guard (48...57).contains(first.value)
+            || startsWithAllowedFamily else { return false }
+    return suffix.unicodeScalars.allSatisfy { scalar in
+        let value = scalar.value
+        return (48...57).contains(value)
+            || (65...90).contains(value)
+            || (97...122).contains(value)
+            || value == 46 || value == 95 || value == 45
+    }
+}
+
+func fallbackPolicyDispatchArgs(
+    trigger: FallbackPolicyTrigger,
+    enabled: Bool
+) -> [String] {
+    [
+        "config", "fallback", trigger.rawValue,
+        enabled ? "on" : "off",
+    ]
+}
+
+func automaticFallbackUnavailableMessage(
+    supportsFallbackPolicy: Bool,
+    policy: FallbackPolicyStatus?
+) -> String? {
+    guard supportsFallbackPolicy, policy != nil else {
+        return "Update the local gateway to configure automatic fallback."
+    }
+    return nil
+}
+
+func basetenModelFallbackDispatchArgs(
+    client: String,
+    model: String
+) -> [String] {
+    ["config", "fallback", "model", client, model]
 }
 
 func projectedUptimeSeconds(snapshot: RoutingSnapshot?,

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/BasetenSwitchState.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/BasetenSwitchState.swift
@@ -196,9 +196,6 @@ final class BasetenSwitchState: ObservableObject {
         }
         return confirmedFallbackPolicy?.onBaseten5xx ?? false
     }
-    var fallbackPolicyWarningVisible: Bool {
-        displayedFallback429 || displayedFallback5xx
-    }
     var fallbackPolicyUnavailableMessage: String? {
         automaticFallbackUnavailableMessage(
             supportsFallbackPolicy:
@@ -1621,9 +1618,15 @@ final class BasetenSwitchState: ObservableObject {
             json: result.standardOutput,
             status: result.status,
             explicitAlias: alias) else {
-            lastError = result.timedOut
-                ? "The model picker preview timed out."
-                : "Switch could not generate a safe model picker preview."
+            if result.timedOut {
+                lastError = "The model picker preview timed out."
+            } else if let failure = ClaudeModelPickerContextMinimumFailure(
+                json: result.standardOutput,
+                status: result.status) {
+                lastError = failure.message
+            } else {
+                lastError = "Switch could not generate a safe model picker preview."
+            }
             return nil
         }
         if case .preview(let preview, _) = outcome,
@@ -1650,9 +1653,15 @@ final class BasetenSwitchState: ObservableObject {
         guard result.succeeded,
               let preview = ClaudeModelPickerEnablePreview(
                 json: result.standardOutput) else {
-            lastError = result.timedOut
-                ? "The model picker setup preview timed out."
-                : "Switch could not generate a safe model picker setup preview."
+            if result.timedOut {
+                lastError = "The model picker setup preview timed out."
+            } else if let failure = ClaudeModelPickerContextMinimumFailure(
+                json: result.standardOutput,
+                status: result.status) {
+                lastError = failure.message
+            } else {
+                lastError = "Switch could not generate a safe model picker setup preview."
+            }
             return nil
         }
         lastError = nil
@@ -1834,11 +1843,17 @@ final class BasetenSwitchState: ObservableObject {
             claudeModelPickerNotice = claudeModelPickerSuccessMessage(kind)
         } else {
             claudeModelPickerNotice = nil
-            lastError = primaryResult.timedOut
-                ? "The Claude Code model picker change timed out and could not be confirmed."
-                : mutationFailureMessage(
+            if primaryResult.timedOut {
+                lastError = "The Claude Code model picker change timed out and could not be confirmed."
+            } else if let failure = ClaudeModelPickerContextMinimumFailure(
+                json: finalResult.standardOutput,
+                status: finalResult.status) {
+                lastError = failure.message
+            } else {
+                lastError = mutationFailureMessage(
                     receipt,
                     fallback: "The Claude Code model picker change was not confirmed in the active configuration.")
+            }
         }
         clearPending(
             key: "claude-model-picker",

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/ClaudeModelPicker.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/ClaudeModelPicker.swift
@@ -72,6 +72,100 @@ enum ClaudeModelPickerMutationKind: Equatable, Sendable {
     }
 }
 
+func basetenFallbackTargetStatusLine(
+    fallback: BasetenModelFallbackStatus?,
+    policy: FallbackPolicyStatus?,
+    desiredMatchesActive: Bool,
+    supportsFallbackPolicy: Bool
+) -> String {
+    let readiness: String
+    if !supportsFallbackPolicy {
+        readiness = "Unavailable"
+    } else if !desiredMatchesActive {
+        readiness = "Needs reload"
+    } else if fallback?.ready == true {
+        readiness = "Ready"
+    } else {
+        readiness = "Not ready"
+    }
+    guard let policy else { return readiness + " · Policy unavailable" }
+    return readiness
+        + " · 429 " + (policy.onBaseten429 ? "On" : "Off")
+        + " · 5xx " + (policy.onBaseten5xx ? "On" : "Off")
+}
+
+func basetenFallbackTargetReadinessDetail(
+    fallback: BasetenModelFallbackStatus?,
+    desiredMatchesActive: Bool,
+    supportsFallbackPolicy: Bool
+) -> String? {
+    guard supportsFallbackPolicy else {
+        return "Update the local gateway to configure automatic fallback."
+    }
+    guard desiredMatchesActive else {
+        return "The saved and active configurations differ. Resolve the reload error first."
+    }
+    guard let fallback else {
+        return "Fallback target status is unavailable."
+    }
+    switch fallback.reason {
+    case nil where fallback.ready:
+        return nil
+    case "not_configured":
+        return "A fallback target is not configured."
+    case "provider_auth_unavailable":
+        return "Anthropic authentication is unavailable to the local gateway."
+    case "desired_active_mismatch":
+        return "The saved fallback target is not active yet."
+    case "unsupported_router":
+        return "Update the local gateway to configure this fallback target."
+    default:
+        return fallback.ready
+            ? nil
+            : "The fallback target is not ready."
+    }
+}
+
+struct ClaudeNativeFallbackOption: Equatable, Sendable {
+    let label: String
+    let model: String
+}
+
+func claudeNativeFallbackOptions(
+    client: ClientStatus
+) -> [ClaudeNativeFallbackOption] {
+    var options: [ClaudeNativeFallbackOption] = []
+    if let current = client.basetenModelFallback?.resolvedModel,
+       isAcceptedClaudeNativeModelID(current) {
+        let displayName = client.basetenModelFallback?.displayName ?? ""
+        options.append(ClaudeNativeFallbackOption(
+            label: displayName.isEmpty
+                ? claudeNativeModelLabel(current)
+                : displayName,
+            model: current))
+    }
+    for available in client.basetenModelFallback?.availableModels ?? []
+    where isAcceptedClaudeNativeModelID(available.model) {
+        options.append(ClaudeNativeFallbackOption(
+            label: available.displayName.isEmpty
+                ? claudeNativeModelLabel(available.model)
+                : available.displayName,
+            model: available.model))
+    }
+    var seen = Set<String>()
+    return options.filter { option in
+        seen.insert(option.model).inserted
+    }
+}
+
+func claudeNativeModelLabel(_ model: String) -> String {
+    for family in ["fable", "opus", "sonnet", "haiku"]
+    where model.contains("-" + family + "-") {
+        return family.prefix(1).uppercased() + family.dropFirst()
+    }
+    return model
+}
+
 struct PendingClaudeModelPickerMutation: Equatable, Sendable {
     let operationID: String
     let kind: ClaudeModelPickerMutationKind
@@ -440,6 +534,8 @@ struct ClaudeModelPickerSectionView: View {
     @State private var previewError: String?
     @State private var previewingSlug: String?
     @State private var previewingEnable = false
+    @State private var showsFallbackTargetEditor = false
+    @State private var fallbackTargetDraft = ""
 
     var body: some View {
         RoutingSectionCard {
@@ -475,6 +571,8 @@ struct ClaudeModelPickerSectionView: View {
 
                 diagnosticsSection
 
+                basetenFallbackSection
+                Divider()
                 configuredSection
                 Divider()
                 availableSection
@@ -543,6 +641,163 @@ struct ClaudeModelPickerSectionView: View {
                 EmptyView()
             }
         }
+        .sheet(isPresented: $showsFallbackTargetEditor) {
+            fallbackTargetEditor
+        }
+    }
+
+    private var basetenFallbackSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Fallback for Baseten models")
+                        .font(.subheadline.weight(.semibold))
+                    Text(displayedFallbackTarget)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+                Spacer()
+                Text(displayedFallbackName)
+                    .font(.callout.weight(.medium))
+                if state.pendingBasetenModelFallback != nil {
+                    ProgressView()
+                        .controlSize(.small)
+                        .accessibilityLabel("Changing fallback target")
+                }
+                Button("Change") {
+                    guard !isPreview else { return }
+                    fallbackTargetDraft = fallbackTargetOptions.first(where: {
+                        $0.model == displayedFallbackTarget
+                    })?.model ?? fallbackTargetOptions.first?.model ?? ""
+                    showsFallbackTargetEditor = true
+                }
+                .disabled(!canEditFallbackTarget)
+                .accessibilityIdentifier("claude-fallback-target-change")
+            }
+            Text("Used when a Baseten model returns a rate limit or server error and Automatic Fallback is enabled.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Text(fallbackTargetStatusLine)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(fallbackTargetStatusColor)
+                .accessibilityIdentifier("claude-fallback-target-status")
+            if let detail = fallbackTargetReadinessDetail {
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .accessibilityIdentifier("claude-baseten-model-fallback")
+    }
+
+    private var fallbackTargetEditor: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Fallback for Baseten models")
+                .font(.headline)
+            Text("Choose a full Claude model ID accepted by Anthropic. Switch writes the concrete model ID, not a Baseten alias.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Picker("Model", selection: $fallbackTargetDraft) {
+                ForEach(fallbackTargetOptions, id: \.model) { option in
+                    VStack(alignment: .leading) {
+                        Text(option.label)
+                        Text(option.model)
+                    }
+                    .tag(option.model)
+                }
+            }
+                .pickerStyle(.radioGroup)
+                .accessibilityIdentifier("claude-fallback-target-model")
+            Label(
+                "Cross-provider fallback replays the current conversation. Provider-specific reasoning history may be rejected during tool-use continuation.",
+                systemImage: "exclamationmark.triangle.fill")
+                .font(.caption)
+                .foregroundStyle(.orange)
+                .fixedSize(horizontal: false, vertical: true)
+            HStack {
+                Spacer()
+                Button("Cancel") {
+                    showsFallbackTargetEditor = false
+                }
+                Button("Save") {
+                    let target = fallbackTargetDraft
+                    showsFallbackTargetEditor = false
+                    state.requestBasetenModelFallback(
+                        client: client.name,
+                        model: target)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(
+                    !isAcceptedClaudeNativeModelID(fallbackTargetDraft)
+                        || fallbackTargetDraft == displayedFallbackTarget)
+                .accessibilityIdentifier("claude-fallback-target-save")
+            }
+        }
+        .padding(20)
+        .frame(width: 500)
+    }
+
+    private var fallbackProjection: BasetenModelFallbackStatus? {
+        client.basetenModelFallback
+    }
+
+    private var fallbackTargetOptions: [ClaudeNativeFallbackOption] {
+        claudeNativeFallbackOptions(client: client)
+    }
+
+    private var displayedFallbackTarget: String {
+        if let pending = state.pendingBasetenModelFallback,
+           pending.client == client.name {
+            return pending.requestedModel
+        }
+        return fallbackProjection?.resolvedModel.isEmpty == false
+            ? fallbackProjection?.resolvedModel ?? ""
+            : "Not configured"
+    }
+
+    private var displayedFallbackName: String {
+        if state.pendingBasetenModelFallback?.client == client.name {
+            return "Changing"
+        }
+        let label = fallbackProjection?.displayName ?? ""
+        return label.isEmpty ? "Unavailable" : label
+    }
+
+    private var canEditFallbackTarget: Bool {
+        !isPreview
+            && fallbackProjection != nil
+            && !fallbackTargetOptions.isEmpty
+            && state.canMutateFallbackSettings
+    }
+
+    private var fallbackTargetStatusLine: String {
+        basetenFallbackTargetStatusLine(
+            fallback: fallbackProjection,
+            policy: state.confirmedFallbackPolicy,
+            desiredMatchesActive:
+                state.routingSnapshot?.desiredMatchesActive == true,
+            supportsFallbackPolicy:
+                state.routingSnapshot?.supportsFallbackPolicy == true)
+    }
+
+    private var fallbackTargetReadinessDetail: String? {
+        basetenFallbackTargetReadinessDetail(
+            fallback: fallbackProjection,
+            desiredMatchesActive:
+                state.routingSnapshot?.desiredMatchesActive == true,
+            supportsFallbackPolicy:
+                state.routingSnapshot?.supportsFallbackPolicy == true)
+    }
+
+    private var fallbackTargetStatusColor: Color {
+        fallbackProjection?.ready == true
+            && state.routingSnapshot?.desiredMatchesActive == true
+            ? Color(nsColor: AppColors.basetenGreen)
+            : .orange
     }
 
     @ViewBuilder

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/ClaudeModelPicker.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/ClaudeModelPicker.swift
@@ -131,6 +131,101 @@ struct ClaudeNativeFallbackOption: Equatable, Sendable {
     let model: String
 }
 
+func initialClaudeNativeFallbackSelection(
+    options: [ClaudeNativeFallbackOption],
+    currentModel: String
+) -> String {
+    options.first(where: { $0.model == currentModel })?.model
+        ?? options.first?.model
+        ?? ""
+}
+
+struct ClaudeNativeFallbackEditorDraft: Equatable, Identifiable, Sendable {
+    let id: UUID
+    var selectedModel: String
+
+    init?(
+        options: [ClaudeNativeFallbackOption],
+        currentModel: String,
+        id: UUID = UUID()
+    ) {
+        let selectedModel = initialClaudeNativeFallbackSelection(
+            options: options,
+            currentModel: currentModel)
+        guard !selectedModel.isEmpty else { return nil }
+        self.id = id
+        self.selectedModel = selectedModel
+    }
+}
+
+struct ClaudeNativeFallbackEditorView: View {
+    let options: [ClaudeNativeFallbackOption]
+    let currentModel: String
+    let onCancel: () -> Void
+    let onSave: (String) -> Void
+
+    @State private var selectedModel: String
+
+    init(
+        options: [ClaudeNativeFallbackOption],
+        presentedModel: String,
+        currentModel: String,
+        onCancel: @escaping () -> Void,
+        onSave: @escaping (String) -> Void
+    ) {
+        self.options = options
+        self.currentModel = currentModel
+        self.onCancel = onCancel
+        self.onSave = onSave
+        _selectedModel = State(initialValue:
+            initialClaudeNativeFallbackSelection(
+                options: options,
+                currentModel: presentedModel))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Fallback for Baseten models")
+                .font(.headline)
+            Text("Choose a full Claude model ID accepted by Anthropic. Switch writes the concrete model ID, not a Baseten alias.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Picker("Model", selection: $selectedModel) {
+                ForEach(options, id: \.model) { option in
+                    VStack(alignment: .leading) {
+                        Text(option.label)
+                        Text(option.model)
+                    }
+                    .tag(option.model)
+                }
+            }
+                .pickerStyle(.radioGroup)
+                .accessibilityIdentifier("claude-fallback-target-model")
+            Label(
+                "Cross-provider fallback replays the current conversation. Provider-specific reasoning history may be rejected during tool-use continuation.",
+                systemImage: "exclamationmark.triangle.fill")
+                .font(.caption)
+                .foregroundStyle(.orange)
+                .fixedSize(horizontal: false, vertical: true)
+            HStack {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                Button("Save") {
+                    onSave(selectedModel)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(
+                    !isAcceptedClaudeNativeModelID(selectedModel)
+                        || selectedModel == currentModel)
+                .accessibilityIdentifier("claude-fallback-target-save")
+            }
+        }
+        .padding(20)
+        .frame(width: 500)
+    }
+}
+
 func claudeNativeFallbackOptions(
     client: ClientStatus
 ) -> [ClaudeNativeFallbackOption] {
@@ -534,8 +629,8 @@ struct ClaudeModelPickerSectionView: View {
     @State private var previewError: String?
     @State private var previewingSlug: String?
     @State private var previewingEnable = false
-    @State private var showsFallbackTargetEditor = false
-    @State private var fallbackTargetDraft = ""
+    @State private var fallbackTargetEditorDraft:
+        ClaudeNativeFallbackEditorDraft?
 
     var body: some View {
         RoutingSectionCard {
@@ -641,8 +736,20 @@ struct ClaudeModelPickerSectionView: View {
                 EmptyView()
             }
         }
-        .sheet(isPresented: $showsFallbackTargetEditor) {
-            fallbackTargetEditor
+        .sheet(item: $fallbackTargetEditorDraft) { draft in
+            ClaudeNativeFallbackEditorView(
+                options: fallbackTargetOptions,
+                presentedModel: draft.selectedModel,
+                currentModel: displayedFallbackTarget,
+                onCancel: {
+                    fallbackTargetEditorDraft = nil
+                },
+                onSave: { target in
+                    fallbackTargetEditorDraft = nil
+                    state.requestBasetenModelFallback(
+                        client: client.name,
+                        model: target)
+                })
         }
     }
 
@@ -667,10 +774,10 @@ struct ClaudeModelPickerSectionView: View {
                 }
                 Button("Change") {
                     guard !isPreview else { return }
-                    fallbackTargetDraft = fallbackTargetOptions.first(where: {
-                        $0.model == displayedFallbackTarget
-                    })?.model ?? fallbackTargetOptions.first?.model ?? ""
-                    showsFallbackTargetEditor = true
+                    fallbackTargetEditorDraft =
+                        ClaudeNativeFallbackEditorDraft(
+                            options: fallbackTargetOptions,
+                            currentModel: displayedFallbackTarget)
                 }
                 .disabled(!canEditFallbackTarget)
                 .accessibilityIdentifier("claude-fallback-target-change")
@@ -691,54 +798,6 @@ struct ClaudeModelPickerSectionView: View {
             }
         }
         .accessibilityIdentifier("claude-baseten-model-fallback")
-    }
-
-    private var fallbackTargetEditor: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            Text("Fallback for Baseten models")
-                .font(.headline)
-            Text("Choose a full Claude model ID accepted by Anthropic. Switch writes the concrete model ID, not a Baseten alias.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-            Picker("Model", selection: $fallbackTargetDraft) {
-                ForEach(fallbackTargetOptions, id: \.model) { option in
-                    VStack(alignment: .leading) {
-                        Text(option.label)
-                        Text(option.model)
-                    }
-                    .tag(option.model)
-                }
-            }
-                .pickerStyle(.radioGroup)
-                .accessibilityIdentifier("claude-fallback-target-model")
-            Label(
-                "Cross-provider fallback replays the current conversation. Provider-specific reasoning history may be rejected during tool-use continuation.",
-                systemImage: "exclamationmark.triangle.fill")
-                .font(.caption)
-                .foregroundStyle(.orange)
-                .fixedSize(horizontal: false, vertical: true)
-            HStack {
-                Spacer()
-                Button("Cancel") {
-                    showsFallbackTargetEditor = false
-                }
-                Button("Save") {
-                    let target = fallbackTargetDraft
-                    showsFallbackTargetEditor = false
-                    state.requestBasetenModelFallback(
-                        client: client.name,
-                        model: target)
-                }
-                .buttonStyle(.borderedProminent)
-                .disabled(
-                    !isAcceptedClaudeNativeModelID(fallbackTargetDraft)
-                        || fallbackTargetDraft == displayedFallbackTarget)
-                .accessibilityIdentifier("claude-fallback-target-save")
-            }
-        }
-        .padding(20)
-        .frame(width: 500)
     }
 
     private var fallbackProjection: BasetenModelFallbackStatus? {

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/ClaudeModelPicker.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/ClaudeModelPicker.swift
@@ -486,12 +486,12 @@ func claudeModelPickerDiagnosticLabel(
 func claudeModelPickerConfiguredRowState(
     allowlistPolicy: String,
     knownPolicy: String
-) -> String {
+) -> String? {
     if allowlistPolicy == "possible_conflict"
         || knownPolicy == "possible_allowlist_conflict" {
         return "Possible allowlist conflict"
     }
-    return "Runtime unverified"
+    return nil
 }
 
 func claudeModelPickerCanRetrySync(
@@ -1128,12 +1128,11 @@ struct ClaudeModelPickerSectionView: View {
                     .font(.caption2.monospaced())
                     .foregroundStyle(.tertiary)
                     .textSelection(.enabled)
-                Text(configuredRowState)
-                    .font(.caption2)
-                    .foregroundStyle(
-                        configuredRowHasAllowlistConflict
-                            ? .orange
-                            : .secondary)
+                if let configuredRowState {
+                    Text(configuredRowState)
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                }
             }
             Spacer(minLength: 12)
             Button {
@@ -1299,16 +1298,12 @@ struct ClaudeModelPickerSectionView: View {
             hasConfiguredPicker: client.modelPicker != nil)
     }
 
-    private var configuredRowState: String {
+    private var configuredRowState: String? {
         claudeModelPickerConfiguredRowState(
             allowlistPolicy:
                 state.claudeModelPickerDiagnostics?.allowlistPolicy ?? "",
             knownPolicy:
                 state.claudeModelPickerDiagnostics?.knownPolicy ?? "")
-    }
-
-    private var configuredRowHasAllowlistConflict: Bool {
-        configuredRowState == "Possible allowlist conflict"
     }
 
     private var confirmationTitle: String {

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/ClaudeModelPicker.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/ClaudeModelPicker.swift
@@ -136,8 +136,26 @@ func initialClaudeNativeFallbackSelection(
     currentModel: String
 ) -> String {
     options.first(where: { $0.model == currentModel })?.model
-        ?? options.first?.model
         ?? ""
+}
+
+func claudeNativeFallbackSelectionDetail(
+    selectedModel: String,
+    currentModel: String
+) -> String? {
+    guard selectedModel.isEmpty else { return nil }
+    if currentModel.isEmpty {
+        return "No fallback model is configured. Select a model to continue."
+    }
+    return "Your configured fallback is not one of the current choices. Select a model to replace it."
+}
+
+func claudeNativeFallbackCatalogDetail(
+    options: [ClaudeNativeFallbackOption]
+) -> String? {
+    options.isEmpty
+        ? "Fallback model choices will appear when the model catalog is available."
+        : nil
 }
 
 struct ClaudeNativeFallbackEditorDraft: Equatable, Identifiable, Sendable {
@@ -152,7 +170,7 @@ struct ClaudeNativeFallbackEditorDraft: Equatable, Identifiable, Sendable {
         let selectedModel = initialClaudeNativeFallbackSelection(
             options: options,
             currentModel: currentModel)
-        guard !selectedModel.isEmpty else { return nil }
+        guard !options.isEmpty else { return nil }
         self.id = id
         self.selectedModel = selectedModel
     }
@@ -184,37 +202,55 @@ struct ClaudeNativeFallbackEditorView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            Text("Fallback for Baseten models")
-                .font(.headline)
-            Text("Choose a full Claude model ID accepted by Anthropic. Switch writes the concrete model ID, not a Baseten alias.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-            Picker("Model", selection: $selectedModel) {
-                ForEach(options, id: \.model) { option in
-                    VStack(alignment: .leading) {
-                        Text(option.label)
-                        Text(option.model)
-                    }
-                    .tag(option.model)
-                }
+        VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Choose a fallback model")
+                    .font(.title3.weight(.semibold))
+                    .accessibilityAddTraits(.isHeader)
+                Text("Select the Claude model to use when requests fall back from Baseten.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
+
+            ScrollView {
+                Picker("Fallback model", selection: $selectedModel) {
+                    ForEach(options, id: \.model) { option in
+                        Text(option.label)
+                            .tag(option.model)
+                    }
+                }
                 .pickerStyle(.radioGroup)
+                .labelsHidden()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .accessibilityLabel("Fallback model")
                 .accessibilityIdentifier("claude-fallback-target-model")
-            Label(
-                "Cross-provider fallback replays the current conversation. Provider-specific reasoning history may be rejected during tool-use continuation.",
-                systemImage: "exclamationmark.triangle.fill")
-                .font(.caption)
-                .foregroundStyle(.orange)
-                .fixedSize(horizontal: false, vertical: true)
-            HStack {
+            }
+            .frame(maxHeight: 220)
+            .padding(12)
+            .background(
+                Color.primary.opacity(0.045),
+                in: RoundedRectangle(cornerRadius: 8))
+
+            if let detail = claudeNativeFallbackSelectionDetail(
+                selectedModel: selectedModel,
+                currentModel: currentModel
+            ) {
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack(spacing: 8) {
                 Spacer()
                 Button("Cancel", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
                 Button("Save") {
                     onSave(selectedModel)
                 }
                 .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
                 .disabled(
                     !isAcceptedClaudeNativeModelID(selectedModel)
                         || selectedModel == currentModel)
@@ -222,7 +258,9 @@ struct ClaudeNativeFallbackEditorView: View {
             }
         }
         .padding(20)
-        .frame(width: 500)
+        .frame(width: 440)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("claude-fallback-target-editor")
     }
 }
 
@@ -230,35 +268,16 @@ func claudeNativeFallbackOptions(
     client: ClientStatus
 ) -> [ClaudeNativeFallbackOption] {
     var options: [ClaudeNativeFallbackOption] = []
-    if let current = client.basetenModelFallback?.resolvedModel,
-       isAcceptedClaudeNativeModelID(current) {
-        let displayName = client.basetenModelFallback?.displayName ?? ""
-        options.append(ClaudeNativeFallbackOption(
-            label: displayName.isEmpty
-                ? claudeNativeModelLabel(current)
-                : displayName,
-            model: current))
-    }
     for available in client.basetenModelFallback?.availableModels ?? []
     where isAcceptedClaudeNativeModelID(available.model) {
         options.append(ClaudeNativeFallbackOption(
-            label: available.displayName.isEmpty
-                ? claudeNativeModelLabel(available.model)
-                : available.displayName,
+            label: available.displayName,
             model: available.model))
     }
     var seen = Set<String>()
     return options.filter { option in
         seen.insert(option.model).inserted
     }
-}
-
-func claudeNativeModelLabel(_ model: String) -> String {
-    for family in ["fable", "opus", "sonnet", "haiku"]
-    where model.contains("-" + family + "-") {
-        return family.prefix(1).uppercased() + family.dropFirst()
-    }
-    return model
 }
 
 struct PendingClaudeModelPickerMutation: Equatable, Sendable {
@@ -272,9 +291,6 @@ private enum ClaudeModelPickerConfirmation {
         ClaudeModelPickerEnablePreview,
         convertReplacementMode: Bool)
     case chooseAlias(slug: String, choices: [ClaudeModelPickerRow])
-    case add(ClaudeModelPickerAddPreview, explicitAlias: String?)
-    case remove(ClaudeModelPickerRow)
-    case syncReplacement
 }
 
 struct ClaudeModelPickerEnablePreview: Equatable, Sendable {
@@ -299,11 +315,35 @@ struct ClaudeModelPickerEnablePreview: Equatable, Sendable {
     }
 }
 
+struct ClaudeModelPickerContextMinimumFailure: Equatable, Sendable {
+    static let code = "context_window_below_claude_picker_minimum"
+
+    let message: String
+
+    init?(json: String, status: Int32) {
+        guard status != 0,
+              let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              let dict = object as? [String: Any],
+              dict["ok"] as? Bool == false,
+              let error = dict["error"] as? [String: Any],
+              error["code"] as? String == Self.code,
+              error["retryable"] as? Bool == false,
+              let rawMessage = error["message"] as? String else {
+            return nil
+        }
+        let message = rawMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !message.isEmpty else { return nil }
+        self.message = message
+    }
+}
+
 struct ClaudeModelPickerRow: Equatable, Identifiable, Sendable {
     let alias: String
     let slug: String
     let label: String
     let description: String
+    let contextTokens: Int64
 
     var id: String { alias }
 
@@ -322,6 +362,7 @@ struct ClaudeModelPickerRow: Equatable, Identifiable, Sendable {
         self.slug = slug
         self.label = label
         self.description = description
+        self.contextTokens = Int64(dict["context_tokens"] as? Int ?? 0)
     }
 }
 
@@ -355,6 +396,7 @@ struct ClaudeModelPickerDiagnostics: Equatable, Sendable {
     let legacyDiscoveryEnabled: Bool
     let savedModel: String?
     let savedModelUnconfigured: Bool
+    let savedModelContextMismatch: Bool
     let message: String
 
     init?(json: String) {
@@ -399,6 +441,8 @@ struct ClaudeModelPickerDiagnostics: Equatable, Sendable {
         savedModel = dict["saved_model"] as? String
         savedModelUnconfigured =
             dict["saved_model_unconfigured"] as? Bool ?? false
+        savedModelContextMismatch =
+            dict["saved_model_context_mismatch"] as? Bool ?? false
         message = dict["message"] as? String ?? ""
     }
 }
@@ -437,6 +481,25 @@ func claudeModelPickerConfiguredRowState(
         return "Possible allowlist conflict"
     }
     return "Runtime unverified"
+}
+
+func claudeModelPickerCanRetrySync(
+    userFileSync: String?,
+    canEditConfiguredRows: Bool,
+    hasConfiguredPicker: Bool
+) -> Bool {
+    userFileSync == "out_of_sync"
+        && canEditConfiguredRows
+        && hasConfiguredPicker
+}
+
+let claudeModelPickerRestartNotice =
+    "Restart Claude Code to see additions or removals."
+
+func claudeModelPickerRemoveMutation(
+    alias: String
+) -> ClaudeModelPickerMutationKind {
+    .remove(alias: alias)
 }
 
 struct ClaudeModelPickerProjection: Equatable {
@@ -502,6 +565,13 @@ struct ClaudeModelPickerAddPreview: Equatable, Sendable {
     }
 }
 
+func claudeModelPickerAddMutation(
+    preview: ClaudeModelPickerAddPreview,
+    explicitAlias: String?
+) -> ClaudeModelPickerMutationKind {
+    .add(slug: preview.slug, alias: explicitAlias)
+}
+
 enum ClaudeModelPickerAddPreviewOutcome: Equatable, Sendable {
     case preview(ClaudeModelPickerAddPreview, explicitAlias: String?)
     case aliasChoices(slug: String, choices: [ClaudeModelPickerRow])
@@ -534,6 +604,16 @@ enum ClaudeModelPickerAddPreviewOutcome: Equatable, Sendable {
         }
         self = .aliasChoices(slug: slug, choices: choices)
     }
+}
+
+func claudeModelPickerAddPreviewErrorMessage(
+    _ error: String?
+) -> String {
+    let message = error?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    guard !message.isEmpty else {
+        return "Switch could not generate an exact preview for this model. No changes were made."
+    }
+    return message
 }
 
 func claudeModelPickerMoveUpCommand(
@@ -609,7 +689,7 @@ func claudeModelPickerSuccessMessage(
     case .enable:
         return "Saved. Reopen /model in Claude Code to verify the configured Baseten models."
     case .add:
-        return "Saved. Reopen /model in Claude Code. Restart Claude Code if the list has not refreshed."
+        return "Added to /model."
     case .remove:
         return "Saved. The routing alias remains available to existing sessions."
     case .move:
@@ -627,11 +707,11 @@ struct ClaudeModelPickerSectionView: View {
     @State private var searchText = ""
     @State private var confirmation: ClaudeModelPickerConfirmation?
     @State private var previewError: String?
+    @State private var addPreviewError: String?
     @State private var previewingSlug: String?
     @State private var previewingEnable = false
     @State private var fallbackTargetEditorDraft:
         ClaudeNativeFallbackEditorDraft?
-
     var body: some View {
         RoutingSectionCard {
             HStack {
@@ -643,18 +723,6 @@ struct ClaudeModelPickerSectionView: View {
                         .controlSize(.small)
                         .accessibilityLabel(pending.kind.progressLabel)
                 }
-                Button("Sync") {
-                    guard !isPreview else { return }
-                    if replacementModeRequiresConversion {
-                        confirmation = .syncReplacement
-                    } else {
-                        state.requestClaudeModelPicker(
-                            .sync(convertReplacementMode: false))
-                    }
-                }
-                .disabled(
-                    !canEditConfiguredRows || client.modelPicker == nil)
-                .accessibilityIdentifier("claude-picker-sync")
             }
         } content: {
             VStack(alignment: .leading, spacing: 16) {
@@ -726,12 +794,6 @@ struct ClaudeModelPickerSectionView: View {
                     convertsReplacementMode: convert))
             case .chooseAlias:
                 Text("More than one configured alias routes to this model. Choose the exact alias to add.")
-            case .add(let preview, _):
-                Text("Model: \(preview.slug)\nAlias: \(preview.alias)\nLabel: \(preview.label)\nDescription: \(preview.description)")
-            case .remove:
-                Text(removeConfirmationMessage)
-            case .syncReplacement:
-                Text("Claude Code currently replaces its built-in model list. Continue only if you want Switch to convert it to append mode and preserve Claude's built-in models.")
             case nil:
                 EmptyView()
             }
@@ -740,7 +802,7 @@ struct ClaudeModelPickerSectionView: View {
             ClaudeNativeFallbackEditorView(
                 options: fallbackTargetOptions,
                 presentedModel: draft.selectedModel,
-                currentModel: displayedFallbackTarget,
+                currentModel: fallbackProjection?.resolvedModel ?? "",
                 onCancel: {
                     fallbackTargetEditorDraft = nil
                 },
@@ -777,7 +839,8 @@ struct ClaudeModelPickerSectionView: View {
                     fallbackTargetEditorDraft =
                         ClaudeNativeFallbackEditorDraft(
                             options: fallbackTargetOptions,
-                            currentModel: displayedFallbackTarget)
+                            currentModel:
+                                fallbackProjection?.resolvedModel ?? "")
                 }
                 .disabled(!canEditFallbackTarget)
                 .accessibilityIdentifier("claude-fallback-target-change")
@@ -786,6 +849,16 @@ struct ClaudeModelPickerSectionView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
+            if let detail = claudeNativeFallbackCatalogDetail(
+                options: fallbackTargetOptions
+            ) {
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier(
+                        "claude-fallback-target-catalog-unavailable")
+            }
             Text(fallbackTargetStatusLine)
                 .font(.caption.weight(.medium))
                 .foregroundStyle(fallbackTargetStatusColor)
@@ -922,6 +995,25 @@ struct ClaudeModelPickerSectionView: View {
                         .foregroundStyle(.orange)
                         .fixedSize(horizontal: false, vertical: true)
                 }
+                if diagnostics.savedModelContextMismatch,
+                   let savedModel = diagnostics.savedModel {
+                    Label(
+                        "Claude Code's saved default, \(savedModel), still requests 1M context. Its configured picker row now uses the 200K context bucket.",
+                        systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                if canRetryModelPickerSync {
+                    HStack {
+                        Spacer()
+                        Button("Retry sync") {
+                            state.requestClaudeModelPicker(
+                                .sync(convertReplacementMode: false))
+                        }
+                        .accessibilityIdentifier("claude-picker-retry-sync")
+                    }
+                }
             }
             .padding(10)
             .background(
@@ -1021,6 +1113,10 @@ struct ClaudeModelPickerSectionView: View {
         VStack(alignment: .leading, spacing: 10) {
             Text("Configured for /model")
                 .font(.subheadline.weight(.semibold))
+            Text(claudeModelPickerRestartNotice)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
             if projection.configured.isEmpty {
                 Text("No Baseten models are configured for /model.")
                     .font(.caption)
@@ -1087,7 +1183,9 @@ struct ClaudeModelPickerSectionView: View {
 
             Button("Remove") {
                 previewError = nil
-                confirmation = .remove(row)
+                guard !isPreview else { return }
+                state.requestClaudeModelPicker(
+                    claudeModelPickerRemoveMutation(alias: row.alias))
             }
             .disabled(!canEditConfiguredRows)
             .accessibilityIdentifier("claude-picker-remove-\(row.alias)")
@@ -1103,6 +1201,17 @@ struct ClaudeModelPickerSectionView: View {
             TextField("Search models", text: $searchText)
                 .textFieldStyle(.roundedBorder)
                 .accessibilityIdentifier("claude-picker-search")
+
+            if let addPreviewError {
+                Label(
+                    addPreviewError,
+                    systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier(
+                        "claude-picker-add-preview-error")
+            }
 
             switch state.liveModelCatalogState {
             case .idle, .loading:
@@ -1195,6 +1304,14 @@ struct ClaudeModelPickerSectionView: View {
         canEditConfiguredRows && state.modelCatalogAllowsMutation
     }
 
+    private var canRetryModelPickerSync: Bool {
+        claudeModelPickerCanRetrySync(
+            userFileSync:
+                state.claudeModelPickerDiagnostics?.userFileSync,
+            canEditConfiguredRows: canEditConfiguredRows,
+            hasConfiguredPicker: client.modelPicker != nil)
+    }
+
     private var replacementModeRequiresConversion: Bool {
         state.claudeModelPickerDiagnostics?.replacementMode == "replace"
     }
@@ -1217,27 +1334,9 @@ struct ClaudeModelPickerSectionView: View {
             return "Set up the Claude Code model picker?"
         case .chooseAlias:
             return "Choose an alias"
-        case .add(let preview, _):
-            return "Add \(preview.label) to /model?"
-        case .remove(let row):
-            return "Remove \(rowDisplayLabel(row)) from /model?"
-        case .syncReplacement:
-            return "Convert Claude's model picker to append mode?"
         case nil:
             return "Confirm model picker change"
         }
-    }
-
-    private var removeConfirmationMessage: String {
-        var message = "The routing alias remains configured. Existing sessions may continue to use it."
-        if case .remove(let row) = confirmation,
-           state.claudeModelPickerDiagnostics?.savedModel == row.alias {
-            message += " This alias is Claude Code's saved default. Removing it from the curated list does not clear that saved default. Select a native default in /model before starting a new session."
-        }
-        if state.claudeModelPickerDiagnostics?.legacyDiscoveryEnabled == true {
-            message += " Legacy gateway model discovery is enabled, so the alias may still appear outside the curated picker list."
-        }
-        return message
     }
 
     @ViewBuilder
@@ -1256,27 +1355,6 @@ struct ClaudeModelPickerSectionView: View {
                     confirmation = nil
                     beginAddPreview(slug: slug, alias: choice.alias)
                 }
-            }
-        case .add(let preview, let explicitAlias):
-            Button("Add to /model") {
-                guard !isPreview else { return }
-                state.requestClaudeModelPicker(.add(
-                    slug: preview.slug,
-                    alias: explicitAlias))
-                confirmation = nil
-            }
-        case .remove(let row):
-            Button("Remove from /model", role: .destructive) {
-                guard !isPreview else { return }
-                state.requestClaudeModelPicker(.remove(alias: row.alias))
-                confirmation = nil
-            }
-        case .syncReplacement:
-            Button("Convert and Sync") {
-                guard !isPreview else { return }
-                state.requestClaudeModelPicker(
-                    .sync(convertReplacementMode: true))
-                confirmation = nil
             }
         case nil:
             EmptyView()
@@ -1298,6 +1376,7 @@ struct ClaudeModelPickerSectionView: View {
     private func beginAddPreview(slug: String, alias: String?) {
         guard !isPreview else { return }
         previewError = nil
+        addPreviewError = nil
         previewingSlug = slug
         Task {
             let outcome = await state.previewClaudeModelPickerAdd(
@@ -1307,15 +1386,17 @@ struct ClaudeModelPickerSectionView: View {
             previewingSlug = nil
             switch outcome {
             case .preview(let preview, let explicitAlias):
-                confirmation = .add(
-                    preview,
-                    explicitAlias: explicitAlias)
+                state.requestClaudeModelPicker(
+                    claudeModelPickerAddMutation(
+                        preview: preview,
+                        explicitAlias: explicitAlias))
             case .aliasChoices(let choiceSlug, let choices):
                 confirmation = .chooseAlias(
                     slug: choiceSlug,
                     choices: choices)
             case nil:
-                previewError = "Switch could not generate an exact preview for this model. No changes were made."
+                addPreviewError = claudeModelPickerAddPreviewErrorMessage(
+                    state.lastError)
             }
         }
     }

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/ClaudeModelPicker.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/ClaudeModelPicker.swift
@@ -504,6 +504,33 @@ func claudeModelPickerCanRetrySync(
         && hasConfiguredPicker
 }
 
+func claudeModelPickerShowsSyncDiagnostic(
+    userFileSync: String
+) -> Bool {
+    userFileSync != "synced"
+}
+
+func claudeModelPickerShowsAllowlistDiagnostic(
+    allowlistPolicy: String
+) -> Bool {
+    allowlistPolicy != "no_known_conflict"
+}
+
+func claudeModelPickerHasDiagnosticIssues(
+    userFileSync: String,
+    allowlistPolicy: String,
+    hasMessage: Bool = false,
+    savedModelUnconfigured: Bool = false,
+    savedModelContextMismatch: Bool = false
+) -> Bool {
+    claudeModelPickerShowsSyncDiagnostic(userFileSync: userFileSync)
+        || claudeModelPickerShowsAllowlistDiagnostic(
+            allowlistPolicy: allowlistPolicy)
+        || hasMessage
+        || savedModelUnconfigured
+        || savedModelContextMismatch
+}
+
 func claudeModelPickerCanAddModels(
     canEditConfiguredRows: Bool,
     modelCatalogAllowsMutation: Bool,
@@ -951,84 +978,78 @@ struct ClaudeModelPickerSectionView: View {
                     .foregroundStyle(.secondary)
             }
         } else if let diagnostics = state.claudeModelPickerDiagnostics {
-            VStack(alignment: .leading, spacing: 6) {
-                diagnosticRow(
-                    "Configuration",
-                    claudeModelPickerDiagnosticLabel(
-                        key: "configuration",
-                        value: diagnostics.configuration))
-                diagnosticRow(
-                    "Claude settings",
-                    claudeModelPickerDiagnosticLabel(
-                        key: "sync",
-                        value: diagnostics.userFileSync))
-                diagnosticRow(
-                    "Overall policy",
-                    claudeModelPickerDiagnosticLabel(
-                        key: "policy",
-                        value: diagnostics.knownPolicy))
-                diagnosticRow(
-                    "Allowlist policy",
-                    claudeModelPickerDiagnosticLabel(
-                        key: "policy",
-                        value: diagnostics.allowlistPolicy))
-                diagnosticRow(
-                    "Managed policy",
-                    claudeModelPickerDiagnosticLabel(
-                        key: "policy",
-                        value: diagnostics.managedPolicy))
-                diagnosticRow(
-                    "Picker mode",
-                    claudeModelPickerDiagnosticLabel(
-                        key: "replacement",
-                        value: diagnostics.replacementMode))
-                diagnosticRow(
-                    "Runtime visibility",
-                    claudeModelPickerDiagnosticLabel(
-                        key: "runtime",
-                        value: diagnostics.runtimeVerification))
-                if !diagnostics.message.isEmpty {
-                    Label(
-                        diagnostics.message,
-                        systemImage: "exclamationmark.triangle.fill")
-                        .font(.caption)
-                        .foregroundStyle(.orange)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                if diagnostics.savedModelUnconfigured,
-                   let savedModel = diagnostics.savedModel {
-                    Label(
-                        "Claude Code's saved default, \(savedModel), is not in the curated picker list.",
-                        systemImage: "exclamationmark.triangle.fill")
-                        .font(.caption)
-                        .foregroundStyle(.orange)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                if diagnostics.savedModelContextMismatch,
-                   let savedModel = diagnostics.savedModel {
-                    Label(
-                        "Claude Code's saved default, \(savedModel), still requests 1M context. Its configured picker row now uses the 200K context bucket.",
-                        systemImage: "exclamationmark.triangle.fill")
-                        .font(.caption)
-                        .foregroundStyle(.orange)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                if canRetryModelPickerSync {
-                    HStack {
-                        Spacer()
-                        Button("Retry sync") {
-                            state.requestClaudeModelPicker(
-                                .sync(convertReplacementMode: false))
+            if claudeModelPickerHasDiagnosticIssues(
+                userFileSync: diagnostics.userFileSync,
+                allowlistPolicy: diagnostics.allowlistPolicy,
+                hasMessage: !diagnostics.message.isEmpty,
+                savedModelUnconfigured:
+                    diagnostics.savedModelUnconfigured,
+                savedModelContextMismatch:
+                    diagnostics.savedModelContextMismatch
+            ) {
+                VStack(alignment: .leading, spacing: 6) {
+                    if claudeModelPickerShowsSyncDiagnostic(
+                        userFileSync: diagnostics.userFileSync
+                    ) {
+                        diagnosticRow(
+                            "Claude settings",
+                            claudeModelPickerDiagnosticLabel(
+                                key: "sync",
+                                value: diagnostics.userFileSync))
+                    }
+                    if claudeModelPickerShowsAllowlistDiagnostic(
+                        allowlistPolicy: diagnostics.allowlistPolicy
+                    ) {
+                        diagnosticRow(
+                            "Allowlist policy",
+                            claudeModelPickerDiagnosticLabel(
+                                key: "policy",
+                                value: diagnostics.allowlistPolicy))
+                    }
+                    if !diagnostics.message.isEmpty {
+                        Label(
+                            diagnostics.message,
+                            systemImage: "exclamationmark.triangle.fill")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    if diagnostics.savedModelUnconfigured,
+                       let savedModel = diagnostics.savedModel {
+                        Label(
+                            "Claude Code's saved default, \(savedModel), is not in the curated picker list.",
+                            systemImage: "exclamationmark.triangle.fill")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    if diagnostics.savedModelContextMismatch,
+                       let savedModel = diagnostics.savedModel {
+                        Label(
+                            "Claude Code's saved default, \(savedModel), still requests 1M context. Its configured picker row now uses the 200K context bucket.",
+                            systemImage: "exclamationmark.triangle.fill")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    if canRetryModelPickerSync {
+                        HStack {
+                            Spacer()
+                            Button("Retry sync") {
+                                state.requestClaudeModelPicker(
+                                    .sync(convertReplacementMode: false))
+                            }
+                            .accessibilityIdentifier(
+                                "claude-picker-retry-sync")
                         }
-                        .accessibilityIdentifier("claude-picker-retry-sync")
                     }
                 }
+                .padding(10)
+                .background(
+                    Color.secondary.opacity(0.06),
+                    in: RoundedRectangle(cornerRadius: 8))
+                .accessibilityIdentifier("claude-picker-diagnostics")
             }
-            .padding(10)
-            .background(
-                Color.secondary.opacity(0.06),
-                in: RoundedRectangle(cornerRadius: 8))
-            .accessibilityIdentifier("claude-picker-diagnostics")
         } else if let error = state.claudeModelPickerDiagnosticsError {
             Label(error, systemImage: "exclamationmark.triangle.fill")
                 .font(.caption)

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/ClaudeModelPicker.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/ClaudeModelPicker.swift
@@ -1,0 +1,1032 @@
+import Foundation
+import SwiftUI
+
+enum ClaudeModelPickerMutationKind: Equatable, Sendable {
+    case enable(convertReplacementMode: Bool)
+    case add(slug: String, alias: String?)
+    case remove(alias: String)
+    case move(alias: String, before: String)
+    case sync(convertReplacementMode: Bool)
+
+    var command: [String] {
+        switch self {
+        case .enable(let convert):
+            return ["claude", "picker", "enable"]
+                + (convert ? ["--convert-replacement-mode"] : [])
+        case .add(let slug, let alias):
+            return ["claude", "picker", "add", slug]
+                + (alias.map { ["--alias", $0] } ?? [])
+        case .remove(let alias):
+            return ["claude", "picker", "remove", alias]
+        case .move(let alias, let before):
+            return [
+                "claude", "picker", "move", alias,
+                "--before", before,
+            ]
+        case .sync(let convert):
+            return ["claude", "picker", "sync"]
+                + (convert ? ["--convert-replacement-mode"] : [])
+        }
+    }
+
+    var receiptOperation: String {
+        switch self {
+        case .enable: return "enable_claude_picker"
+        case .add: return "add_claude_picker_model"
+        case .remove: return "remove_claude_picker_model"
+        case .move: return "move_claude_picker_model"
+        case .sync: return "sync_claude_picker"
+        }
+    }
+
+    var requestedTarget: String {
+        switch self {
+        case .enable, .sync: return ""
+        case .add(let slug, let alias):
+            return alias.map { "\(slug) via \($0)" } ?? slug
+        case .remove(let alias): return alias
+        case .move(let alias, let before): return "\(alias) before \(before)"
+        }
+    }
+
+    var progressLabel: String {
+        switch self {
+        case .enable: return "Setting up model picker"
+        case .add: return "Adding model"
+        case .remove: return "Removing model"
+        case .move: return "Saving model order"
+        case .sync: return "Syncing with Claude Code"
+        }
+    }
+
+    var convertsReplacementMode: Bool {
+        switch self {
+        case .enable(let convert), .sync(let convert): return convert
+        default: return false
+        }
+    }
+
+    var isSync: Bool {
+        if case .sync = self { return true }
+        return false
+    }
+}
+
+struct PendingClaudeModelPickerMutation: Equatable, Sendable {
+    let operationID: String
+    let kind: ClaudeModelPickerMutationKind
+    var phase: MutationPhase
+}
+
+private enum ClaudeModelPickerConfirmation {
+    case enable(
+        ClaudeModelPickerEnablePreview,
+        convertReplacementMode: Bool)
+    case chooseAlias(slug: String, choices: [ClaudeModelPickerRow])
+    case add(ClaudeModelPickerAddPreview, explicitAlias: String?)
+    case remove(ClaudeModelPickerRow)
+    case syncReplacement
+}
+
+struct ClaudeModelPickerEnablePreview: Equatable, Sendable {
+    let models: [ClaudeModelPickerRow]
+
+    init(models: [ClaudeModelPickerRow]) {
+        self.models = models
+    }
+
+    init?(json: String) {
+        guard let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              let dict = object as? [String: Any],
+              let rawModels = dict["models"] as? [[String: Any]] else {
+            return nil
+        }
+        let models = rawModels.compactMap(ClaudeModelPickerRow.init)
+        guard !models.isEmpty, models.count == rawModels.count else {
+            return nil
+        }
+        self.models = models
+    }
+}
+
+struct ClaudeModelPickerRow: Equatable, Identifiable, Sendable {
+    let alias: String
+    let slug: String
+    let label: String
+    let description: String
+
+    var id: String { alias }
+
+    init?(dict: [String: Any]) {
+        guard let alias = dict["alias"] as? String,
+              !alias.isEmpty,
+              let slug = dict["slug"] as? String,
+              !slug.isEmpty,
+              let label = dict["label"] as? String,
+              !label.isEmpty,
+              let description = dict["description"] as? String,
+              !description.isEmpty else {
+            return nil
+        }
+        self.alias = alias
+        self.slug = slug
+        self.label = label
+        self.description = description
+    }
+}
+
+struct ClaudeModelPickerStatus: Equatable, Sendable {
+    let enabled: Bool
+    let models: [ClaudeModelPickerRow]
+
+    init?(dict: [String: Any]) {
+        guard let enabled = dict["enabled"] as? Bool,
+              let rawModels = dict["models"] as? [[String: Any]] else {
+            return nil
+        }
+        let models = rawModels.compactMap(ClaudeModelPickerRow.init)
+        guard models.count == rawModels.count else { return nil }
+        self.enabled = enabled
+        self.models = models
+    }
+}
+
+struct ClaudeModelPickerDiagnostics: Equatable, Sendable {
+    let enabled: Bool
+    let configuration: String
+    let userFileSync: String
+    let knownPolicy: String
+    let allowlistPolicy: String
+    let managedPolicy: String
+    let replacementMode: String
+    let runtimeVerification: String
+    let configuredRows: Int
+    let installedRows: Int
+    let legacyDiscoveryEnabled: Bool
+    let savedModel: String?
+    let savedModelUnconfigured: Bool
+    let message: String
+
+    init?(json: String) {
+        guard let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              let dict = object as? [String: Any],
+              let enabled = dict["enabled"] as? Bool,
+              let configuration = dict["configuration"] as? String,
+              !configuration.isEmpty,
+              let userFileSync = dict["user_file_sync"] as? String,
+              !userFileSync.isEmpty,
+              let knownPolicy = dict["known_policy"] as? String,
+              !knownPolicy.isEmpty,
+              let allowlistPolicy = dict["allowlist_policy"] as? String,
+              !allowlistPolicy.isEmpty,
+              let managedPolicy = dict["managed_policy"] as? String,
+              !managedPolicy.isEmpty,
+              let replacementMode = dict["replacement_mode"] as? String,
+              !replacementMode.isEmpty,
+              let runtimeVerification =
+                dict["runtime_verification"] as? String,
+              !runtimeVerification.isEmpty,
+              let configuredRows = dict["configured_rows"] as? Int,
+              configuredRows >= 0,
+              let installedRows = dict["installed_rows"] as? Int,
+              installedRows >= 0,
+              let legacyDiscoveryEnabled =
+                dict["legacy_discovery_enabled"] as? Bool else {
+            return nil
+        }
+        self.enabled = enabled
+        self.configuration = configuration
+        self.userFileSync = userFileSync
+        self.knownPolicy = knownPolicy
+        self.allowlistPolicy = allowlistPolicy
+        self.managedPolicy = managedPolicy
+        self.replacementMode = replacementMode
+        self.runtimeVerification = runtimeVerification
+        self.configuredRows = configuredRows
+        self.installedRows = installedRows
+        self.legacyDiscoveryEnabled = legacyDiscoveryEnabled
+        savedModel = dict["saved_model"] as? String
+        savedModelUnconfigured =
+            dict["saved_model_unconfigured"] as? Bool ?? false
+        message = dict["message"] as? String ?? ""
+    }
+}
+
+func claudeModelPickerDiagnosticLabel(
+    key: String,
+    value: String
+) -> String {
+    switch (key, value) {
+    case ("sync", "synced"):
+        return "Synced"
+    case ("sync", "out_of_sync"):
+        return "Out of sync"
+    case ("policy", "no_known_conflict"):
+        return "No known conflict"
+    case ("policy", "possible_allowlist_conflict"):
+        return "Possible allowlist conflict"
+    case ("policy", "possible_conflict"):
+        return "Possible conflict"
+    case ("policy", "blocked"):
+        return "Blocked"
+    case ("runtime", "unverified"):
+        return "Unverified"
+    default:
+        return value.replacingOccurrences(of: "_", with: " ")
+            .localizedCapitalized
+    }
+}
+
+func claudeModelPickerConfiguredRowState(
+    allowlistPolicy: String,
+    knownPolicy: String
+) -> String {
+    if allowlistPolicy == "possible_conflict"
+        || knownPolicy == "possible_allowlist_conflict" {
+        return "Possible allowlist conflict"
+    }
+    return "Runtime unverified"
+}
+
+struct ClaudeModelPickerProjection: Equatable {
+    let configured: [ClaudeModelPickerRow]
+    let availableToAdd: [LiveModelCatalogEntry]
+}
+
+func projectClaudeModelPicker(
+    status: ClaudeModelPickerStatus?,
+    liveState: LiveModelCatalogLoadState
+) -> ClaudeModelPickerProjection {
+    let configured = status?.models ?? []
+    guard case .ready(let liveModels) = liveState else {
+        return ClaudeModelPickerProjection(
+            configured: configured,
+            availableToAdd: [])
+    }
+
+    let selectedSlugs = Set(configured.map(\.slug))
+    var seenSlugs = Set<String>()
+    let available = liveModels
+        .filter { model in
+            !selectedSlugs.contains(model.slug)
+                && seenSlugs.insert(model.slug).inserted
+        }
+        .sorted { lhs, rhs in
+            let labelOrder = lhs.displayLabel.localizedCaseInsensitiveCompare(
+                rhs.displayLabel)
+            if labelOrder != .orderedSame {
+                return labelOrder == .orderedAscending
+            }
+            return lhs.slug < rhs.slug
+        }
+    return ClaudeModelPickerProjection(
+        configured: configured,
+        availableToAdd: available)
+}
+
+struct ClaudeModelPickerAddPreview: Equatable, Sendable {
+    let slug: String
+    let alias: String
+    let label: String
+    let description: String
+
+    init?(json: String) {
+        guard let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              let dict = object as? [String: Any],
+              let alias = dict["alias"] as? String,
+              !alias.isEmpty,
+              let slug = dict["slug"] as? String,
+              !slug.isEmpty,
+              let label = dict["label"] as? String,
+              !label.isEmpty,
+              let description = dict["description"] as? String,
+              !description.isEmpty else {
+            return nil
+        }
+        self.slug = slug
+        self.alias = alias
+        self.label = label
+        self.description = description
+    }
+}
+
+enum ClaudeModelPickerAddPreviewOutcome: Equatable, Sendable {
+    case preview(ClaudeModelPickerAddPreview, explicitAlias: String?)
+    case aliasChoices(slug: String, choices: [ClaudeModelPickerRow])
+
+    init?(json: String, status: Int32, explicitAlias: String?) {
+        if status == 0, let preview = ClaudeModelPickerAddPreview(json: json) {
+            self = .preview(preview, explicitAlias: explicitAlias)
+            return
+        }
+        guard status == 1,
+              explicitAlias == nil,
+              let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              let dict = object as? [String: Any],
+              dict["ok"] as? Bool == false,
+              let slug = dict["slug"] as? String,
+              !slug.isEmpty,
+              let error = dict["error"] as? [String: Any],
+              error["code"] as? String == "ambiguous_alias",
+              error["retryable"] as? Bool == false,
+              let rawChoices = dict["alias_choices"] as? [[String: Any]] else {
+            return nil
+        }
+        let choices = rawChoices.compactMap(ClaudeModelPickerRow.init)
+        guard choices.count > 1,
+              choices.count == rawChoices.count,
+              Set(choices.map(\.alias)).count == choices.count,
+              choices.allSatisfy({ $0.slug == slug }) else {
+            return nil
+        }
+        self = .aliasChoices(slug: slug, choices: choices)
+    }
+}
+
+func claudeModelPickerMoveUpCommand(
+    rows: [ClaudeModelPickerRow],
+    index: Int
+) -> [String]? {
+    guard index > 0, rows.indices.contains(index) else { return nil }
+    return [
+        "move", rows[index].alias,
+        "--before", rows[index - 1].alias,
+    ]
+}
+
+func claudeModelPickerMoveDownCommand(
+    rows: [ClaudeModelPickerRow],
+    index: Int
+) -> [String]? {
+    guard rows.indices.contains(index), rows.indices.contains(index + 1) else {
+        return nil
+    }
+    // Moving the following row before the current row is a one-step swap and
+    // also supports moving the penultimate row to the final position.
+    return [
+        "move", rows[index + 1].alias,
+        "--before", rows[index].alias,
+    ]
+}
+
+func claudeModelPickerMutationConfirmed(
+    _ kind: ClaudeModelPickerMutationKind,
+    status: ClaudeModelPickerStatus?
+) -> Bool {
+    switch kind {
+    case .enable:
+        return status?.enabled == true
+    case .add(let slug, let alias):
+        return status?.models.contains(where: { row in
+            if let alias { return row.alias == alias }
+            return row.slug == slug
+        }) == true
+    case .remove(let alias):
+        return status?.models.contains(where: { $0.alias == alias }) == false
+    case .move(let alias, let before):
+        guard let rows = status?.models,
+              let aliasIndex = rows.firstIndex(where: { $0.alias == alias }),
+              let beforeIndex = rows.firstIndex(where: {
+                  $0.alias == before
+              }) else { return false }
+        return aliasIndex + 1 == beforeIndex
+    case .sync:
+        return status != nil
+    }
+}
+
+func claudeModelPickerReceiptMatches(
+    _ receipt: GlobalMutationReceipt?,
+    operationID: String,
+    kind: ClaudeModelPickerMutationKind
+) -> Bool {
+    guard let receipt else { return false }
+    return receipt.operationID == operationID
+        && receipt.operation == kind.receiptOperation
+        && receipt.client == "claude-code"
+        && receipt.key == "model_picker"
+        && (kind.requestedTarget.isEmpty
+            || receipt.requestedTarget == kind.requestedTarget)
+}
+
+func claudeModelPickerSuccessMessage(
+    _ kind: ClaudeModelPickerMutationKind
+) -> String {
+    switch kind {
+    case .enable:
+        return "Saved. Reopen /model in Claude Code to verify the configured Baseten models."
+    case .add:
+        return "Saved. Reopen /model in Claude Code. Restart Claude Code if the list has not refreshed."
+    case .remove:
+        return "Saved. The routing alias remains available to existing sessions."
+    case .move:
+        return "Saved. Reopen /model in Claude Code to verify the order."
+    case .sync:
+        return "Synced. Reopen /model in Claude Code to verify the configured models."
+    }
+}
+
+struct ClaudeModelPickerSectionView: View {
+    @ObservedObject var state: BasetenSwitchState
+    let client: ClientStatus
+    let isPreview: Bool
+
+    @State private var searchText = ""
+    @State private var confirmation: ClaudeModelPickerConfirmation?
+    @State private var previewError: String?
+    @State private var previewingSlug: String?
+    @State private var previewingEnable = false
+
+    var body: some View {
+        RoutingSectionCard {
+            HStack {
+                Label("Claude Code /model", systemImage: "list.bullet")
+                    .font(.headline)
+                Spacer()
+                if let pending = state.pendingClaudeModelPicker {
+                    ProgressView()
+                        .controlSize(.small)
+                        .accessibilityLabel(pending.kind.progressLabel)
+                }
+                Button("Sync") {
+                    guard !isPreview else { return }
+                    if replacementModeRequiresConversion {
+                        confirmation = .syncReplacement
+                    } else {
+                        state.requestClaudeModelPicker(
+                            .sync(convertReplacementMode: false))
+                    }
+                }
+                .disabled(
+                    !canEditConfiguredRows || client.modelPicker == nil)
+                .accessibilityIdentifier("claude-picker-sync")
+            }
+        } content: {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Claude's built-in models stay current automatically. Choose which Baseten models are appended to /model.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                pickerStateCallout
+
+                diagnosticsSection
+
+                configuredSection
+                Divider()
+                availableSection
+
+                if let notice = state.claudeModelPickerNotice {
+                    Label(notice, systemImage: "checkmark.circle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.green)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityIdentifier("claude-picker-saved")
+                }
+                ForEach(
+                    Array(state.claudeModelPickerWarnings.enumerated()),
+                    id: \.offset
+                ) { _, warning in
+                    Label(
+                        warning,
+                        systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityIdentifier("claude-picker-warning")
+                }
+                if let previewError {
+                    Label(
+                        previewError,
+                        systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                if let reason = state.claudeModelPickerMutationDisabledReason,
+                   state.pendingClaudeModelPicker == nil,
+                   !isPreview {
+                    Text(reason)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+        .accessibilityIdentifier("claude-model-picker")
+        .confirmationDialog(
+            confirmationTitle,
+            isPresented: Binding(
+                get: { confirmation != nil },
+                set: { if !$0 { confirmation = nil } }),
+            titleVisibility: .visible
+        ) {
+            confirmationActions
+        } message: {
+            switch confirmation {
+            case .enable(let preview, let convert):
+                Text(enableConfirmationMessage(
+                    preview: preview,
+                    convertsReplacementMode: convert))
+            case .chooseAlias:
+                Text("More than one configured alias routes to this model. Choose the exact alias to add.")
+            case .add(let preview, _):
+                Text("Model: \(preview.slug)\nAlias: \(preview.alias)\nLabel: \(preview.label)\nDescription: \(preview.description)")
+            case .remove:
+                Text(removeConfirmationMessage)
+            case .syncReplacement:
+                Text("Claude Code currently replaces its built-in model list. Continue only if you want Switch to convert it to append mode and preserve Claude's built-in models.")
+            case nil:
+                EmptyView()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var diagnosticsSection: some View {
+        if state.claudeModelPickerDiagnosticsLoading {
+            HStack(spacing: 8) {
+                ProgressView().controlSize(.small)
+                Text("Checking Claude picker status…")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        } else if let diagnostics = state.claudeModelPickerDiagnostics {
+            VStack(alignment: .leading, spacing: 6) {
+                diagnosticRow(
+                    "Configuration",
+                    claudeModelPickerDiagnosticLabel(
+                        key: "configuration",
+                        value: diagnostics.configuration))
+                diagnosticRow(
+                    "Claude settings",
+                    claudeModelPickerDiagnosticLabel(
+                        key: "sync",
+                        value: diagnostics.userFileSync))
+                diagnosticRow(
+                    "Overall policy",
+                    claudeModelPickerDiagnosticLabel(
+                        key: "policy",
+                        value: diagnostics.knownPolicy))
+                diagnosticRow(
+                    "Allowlist policy",
+                    claudeModelPickerDiagnosticLabel(
+                        key: "policy",
+                        value: diagnostics.allowlistPolicy))
+                diagnosticRow(
+                    "Managed policy",
+                    claudeModelPickerDiagnosticLabel(
+                        key: "policy",
+                        value: diagnostics.managedPolicy))
+                diagnosticRow(
+                    "Picker mode",
+                    claudeModelPickerDiagnosticLabel(
+                        key: "replacement",
+                        value: diagnostics.replacementMode))
+                diagnosticRow(
+                    "Runtime visibility",
+                    claudeModelPickerDiagnosticLabel(
+                        key: "runtime",
+                        value: diagnostics.runtimeVerification))
+                if !diagnostics.message.isEmpty {
+                    Label(
+                        diagnostics.message,
+                        systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                if diagnostics.savedModelUnconfigured,
+                   let savedModel = diagnostics.savedModel {
+                    Label(
+                        "Claude Code's saved default, \(savedModel), is not in the curated picker list.",
+                        systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .padding(10)
+            .background(
+                Color.secondary.opacity(0.06),
+                in: RoundedRectangle(cornerRadius: 8))
+            .accessibilityIdentifier("claude-picker-diagnostics")
+        } else if let error = state.claudeModelPickerDiagnosticsError {
+            Label(error, systemImage: "exclamationmark.triangle.fill")
+                .font(.caption)
+                .foregroundStyle(.orange)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func diagnosticRow(_ label: String, _ value: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(label)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+                .multilineTextAlignment(.trailing)
+        }
+        .font(.caption)
+    }
+
+    @ViewBuilder
+    private var pickerStateCallout: some View {
+        if client.modelPicker == nil {
+            HStack(alignment: .center, spacing: 12) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Add your configured Baseten models to /model")
+                        .font(.body.weight(.medium))
+                    Text("Setup previews and appends every configured alias. Claude's built-in models remain unchanged.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button("Set Up Model Picker") {
+                    guard !isPreview else { return }
+                    previewError = nil
+                    previewingEnable = true
+                    Task {
+                        let preview = await state
+                            .previewClaudeModelPickerEnable()
+                        guard previewingEnable else { return }
+                        previewingEnable = false
+                        if let preview {
+                            confirmation = .enable(
+                                preview,
+                                convertReplacementMode:
+                                    replacementModeRequiresConversion)
+                        } else {
+                            previewError = "Switch could not generate an exact setup preview. No changes were made."
+                        }
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!canEditConfiguredRows || previewingEnable)
+                .accessibilityIdentifier("claude-picker-enable")
+                if previewingEnable {
+                    ProgressView()
+                        .controlSize(.small)
+                        .accessibilityLabel("Previewing model picker setup")
+                }
+            }
+            .padding(12)
+            .background(
+                Color.accentColor.opacity(0.08),
+                in: RoundedRectangle(cornerRadius: 8))
+        } else if client.modelPicker?.enabled == false {
+            HStack(spacing: 10) {
+                Label(
+                    "The saved picker rows are not currently installed in Claude Code.",
+                    systemImage: "pause.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                Spacer()
+                Button("Enable") {
+                    guard !isPreview else { return }
+                    if replacementModeRequiresConversion {
+                        confirmation = .enable(
+                            ClaudeModelPickerEnablePreview(
+                                models: projection.configured),
+                            convertReplacementMode: true)
+                    } else {
+                        state.requestClaudeModelPicker(
+                            .enable(convertReplacementMode: false))
+                    }
+                }
+                .disabled(!canEditConfiguredRows)
+                .accessibilityIdentifier("claude-picker-enable")
+            }
+        }
+    }
+
+    private var configuredSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Configured for /model")
+                .font(.subheadline.weight(.semibold))
+            if projection.configured.isEmpty {
+                Text("No Baseten models are configured for /model.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("claude-picker-configured-empty")
+            } else {
+                ForEach(Array(projection.configured.enumerated()), id: \.element.id) {
+                    index, row in
+                    configuredRow(row, index: index)
+                    if index < projection.configured.count - 1 {
+                        Divider()
+                    }
+                }
+            }
+        }
+    }
+
+    private func configuredRow(
+        _ row: ClaudeModelPickerRow,
+        index: Int
+    ) -> some View {
+        HStack(alignment: .center, spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(rowDisplayLabel(row))
+                    .font(.body.weight(.medium))
+                Text(row.description)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(row.alias)
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.tertiary)
+                    .textSelection(.enabled)
+                Text(configuredRowState)
+                    .font(.caption2)
+                    .foregroundStyle(
+                        configuredRowHasAllowlistConflict
+                            ? .orange
+                            : .secondary)
+            }
+            Spacer(minLength: 12)
+            Button {
+                moveUp(index: index)
+            } label: {
+                Image(systemName: "arrow.up")
+            }
+            .buttonStyle(.borderless)
+            .disabled(!canEditConfiguredRows || index == 0)
+            .help("Move up")
+            .accessibilityLabel("Move \(rowDisplayLabel(row)) up")
+            .accessibilityIdentifier("claude-picker-move-up-\(row.alias)")
+
+            Button {
+                moveDown(index: index)
+            } label: {
+                Image(systemName: "arrow.down")
+            }
+            .buttonStyle(.borderless)
+            .disabled(
+                !canEditConfiguredRows
+                    || index == projection.configured.count - 1)
+            .help("Move down")
+            .accessibilityLabel("Move \(rowDisplayLabel(row)) down")
+            .accessibilityIdentifier("claude-picker-move-down-\(row.alias)")
+
+            Button("Remove") {
+                previewError = nil
+                confirmation = .remove(row)
+            }
+            .disabled(!canEditConfiguredRows)
+            .accessibilityIdentifier("claude-picker-remove-\(row.alias)")
+        }
+        .padding(.vertical, 3)
+        .accessibilityElement(children: .contain)
+    }
+
+    private var availableSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Available to add")
+                .font(.subheadline.weight(.semibold))
+            TextField("Search models", text: $searchText)
+                .textFieldStyle(.roundedBorder)
+                .accessibilityIdentifier("claude-picker-search")
+
+            switch state.liveModelCatalogState {
+            case .idle, .loading:
+                HStack(spacing: 8) {
+                    ProgressView().controlSize(.small)
+                    Text("Loading Baseten Model APIs…")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            case .signedOut(let reason):
+                Label(
+                    liveModelCatalogSignedOutMessage(reason),
+                    systemImage: "key.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            case .error:
+                Label(
+                    "Available models could not be loaded. Configured rows remain editable.",
+                    systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            case .ready:
+                if filteredAvailable.isEmpty {
+                    Text(searchText.isEmpty
+                        ? "Every available model is already configured."
+                        : "No available models match your search.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(filteredAvailable, id: \.slug) { model in
+                        availableRow(model)
+                    }
+                }
+            }
+        }
+    }
+
+    private func availableRow(
+        _ model: LiveModelCatalogEntry
+    ) -> some View {
+        HStack(alignment: .center, spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(model.displayLabel)
+                    .font(.body.weight(.medium))
+                Text(model.slug)
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+            Spacer(minLength: 12)
+            if previewingSlug == model.slug {
+                ProgressView()
+                    .controlSize(.small)
+                    .accessibilityLabel(
+                        "Previewing \(model.displayLabel)")
+            }
+            Button("Add") {
+                beginAddPreview(slug: model.slug, alias: nil)
+            }
+            .disabled(!canAddModels || previewingSlug != nil)
+            .accessibilityIdentifier("claude-picker-add-\(model.slug)")
+        }
+        .padding(.vertical, 3)
+    }
+
+    private var projection: ClaudeModelPickerProjection {
+        state.claudeModelPickerProjection(for: client)
+    }
+
+    private var filteredAvailable: [LiveModelCatalogEntry] {
+        let query = searchText.trimmingCharacters(
+            in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return projection.availableToAdd }
+        return projection.availableToAdd.filter {
+            $0.displayLabel.localizedCaseInsensitiveContains(query)
+                || $0.slug.localizedCaseInsensitiveContains(query)
+        }
+    }
+
+    private var canEditConfiguredRows: Bool {
+        !isPreview
+            && state.canMutateClaudeModelPicker
+            && state.pendingClaudeModelPicker == nil
+            && state.claudeModelPickerDiagnostics != nil
+            && state.claudeModelPickerDiagnostics?.userFileSync != "blocked"
+            && state.claudeModelPickerDiagnostics?.replacementMode != "blocked"
+    }
+
+    private var canAddModels: Bool {
+        canEditConfiguredRows && state.modelCatalogAllowsMutation
+    }
+
+    private var replacementModeRequiresConversion: Bool {
+        state.claudeModelPickerDiagnostics?.replacementMode == "replace"
+    }
+
+    private var configuredRowState: String {
+        claudeModelPickerConfiguredRowState(
+            allowlistPolicy:
+                state.claudeModelPickerDiagnostics?.allowlistPolicy ?? "",
+            knownPolicy:
+                state.claudeModelPickerDiagnostics?.knownPolicy ?? "")
+    }
+
+    private var configuredRowHasAllowlistConflict: Bool {
+        configuredRowState == "Possible allowlist conflict"
+    }
+
+    private var confirmationTitle: String {
+        switch confirmation {
+        case .enable:
+            return "Set up the Claude Code model picker?"
+        case .chooseAlias:
+            return "Choose an alias"
+        case .add(let preview, _):
+            return "Add \(preview.label) to /model?"
+        case .remove(let row):
+            return "Remove \(rowDisplayLabel(row)) from /model?"
+        case .syncReplacement:
+            return "Convert Claude's model picker to append mode?"
+        case nil:
+            return "Confirm model picker change"
+        }
+    }
+
+    private var removeConfirmationMessage: String {
+        var message = "The routing alias remains configured. Existing sessions may continue to use it."
+        if case .remove(let row) = confirmation,
+           state.claudeModelPickerDiagnostics?.savedModel == row.alias {
+            message += " This alias is Claude Code's saved default. Removing it from the curated list does not clear that saved default. Select a native default in /model before starting a new session."
+        }
+        if state.claudeModelPickerDiagnostics?.legacyDiscoveryEnabled == true {
+            message += " Legacy gateway model discovery is enabled, so the alias may still appear outside the curated picker list."
+        }
+        return message
+    }
+
+    @ViewBuilder
+    private var confirmationActions: some View {
+        switch confirmation {
+        case .enable(_, let convert):
+            Button(convert ? "Convert and Set Up" : "Set Up Model Picker") {
+                guard !isPreview else { return }
+                state.requestClaudeModelPicker(
+                    .enable(convertReplacementMode: convert))
+                confirmation = nil
+            }
+        case .chooseAlias(let slug, let choices):
+            ForEach(choices, id: \.alias) { choice in
+                Button(choice.alias) {
+                    confirmation = nil
+                    beginAddPreview(slug: slug, alias: choice.alias)
+                }
+            }
+        case .add(let preview, let explicitAlias):
+            Button("Add to /model") {
+                guard !isPreview else { return }
+                state.requestClaudeModelPicker(.add(
+                    slug: preview.slug,
+                    alias: explicitAlias))
+                confirmation = nil
+            }
+        case .remove(let row):
+            Button("Remove from /model", role: .destructive) {
+                guard !isPreview else { return }
+                state.requestClaudeModelPicker(.remove(alias: row.alias))
+                confirmation = nil
+            }
+        case .syncReplacement:
+            Button("Convert and Sync") {
+                guard !isPreview else { return }
+                state.requestClaudeModelPicker(
+                    .sync(convertReplacementMode: true))
+                confirmation = nil
+            }
+        case nil:
+            EmptyView()
+        }
+        Button("Cancel", role: .cancel) { confirmation = nil }
+    }
+
+    private func enableConfirmationMessage(
+        preview: ClaudeModelPickerEnablePreview,
+        convertsReplacementMode: Bool
+    ) -> String {
+        var message = "Switch will append these aliases in this order and leave Claude's built-in models unchanged:\n\(preview.models.map(\.alias).joined(separator: "\n"))"
+        if convertsReplacementMode {
+            message += "\n\nClaude Code currently replaces its built-in model list. This will explicitly convert it to append mode."
+        }
+        return message
+    }
+
+    private func beginAddPreview(slug: String, alias: String?) {
+        guard !isPreview else { return }
+        previewError = nil
+        previewingSlug = slug
+        Task {
+            let outcome = await state.previewClaudeModelPickerAdd(
+                slug: slug,
+                alias: alias)
+            guard previewingSlug == slug else { return }
+            previewingSlug = nil
+            switch outcome {
+            case .preview(let preview, let explicitAlias):
+                confirmation = .add(
+                    preview,
+                    explicitAlias: explicitAlias)
+            case .aliasChoices(let choiceSlug, let choices):
+                confirmation = .chooseAlias(
+                    slug: choiceSlug,
+                    choices: choices)
+            case nil:
+                previewError = "Switch could not generate an exact preview for this model. No changes were made."
+            }
+        }
+    }
+
+    private func rowDisplayLabel(_ row: ClaudeModelPickerRow) -> String {
+        row.label
+    }
+
+    private func moveUp(index: Int) {
+        guard !isPreview,
+              let command = claudeModelPickerMoveUpCommand(
+                rows: projection.configured,
+                index: index) else { return }
+        state.requestClaudeModelPicker(.move(
+            alias: command[1],
+            before: command[3]))
+    }
+
+    private func moveDown(index: Int) {
+        guard !isPreview,
+              let command = claudeModelPickerMoveDownCommand(
+                rows: projection.configured,
+                index: index) else { return }
+        state.requestClaudeModelPicker(.move(
+            alias: command[1],
+            before: command[3]))
+    }
+}

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/ClaudeModelPicker.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/ClaudeModelPicker.swift
@@ -51,7 +51,7 @@ enum ClaudeModelPickerMutationKind: Equatable, Sendable {
 
     var progressLabel: String {
         switch self {
-        case .enable: return "Setting up model picker"
+        case .enable: return "Enabling model picker"
         case .add: return "Adding model"
         case .remove: return "Removing model"
         case .move: return "Saving model order"
@@ -287,10 +287,21 @@ struct PendingClaudeModelPickerMutation: Equatable, Sendable {
 }
 
 private enum ClaudeModelPickerConfirmation {
-    case enable(
-        ClaudeModelPickerEnablePreview,
-        convertReplacementMode: Bool)
+    case convertReplacementMode
     case chooseAlias(slug: String, choices: [ClaudeModelPickerRow])
+}
+
+enum ClaudeModelPickerEnableDecision: Equatable, Sendable {
+    case enableDirectly
+    case confirmReplacementModeConversion
+}
+
+func claudeModelPickerEnableDecision(
+    replacementMode: String?
+) -> ClaudeModelPickerEnableDecision {
+    replacementMode == "replace"
+        ? .confirmReplacementModeConversion
+        : .enableDirectly
 }
 
 struct ClaudeModelPickerEnablePreview: Equatable, Sendable {
@@ -493,6 +504,16 @@ func claudeModelPickerCanRetrySync(
         && hasConfiguredPicker
 }
 
+func claudeModelPickerCanAddModels(
+    canEditConfiguredRows: Bool,
+    modelCatalogAllowsMutation: Bool,
+    pickerEnabled: Bool
+) -> Bool {
+    canEditConfiguredRows
+        && modelCatalogAllowsMutation
+        && pickerEnabled
+}
+
 let claudeModelPickerRestartNotice =
     "Restart Claude Code to see additions or removals."
 
@@ -687,7 +708,7 @@ func claudeModelPickerSuccessMessage(
 ) -> String {
     switch kind {
     case .enable:
-        return "Saved. Reopen /model in Claude Code to verify the configured Baseten models."
+        return "Enabled. Choose a Baseten model to add to /model."
     case .add:
         return "Added to /model."
     case .remove:
@@ -706,10 +727,8 @@ struct ClaudeModelPickerSectionView: View {
 
     @State private var searchText = ""
     @State private var confirmation: ClaudeModelPickerConfirmation?
-    @State private var previewError: String?
     @State private var addPreviewError: String?
     @State private var previewingSlug: String?
-    @State private var previewingEnable = false
     @State private var fallbackTargetEditorDraft:
         ClaudeNativeFallbackEditorDraft?
     var body: some View {
@@ -759,14 +778,6 @@ struct ClaudeModelPickerSectionView: View {
                         .fixedSize(horizontal: false, vertical: true)
                         .accessibilityIdentifier("claude-picker-warning")
                 }
-                if let previewError {
-                    Label(
-                        previewError,
-                        systemImage: "exclamationmark.triangle.fill")
-                        .font(.caption)
-                        .foregroundStyle(.orange)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
                 if let reason = state.claudeModelPickerMutationDisabledReason,
                    state.pendingClaudeModelPicker == nil,
                    !isPreview {
@@ -788,10 +799,8 @@ struct ClaudeModelPickerSectionView: View {
             confirmationActions
         } message: {
             switch confirmation {
-            case .enable(let preview, let convert):
-                Text(enableConfirmationMessage(
-                    preview: preview,
-                    convertsReplacementMode: convert))
+            case .convertReplacementMode:
+                Text("Claude Code currently replaces its built-in model list. Enabling the picker will keep those models available and append any Baseten models you add.")
             case .chooseAlias:
                 Text("More than one configured alias routes to this model. Choose the exact alias to add.")
             case nil:
@@ -1044,40 +1053,19 @@ struct ClaudeModelPickerSectionView: View {
         if client.modelPicker == nil {
             HStack(alignment: .center, spacing: 12) {
                 VStack(alignment: .leading, spacing: 3) {
-                    Text("Add your configured Baseten models to /model")
+                    Text("Enable the Claude Code model picker")
                         .font(.body.weight(.medium))
-                    Text("Setup previews and appends every configured alias. Claude's built-in models remain unchanged.")
+                    Text("Then choose which Baseten models to add. Claude's built-in models stay available.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
-                Button("Set Up Model Picker") {
-                    guard !isPreview else { return }
-                    previewError = nil
-                    previewingEnable = true
-                    Task {
-                        let preview = await state
-                            .previewClaudeModelPickerEnable()
-                        guard previewingEnable else { return }
-                        previewingEnable = false
-                        if let preview {
-                            confirmation = .enable(
-                                preview,
-                                convertReplacementMode:
-                                    replacementModeRequiresConversion)
-                        } else {
-                            previewError = "Switch could not generate an exact setup preview. No changes were made."
-                        }
-                    }
+                Button("Enable Model Picker") {
+                    enableModelPicker()
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(!canEditConfiguredRows || previewingEnable)
+                .disabled(!canEditConfiguredRows)
                 .accessibilityIdentifier("claude-picker-enable")
-                if previewingEnable {
-                    ProgressView()
-                        .controlSize(.small)
-                        .accessibilityLabel("Previewing model picker setup")
-                }
             }
             .padding(12)
             .background(
@@ -1092,16 +1080,7 @@ struct ClaudeModelPickerSectionView: View {
                     .foregroundStyle(.orange)
                 Spacer()
                 Button("Enable") {
-                    guard !isPreview else { return }
-                    if replacementModeRequiresConversion {
-                        confirmation = .enable(
-                            ClaudeModelPickerEnablePreview(
-                                models: projection.configured),
-                            convertReplacementMode: true)
-                    } else {
-                        state.requestClaudeModelPicker(
-                            .enable(convertReplacementMode: false))
-                    }
+                    enableModelPicker()
                 }
                 .disabled(!canEditConfiguredRows)
                 .accessibilityIdentifier("claude-picker-enable")
@@ -1182,7 +1161,6 @@ struct ClaudeModelPickerSectionView: View {
             .accessibilityIdentifier("claude-picker-move-down-\(row.alias)")
 
             Button("Remove") {
-                previewError = nil
                 guard !isPreview else { return }
                 state.requestClaudeModelPicker(
                     claudeModelPickerRemoveMutation(alias: row.alias))
@@ -1198,6 +1176,11 @@ struct ClaudeModelPickerSectionView: View {
         VStack(alignment: .leading, spacing: 10) {
             Text("Available to add")
                 .font(.subheadline.weight(.semibold))
+            if client.modelPicker?.enabled != true {
+                Text("Enable the model picker before adding models.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
             TextField("Search models", text: $searchText)
                 .textFieldStyle(.roundedBorder)
                 .accessibilityIdentifier("claude-picker-search")
@@ -1301,7 +1284,11 @@ struct ClaudeModelPickerSectionView: View {
     }
 
     private var canAddModels: Bool {
-        canEditConfiguredRows && state.modelCatalogAllowsMutation
+        claudeModelPickerCanAddModels(
+            canEditConfiguredRows: canEditConfiguredRows,
+            modelCatalogAllowsMutation:
+                state.modelCatalogAllowsMutation,
+            pickerEnabled: client.modelPicker?.enabled == true)
     }
 
     private var canRetryModelPickerSync: Bool {
@@ -1310,10 +1297,6 @@ struct ClaudeModelPickerSectionView: View {
                 state.claudeModelPickerDiagnostics?.userFileSync,
             canEditConfiguredRows: canEditConfiguredRows,
             hasConfiguredPicker: client.modelPicker != nil)
-    }
-
-    private var replacementModeRequiresConversion: Bool {
-        state.claudeModelPickerDiagnostics?.replacementMode == "replace"
     }
 
     private var configuredRowState: String {
@@ -1330,8 +1313,8 @@ struct ClaudeModelPickerSectionView: View {
 
     private var confirmationTitle: String {
         switch confirmation {
-        case .enable:
-            return "Set up the Claude Code model picker?"
+        case .convertReplacementMode:
+            return "Keep Claude's built-in models?"
         case .chooseAlias:
             return "Choose an alias"
         case nil:
@@ -1342,11 +1325,11 @@ struct ClaudeModelPickerSectionView: View {
     @ViewBuilder
     private var confirmationActions: some View {
         switch confirmation {
-        case .enable(_, let convert):
-            Button(convert ? "Convert and Set Up" : "Set Up Model Picker") {
+        case .convertReplacementMode:
+            Button("Convert and Enable") {
                 guard !isPreview else { return }
                 state.requestClaudeModelPicker(
-                    .enable(convertReplacementMode: convert))
+                    .enable(convertReplacementMode: true))
                 confirmation = nil
             }
         case .chooseAlias(let slug, let choices):
@@ -1362,20 +1345,22 @@ struct ClaudeModelPickerSectionView: View {
         Button("Cancel", role: .cancel) { confirmation = nil }
     }
 
-    private func enableConfirmationMessage(
-        preview: ClaudeModelPickerEnablePreview,
-        convertsReplacementMode: Bool
-    ) -> String {
-        var message = "Switch will append these aliases in this order and leave Claude's built-in models unchanged:\n\(preview.models.map(\.alias).joined(separator: "\n"))"
-        if convertsReplacementMode {
-            message += "\n\nClaude Code currently replaces its built-in model list. This will explicitly convert it to append mode."
+    private func enableModelPicker() {
+        guard !isPreview else { return }
+        switch claudeModelPickerEnableDecision(
+            replacementMode:
+                state.claudeModelPickerDiagnostics?.replacementMode
+        ) {
+        case .enableDirectly:
+            state.requestClaudeModelPicker(
+                .enable(convertReplacementMode: false))
+        case .confirmReplacementModeConversion:
+            confirmation = .convertReplacementMode
         }
-        return message
     }
 
     private func beginAddPreview(slug: String, alias: String?) {
         guard !isPreview else { return }
-        previewError = nil
         addPreviewError = nil
         previewingSlug = slug
         Task {

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/GatewayClient.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/GatewayClient.swift
@@ -124,6 +124,7 @@ struct ClientStatus: Identifiable, Equatable, Sendable {
     var unmatchedNativeModel: ModelResolution?
     var families: [FamilyEntry]
     var modelCatalog: [ModelCatalogEntry]
+    var modelPicker: ClaudeModelPickerStatus?
     var modelOptions: ClientModelOptions
 
     var id: String { name }
@@ -158,6 +159,8 @@ struct ClientStatus: Identifiable, Equatable, Sendable {
         families = familyArray.compactMap(FamilyEntry.init)
         let catalogArray = dict["model_catalog"] as? [[String: Any]] ?? []
         modelCatalog = catalogArray.compactMap(ModelCatalogEntry.init)
+        modelPicker = (dict["model_picker"] as? [String: Any])
+            .flatMap(ClaudeModelPickerStatus.init)
         modelOptions = decodeClientModelOptions(dict["model_options"])
     }
 }

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/GatewayClient.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/GatewayClient.swift
@@ -37,12 +37,17 @@ struct RoutingSnapshot: Equatable, Sendable {
     let configPath: String
     let capabilities: Set<String>
     let globalRoutingEnabled: Bool
+    let fallbackPolicy: FallbackPolicyStatus?
     let reload: ReloadStatus
     let auth: AuthStatus?
     let clients: [ClientStatus]
 
     var supportsGlobalRouting: Bool {
         capabilities.contains("global_routing")
+    }
+
+    var supportsFallbackPolicy: Bool {
+        capabilities.contains("fallback_policy")
     }
 
     var desiredMatchesActive: Bool {
@@ -63,6 +68,7 @@ struct RoutingSnapshot: Equatable, Sendable {
         configPath = status.configPath
         capabilities = Set(status.capabilities)
         globalRoutingEnabled = status.globalRoutingEnabled
+        fallbackPolicy = status.fallbackPolicy
         reload = status.reload
         auth = status.auth
         clients = status.clients
@@ -72,6 +78,8 @@ struct RoutingSnapshot: Equatable, Sendable {
          version: String,
          uptimeSeconds: Int64,
          globalRoutingEnabled: Bool,
+         capabilities: Set<String> = [],
+         fallbackPolicy: FallbackPolicyStatus? = nil,
          auth: AuthStatus?,
          clients: [ClientStatus]) {
         token = RoutingToken(routerBootID: "", activeGeneration: 0)
@@ -83,8 +91,9 @@ struct RoutingSnapshot: Equatable, Sendable {
         self.version = version
         self.uptimeSeconds = uptimeSeconds
         configPath = ""
-        capabilities = []
+        self.capabilities = capabilities
         self.globalRoutingEnabled = globalRoutingEnabled
+        self.fallbackPolicy = fallbackPolicy
         reload = ReloadStatus(state: "", error: "")
         self.auth = auth
         self.clients = clients
@@ -125,6 +134,7 @@ struct ClientStatus: Identifiable, Equatable, Sendable {
     var families: [FamilyEntry]
     var modelCatalog: [ModelCatalogEntry]
     var modelPicker: ClaudeModelPickerStatus?
+    var basetenModelFallback: BasetenModelFallbackStatus?
     var modelOptions: ClientModelOptions
 
     var id: String { name }
@@ -161,8 +171,97 @@ struct ClientStatus: Identifiable, Equatable, Sendable {
         modelCatalog = catalogArray.compactMap(ModelCatalogEntry.init)
         modelPicker = (dict["model_picker"] as? [String: Any])
             .flatMap(ClaudeModelPickerStatus.init)
+        basetenModelFallback = (dict["baseten_model_fallback"]
+            as? [String: Any])
+            .flatMap(BasetenModelFallbackStatus.init)
         modelOptions = decodeClientModelOptions(dict["model_options"])
     }
+}
+
+struct FallbackPolicyStatus: Equatable, Sendable {
+    let onBaseten429: Bool
+    let onBaseten5xx: Bool
+
+    init(onBaseten429: Bool, onBaseten5xx: Bool) {
+        self.onBaseten429 = onBaseten429
+        self.onBaseten5xx = onBaseten5xx
+    }
+
+    init?(dict: [String: Any]) {
+        guard let onBaseten429 = dict["on_baseten_429"] as? Bool,
+              let onBaseten5xx = dict["on_baseten_5xx"] as? Bool else {
+            return nil
+        }
+        self.onBaseten429 = onBaseten429
+        self.onBaseten5xx = onBaseten5xx
+    }
+}
+
+struct BasetenModelFallbackStatus: Equatable, Sendable {
+    let configuredModel: String
+    let resolvedModel: String
+    let displayName: String
+    let providerReady: Bool
+    let ready: Bool
+    let reason: String?
+    let availableModels: [BasetenModelFallbackOption]
+
+    init?(dict: [String: Any]) {
+        guard let configuredModel = dict["configured_model"] as? String,
+              let resolvedModel = dict["resolved_model"] as? String,
+              let displayName = dict["display_name"] as? String,
+              let providerReady = dict["provider_ready"] as? Bool,
+              let ready = dict["ready"] as? Bool else {
+            return nil
+        }
+        self.configuredModel = configuredModel
+        self.resolvedModel = resolvedModel
+        self.displayName = displayName
+        self.providerReady = providerReady
+        self.ready = ready
+        reason = dict["reason"] as? String
+        availableModels = decodeBasetenModelFallbackOptions(
+            dict["available_models"])
+    }
+}
+
+struct BasetenModelFallbackOption: Equatable, Sendable {
+    let model: String
+    let displayName: String
+
+    init(model: String, displayName: String) {
+        self.model = model
+        self.displayName = displayName
+    }
+
+    init?(dict: [String: Any]) {
+        guard let model = dict["model"] as? String,
+              !model.isEmpty,
+              let displayName = dict["display_name"] as? String,
+              !displayName.isEmpty else {
+            return nil
+        }
+        self.model = model
+        self.displayName = displayName
+    }
+}
+
+private func decodeBasetenModelFallbackOptions(
+    _ raw: Any?
+) -> [BasetenModelFallbackOption] {
+    // Missing means an older router. A malformed additive projection fails
+    // closed instead of presenting an unvalidated partial selector.
+    guard let raw else { return [] }
+    guard let rows = raw as? [[String: Any]] else { return [] }
+    var decoded: [BasetenModelFallbackOption] = []
+    for row in rows {
+        guard let option = BasetenModelFallbackOption(dict: row),
+              isAcceptedClaudeNativeModelID(option.model) else {
+            return []
+        }
+        decoded.append(option)
+    }
+    return decoded
 }
 
 struct FallbackStatus: Equatable, Sendable {
@@ -623,6 +722,7 @@ struct AdminStatusSnapshot: Equatable, Sendable {
     var configPath: String
     var reload: ReloadStatus
     var globalRoutingEnabled: Bool
+    var fallbackPolicy: FallbackPolicyStatus?
     var auth: AuthStatus?
     var clients: [ClientStatus]
 
@@ -646,6 +746,8 @@ struct AdminStatusSnapshot: Equatable, Sendable {
         clients = array.compactMap(ClientStatus.init)
 
         globalRoutingEnabled = dict["global_routing_enabled"] as? Bool ?? false
+        fallbackPolicy = (dict["fallback_policy"] as? [String: Any])
+            .flatMap(FallbackPolicyStatus.init)
     }
 }
 

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/PopupPreviewFixtures.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/PopupPreviewFixtures.swift
@@ -180,7 +180,7 @@ struct PopupPreviewFixture: Identifiable {
                                nativeRoute: String = "anthropic",
                                effectiveModel: String = "zai-org/GLM-5.2",
                                fallbackActive: Bool = false) -> ClientStatus {
-        ClientStatus(dict: [
+        var dict: [String: Any] = [
             "name": name,
             "enabled": true,
             "bind_addr": "127.0.0.1:45272",
@@ -238,7 +238,27 @@ struct PopupPreviewFixture: Identifiable {
                     ],
                 ],
             ],
-        ])!
+        ]
+        if name == "claude-code" {
+            dict["model_picker"] = [
+                "enabled": true,
+                "models": [
+                    [
+                        "alias": "claude-baseten-glm-5-2",
+                        "slug": "zai-org/GLM-5.2",
+                        "label": "GLM 5.2 via Baseten",
+                        "description": "Served by Baseten.",
+                    ],
+                    [
+                        "alias": "claude-baseten-kimi-k2-7-code",
+                        "slug": "moonshotai/Kimi-K2.7-Code",
+                        "label": "Kimi K2.7 Code via Baseten",
+                        "description": "Served by Baseten.",
+                    ],
+                ],
+            ]
+        }
+        return ClientStatus(dict: dict)!
     }
 
     private static func family(_ family: String,

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/PopupPreviewFixtures.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/PopupPreviewFixtures.swift
@@ -197,6 +197,27 @@ struct PopupPreviewFixture: Identifiable {
                 "served_route": fallbackActive ? nativeRoute : "",
                 "cause": fallbackActive ? "http_429" : "",
             ],
+            "baseten_model_fallback": [
+                "configured_model": "claude-opus-5",
+                "resolved_model": "claude-opus-5",
+                "display_name": "Opus",
+                "provider_ready": true,
+                "ready": true,
+                "available_models": [
+                    [
+                        "model": "claude-opus-5",
+                        "display_name": "Opus",
+                    ],
+                    [
+                        "model": "claude-sonnet-5",
+                        "display_name": "Sonnet",
+                    ],
+                    [
+                        "model": "claude-haiku-4-5",
+                        "display_name": "Haiku",
+                    ],
+                ],
+            ],
             "subagent_model": "",
             "subagent_routing": "off",
             "subagent_effective": "inherit",
@@ -247,13 +268,13 @@ struct PopupPreviewFixture: Identifiable {
                         "alias": "claude-baseten-glm-5-2",
                         "slug": "zai-org/GLM-5.2",
                         "label": "GLM 5.2 via Baseten",
-                        "description": "Served by Baseten.",
+                        "description": "Baseten primary route.",
                     ],
                     [
                         "alias": "claude-baseten-kimi-k2-7-code",
                         "slug": "moonshotai/Kimi-K2.7-Code",
                         "label": "Kimi K2.7 Code via Baseten",
-                        "description": "Served by Baseten.",
+                        "description": "Baseten primary route.",
                     ],
                 ],
             ]

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/RequestsModels.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/RequestsModels.swift
@@ -41,17 +41,25 @@ struct RequestFallback: Decodable, Equatable, Sendable {
     var attempted: Bool
     var count: Int
     var trigger: String?
+    var suppressedReason: String?
 
     enum CodingKeys: String, CodingKey {
         case attempted
         case count
         case trigger
+        case suppressedReason = "suppressed_reason"
     }
 
-    init(attempted: Bool, count: Int = 0, trigger: String? = nil) {
+    init(
+        attempted: Bool,
+        count: Int = 0,
+        trigger: String? = nil,
+        suppressedReason: String? = nil
+    ) {
         self.attempted = attempted
         self.count = count
         self.trigger = trigger
+        self.suppressedReason = suppressedReason
     }
 
     init(from decoder: Decoder) throws {
@@ -61,6 +69,9 @@ struct RequestFallback: Decodable, Equatable, Sendable {
             forKey: .attempted) ?? false
         count = try values.decodeIfPresent(Int.self, forKey: .count) ?? 0
         trigger = try values.decodeIfPresent(String.self, forKey: .trigger)
+        suppressedReason = try values.decodeIfPresent(
+            String.self,
+            forKey: .suppressedReason)
     }
 }
 

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/RequestsView.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/RequestsView.swift
@@ -250,6 +250,10 @@ private struct RequestTableRow: View {
         requestFallbackReason(item.fallback)
     }
 
+    private var fallbackHelp: String? {
+        requestFallbackHelp(item.fallback)
+    }
+
     var body: some View {
         HStack(spacing: 0) {
             Text(requestCompletedAtLabel(item.completedAt))
@@ -305,8 +309,9 @@ private struct RequestTableRow: View {
                         .background(
                             Color.orange.opacity(0.12),
                             in: Capsule())
-                        .help(fallbackReason)
+                        .help(fallbackHelp ?? fallbackReason)
                         .accessibilityIdentifier("request-fallback-reason")
+                        .accessibilityLabel(fallbackHelp ?? fallbackReason)
                 } else {
                     Text("None")
                         .font(.caption)
@@ -499,8 +504,35 @@ func requestIsError(_ item: RequestItem) -> Bool {
 }
 
 func requestFallbackReason(_ fallback: RequestFallback?) -> String? {
-    guard fallback?.attempted == true else { return nil }
-    return requestFallbackLabel(fallback?.trigger)
+    guard let fallback else { return nil }
+    if fallback.attempted {
+        return requestFallbackLabel(fallback.trigger)
+    }
+    switch fallback.suppressedReason {
+    case "policy_disabled_http_429", "policy_disabled_http_5xx":
+        return "Disabled by setting"
+    case "native_target_unconfigured":
+        return "Fallback target not configured"
+    default:
+        return nil
+    }
+}
+
+func requestFallbackHelp(_ fallback: RequestFallback?) -> String? {
+    guard let fallback else { return nil }
+    if fallback.attempted {
+        return requestFallbackLabel(fallback.trigger)
+    }
+    switch fallback.suppressedReason {
+    case "policy_disabled_http_429":
+        return "Automatic fallback for HTTP 429 is disabled by setting."
+    case "policy_disabled_http_5xx":
+        return "Automatic fallback for HTTP 5xx is disabled by setting."
+    case "native_target_unconfigured":
+        return "Automatic fallback was enabled, but a native fallback target is not configured."
+    default:
+        return nil
+    }
 }
 
 func requestModelLabel(_ item: RequestItem) -> String {

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/RouterWindow.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/RouterWindow.swift
@@ -707,6 +707,7 @@ private struct RoutingOverviewView: View {
 
                 if state.routingSnapshot != nil {
                     routingGroup
+                    automaticFallbackGroup
                     statusGroup
                 } else {
                     stopped
@@ -946,6 +947,121 @@ private struct RoutingOverviewView: View {
             }
             .padding(6)
         }
+    }
+
+    private var automaticFallbackGroup: some View {
+        RoutingSectionCard {
+            HStack {
+                Label(
+                    "Automatic Fallback",
+                    systemImage: "arrow.uturn.forward.circle")
+                    .font(.headline)
+                Spacer()
+                if state.pendingFallbackPolicy != nil {
+                    ProgressView()
+                        .controlSize(.small)
+                        .accessibilityLabel(
+                            "Changing automatic fallback settings")
+                }
+            }
+        } content: {
+            VStack(alignment: .leading, spacing: 14) {
+                if let unavailable = state.fallbackPolicyUnavailableMessage {
+                    fallbackUnavailableRow(
+                        title: "Rate limits (HTTP 429)",
+                        identifier: "fallback-policy-429-unavailable")
+                    Divider()
+                    fallbackUnavailableRow(
+                        title: "Server errors (HTTP 5xx)",
+                        identifier: "fallback-policy-5xx-unavailable")
+                    Text(unavailable)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityIdentifier(
+                            "fallback-policy-unavailable")
+                } else {
+                    fallbackToggle(
+                        title: "Rate limits (HTTP 429)",
+                        description: "When a request routed to Baseten is rate limited, try the client's native provider once and use it briefly while Baseten recovers.",
+                        trigger: .http429,
+                        isOn: state.displayedFallback429,
+                        identifier: "fallback-policy-429")
+                    Divider()
+                    fallbackToggle(
+                        title: "Server errors (HTTP 5xx)",
+                        description: "When a request routed to Baseten returns a server error, try the client's native provider once and use it briefly while Baseten recovers.",
+                        trigger: .http5xx,
+                        isOn: state.displayedFallback5xx,
+                        identifier: "fallback-policy-5xx")
+                }
+                Text("Native Claude requests fall back to the exact model Claude requested. Baseten models selected from /model fall back to the model configured on the Claude Code page.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                if state.fallbackPolicyWarningVisible {
+                    Label(
+                        "Cross-provider fallback replays the current conversation. This includes models selected from /model; provider-specific reasoning history may be rejected during tool-use continuation.",
+                        systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityIdentifier(
+                            "fallback-policy-provider-affinity-warning")
+                }
+                if state.fallbackPolicyUnavailableMessage == nil,
+                   let reason = state.fallbackPolicyMutationDisabledReason {
+                    Text(reason)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .padding(6)
+        }
+        .accessibilityIdentifier("overview-automatic-fallback")
+    }
+
+    private func fallbackToggle(
+        title: String,
+        description: String,
+        trigger: FallbackPolicyTrigger,
+        isOn: Bool,
+        identifier: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Toggle(
+                title,
+                isOn: Binding(
+                    get: { isOn },
+                    set: { enabled in
+                        guard !isPreview else { return }
+                        state.requestFallbackPolicy(
+                            trigger,
+                            enabled: enabled)
+                    }))
+                .disabled(!state.canMutateFallbackSettings)
+                .accessibilityIdentifier(identifier)
+            Text(description)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func fallbackUnavailableRow(
+        title: String,
+        identifier: String
+    ) -> some View {
+        HStack {
+            Text(title)
+            Spacer()
+            Text("Unavailable")
+                .foregroundStyle(.secondary)
+        }
+        .font(.callout)
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier(identifier)
     }
 
     private var stopped: some View {

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/RouterWindow.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/RouterWindow.swift
@@ -234,6 +234,9 @@ final class RouterWindowController: NSObject, NSWindowDelegate, NSToolbarDelegat
             selection: navigation.selection
         ) {
             state.requestClientPageRefresh()
+            if navigation.selection == .client("claude-code") {
+                state.requestClaudeModelPickerDiagnosticsRefresh()
+            }
         } else {
             state.requestInteractiveRefresh(includeStats: false)
             if navigation.selection == .overview {
@@ -272,6 +275,9 @@ final class RouterWindowController: NSObject, NSWindowDelegate, NSToolbarDelegat
             return
         }
         state.ensureModelCatalogLoaded()
+        if selection == .client("claude-code") {
+            state.ensureClaudeModelPickerDiagnosticsLoaded()
+        }
     }
 }
 
@@ -679,6 +685,9 @@ private struct RouterConfigurationView: View {
             return
         }
         state.ensureModelCatalogLoaded()
+        if selection == .client("claude-code") {
+            state.ensureClaudeModelPickerDiagnosticsLoaded()
+        }
     }
 }
 
@@ -998,6 +1007,12 @@ private struct ClientRoutingView: View {
                     warnings
                     if presentation.showsModelRouting {
                         modelRoutingSection
+                    }
+                    if client.name == "claude-code" {
+                        ClaudeModelPickerSectionView(
+                            state: state,
+                            client: client,
+                            isPreview: isPreview)
                     }
                     if presentation.showsReasoning {
                         reasoningSection

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/RouterWindow.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/RouterWindow.swift
@@ -999,16 +999,6 @@ private struct RoutingOverviewView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
-                if state.fallbackPolicyWarningVisible {
-                    Label(
-                        "Cross-provider fallback replays the current conversation. This includes models selected from /model; provider-specific reasoning history may be rejected during tool-use continuation.",
-                        systemImage: "exclamationmark.triangle.fill")
-                        .font(.caption)
-                        .foregroundStyle(.orange)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .accessibilityIdentifier(
-                            "fallback-policy-provider-affinity-warning")
-                }
                 if state.fallbackPolicyUnavailableMessage == nil,
                    let reason = state.fallbackPolicyMutationDisabledReason {
                     Text(reason)

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/RuntimeCoordination.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/RuntimeCoordination.swift
@@ -452,11 +452,13 @@ struct GlobalMutationReceipt: Equatable, Sendable {
     var activeConfigHash: String
     var applied: Bool
     var reconciliationRequired: Bool
+    var reconciliationAction: String
     var blockingOperationID: String
     var outcome: String
     var cleanupPending: Bool
     var requestFingerprint: String
     var identityStrength: String
+    var warnings: [String]
     var errorCode: String
     var errorMessage: String
     var errorRetryable: Bool
@@ -480,11 +482,15 @@ struct GlobalMutationReceipt: Equatable, Sendable {
         applied = dict["applied"] as? Bool ?? false
         reconciliationRequired =
             dict["reconciliation_required"] as? Bool ?? false
+        reconciliationAction =
+            dict["reconciliation_action"] as? String ?? ""
         blockingOperationID = dict["blocking_operation_id"] as? String ?? ""
         outcome = dict["outcome"] as? String ?? ""
         cleanupPending = dict["cleanup_pending"] as? Bool ?? false
         requestFingerprint = dict["request_fingerprint"] as? String ?? ""
         identityStrength = dict["identity_strength"] as? String ?? ""
+        warnings = (dict["warnings"] as? [String] ?? [])
+            .filter { !$0.isEmpty }
         let error = dict["error"] as? [String: Any]
         errorCode = error?["code"] as? String ?? ""
         errorMessage = error?["message"] as? String ?? ""
@@ -531,13 +537,26 @@ func allowlistedCLIEnvironment(
     ambient: [String: String] = ProcessInfo.processInfo.environment,
     overrides: [String: String]
 ) -> [String: String] {
-    let fixedPath =
-        "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    var executableSearchPaths = [
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+        "/usr/bin",
+        "/bin",
+        "/usr/sbin",
+        "/sbin",
+    ]
+    if let localBin = currentUserLocalBin(home: ambient["HOME"]) {
+        // Keep system locations first while supporting Claude Code's standard
+        // user-local installer location without inheriting an ambient PATH.
+        executableSearchPaths.append(localBin)
+    }
     let inherited = [
         "HOME", "USER", "LOGNAME", "SHELL", "TMPDIR",
         "LANG", "LC_ALL",
     ]
-    var result: [String: String] = ["PATH": fixedPath]
+    var result: [String: String] = [
+        "PATH": executableSearchPaths.joined(separator: ":"),
+    ]
     for key in inherited {
         if let value = ambient[key], !value.isEmpty {
             result[key] = value
@@ -547,6 +566,17 @@ func allowlistedCLIEnvironment(
         result[key] = value
     }
     return result
+}
+
+private func currentUserLocalBin(home: String?) -> String? {
+    guard let home,
+          !home.isEmpty,
+          home.hasPrefix("/"),
+          !home.contains(":"),
+          !home.contains("\0") else { return nil }
+    return URL(fileURLWithPath: home, isDirectory: true)
+        .appendingPathComponent(".local/bin", isDirectory: true)
+        .standardizedFileURL.path
 }
 
 /// Returns a user-facing refusal when any Preview runtime entry can escape the

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/RuntimeCoordination.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/RuntimeCoordination.swift
@@ -489,12 +489,26 @@ struct GlobalMutationReceipt: Equatable, Sendable {
         cleanupPending = dict["cleanup_pending"] as? Bool ?? false
         requestFingerprint = dict["request_fingerprint"] as? String ?? ""
         identityStrength = dict["identity_strength"] as? String ?? ""
-        warnings = (dict["warnings"] as? [String] ?? [])
-            .filter { !$0.isEmpty }
+        warnings = decodeMutationWarnings(dict["warnings"])
         let error = dict["error"] as? [String: Any]
         errorCode = error?["code"] as? String ?? ""
         errorMessage = error?["message"] as? String ?? ""
         errorRetryable = error?["retryable"] as? Bool ?? false
+    }
+}
+
+private func decodeMutationWarnings(_ raw: Any?) -> [String] {
+    guard let values = raw as? [Any] else { return [] }
+    return values.compactMap { value in
+        if let warning = value as? String {
+            return warning.isEmpty ? nil : warning
+        }
+        if let object = value as? [String: Any],
+           let code = object["code"] as? String,
+           !code.isEmpty {
+            return code
+        }
+        return nil
     }
 }
 

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/ClaudeModelPickerTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/ClaudeModelPickerTests.swift
@@ -563,6 +563,47 @@ final class ClaudeModelPickerTests: XCTestCase {
             hasConfiguredPicker: false))
     }
 
+    func testEnableConfirmsOnlyWhenReplacementModeMustBeConverted() {
+        XCTAssertEqual(
+            claudeModelPickerEnableDecision(replacementMode: nil),
+            .enableDirectly)
+        XCTAssertEqual(
+            claudeModelPickerEnableDecision(replacementMode: "append"),
+            .enableDirectly)
+        XCTAssertEqual(
+            claudeModelPickerEnableDecision(replacementMode: "blocked"),
+            .enableDirectly)
+        XCTAssertEqual(
+            claudeModelPickerEnableDecision(replacementMode: "replace"),
+            .confirmReplacementModeConversion)
+    }
+
+    func testEnableSuccessCopyDoesNotClaimModelsWereAdded() {
+        XCTAssertEqual(
+            claudeModelPickerSuccessMessage(
+                .enable(convertReplacementMode: false)),
+            "Enabled. Choose a Baseten model to add to /model.")
+    }
+
+    func testAddRequiresAnEnabledPickerAndMutableCatalog() {
+        XCTAssertTrue(claudeModelPickerCanAddModels(
+            canEditConfiguredRows: true,
+            modelCatalogAllowsMutation: true,
+            pickerEnabled: true))
+        XCTAssertFalse(claudeModelPickerCanAddModels(
+            canEditConfiguredRows: true,
+            modelCatalogAllowsMutation: true,
+            pickerEnabled: false))
+        XCTAssertFalse(claudeModelPickerCanAddModels(
+            canEditConfiguredRows: false,
+            modelCatalogAllowsMutation: true,
+            pickerEnabled: true))
+        XCTAssertFalse(claudeModelPickerCanAddModels(
+            canEditConfiguredRows: true,
+            modelCatalogAllowsMutation: false,
+            pickerEnabled: true))
+    }
+
     func testMalformedPickerProjectionFailsClosedWithoutDroppingRows() throws {
         let client = try XCTUnwrap(ClientStatus(dict: [
             "name": "claude-code",

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/ClaudeModelPickerTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/ClaudeModelPickerTests.swift
@@ -1,0 +1,947 @@
+import Foundation
+import ServiceManagement
+import XCTest
+@testable import BasetenSwitch
+
+private actor PickerSequencedAdminReader: AdminStatusReading {
+    private var snapshots: [AdminStatusSnapshot]
+
+    init(_ snapshots: [AdminStatusSnapshot]) {
+        self.snapshots = snapshots
+    }
+
+    func fetchStatus() async throws -> AdminStatusSnapshot {
+        guard !snapshots.isEmpty else {
+            throw GatewayClientError.invalidPayload
+        }
+        if snapshots.count == 1 { return snapshots[0] }
+        return snapshots.removeFirst()
+    }
+
+    func fetchStats(
+        windowSeconds: Int,
+        bucketSeconds: Int
+    ) async throws -> StatsSnapshot {
+        StatsSnapshot(dict: [:])
+    }
+}
+
+private actor PickerCatalogReader: ModelCatalogReading {
+    func fetchModelCatalog() async throws -> LiveModelCatalogSnapshot {
+        LiveModelCatalogSnapshot(dict: [
+            "state": "ready",
+            "signed_out_reason": "",
+            "models": [[
+                "slug": "org/b",
+                "display_name": "B",
+            ]],
+            "fetched_at": "2026-08-29T00:00:00Z",
+            "error": "",
+        ])!
+    }
+}
+
+private actor PickerMutationRunner: CLIRunning {
+    private(set) var requests: [CLIExecutionRequest] = []
+
+    func run(_ request: CLIExecutionRequest) async -> CLIExecutionResult {
+        requests.append(request)
+        if request.arguments.suffix(4).elementsEqual([
+            "claude", "picker", "status", "--json",
+        ]) {
+            return pickerDiagnosticsResult()
+        }
+        if request.arguments.contains("--dry-run") {
+            let addPreview: [String: Any] = [
+                "alias": "claude-baseten-b",
+                "slug": "org/b",
+                "label": "B via Baseten",
+                "description": "Served by Baseten.",
+            ]
+            let object: [String: Any]
+            if request.arguments.contains("enable") {
+                object = ["models": [
+                    [
+                        "alias": "claude-baseten-a",
+                        "slug": "org/a",
+                        "label": "A via Baseten",
+                        "description": "Served by Baseten.",
+                    ],
+                    addPreview,
+                ]]
+            } else {
+                object = addPreview
+            }
+            let data = try! JSONSerialization.data(withJSONObject: object)
+            return CLIExecutionResult(
+                status: 0,
+                standardOutput: String(decoding: data, as: UTF8.self),
+                standardError: "",
+                timedOut: false)
+        }
+        let operationID = argumentValue("--operation-id", request.arguments)
+            ?? ""
+        let slug = request.arguments.last ?? ""
+        let object: [String: Any] = [
+            "ok": true,
+            "operation_id": operationID,
+            "operation": "add_claude_picker_model",
+            "client": "claude-code",
+            "key": "model_picker",
+            "requested_target": slug,
+            "desired_config_hash": "sha256:picker-updated",
+            "active_config_hash": "sha256:picker-updated",
+            "active_token": "picker-boot:2",
+            "applied": true,
+            "reconciliation_required": false,
+            "outcome": "applied",
+            "warnings": [
+                "Claude Code may require reopening /model.",
+            ],
+            "error": NSNull(),
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: object)
+        return CLIExecutionResult(
+            status: 0,
+            standardOutput: String(decoding: data, as: UTF8.self),
+            standardError: "",
+            timedOut: false)
+    }
+
+    private func argumentValue(
+        _ flag: String,
+        _ arguments: [String]
+    ) -> String? {
+        guard let index = arguments.firstIndex(of: flag),
+              arguments.indices.contains(index + 1) else { return nil }
+        return arguments[index + 1]
+    }
+}
+
+private actor PickerSettingsRecoveryRunner: CLIRunning {
+    private(set) var requests: [CLIExecutionRequest] = []
+
+    func run(_ request: CLIExecutionRequest) async -> CLIExecutionResult {
+        requests.append(request)
+        if request.arguments.suffix(4).elementsEqual([
+            "claude", "picker", "status", "--json",
+        ]) {
+            return pickerDiagnosticsResult()
+        }
+        let operationID = argumentValue(
+            "--operation-id",
+            request.arguments) ?? ""
+        let syncing = request.arguments.suffix(3).elementsEqual([
+            "claude", "picker", "sync",
+        ])
+        let operation = syncing
+            ? "sync_claude_picker"
+            : "add_claude_picker_model"
+        let object: [String: Any] = [
+            "ok": syncing,
+            "operation_id": operationID,
+            "operation": operation,
+            "client": "claude-code",
+            "key": "model_picker",
+            "requested_target": syncing ? "" : "org/b",
+            "desired_config_hash": "sha256:picker-updated",
+            "active_config_hash": "sha256:picker-updated",
+            "active_token": "picker-boot:2",
+            "applied": true,
+            "reconciliation_required": !syncing,
+            "reconciliation_action": syncing ? "" : "claude_picker_sync",
+            "outcome": syncing ? "applied" : "settings_sync_pending",
+            "error": syncing ? NSNull() : [
+                "code": "settings_sync_failed",
+                "message": "settings sync pending",
+                "retryable": true,
+            ],
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: object)
+        return CLIExecutionResult(
+            status: syncing ? 0 : 1,
+            standardOutput: String(decoding: data, as: UTF8.self),
+            standardError: "",
+            timedOut: false)
+    }
+
+    private func argumentValue(
+        _ flag: String,
+        _ arguments: [String]
+    ) -> String? {
+        guard let index = arguments.firstIndex(of: flag),
+              arguments.indices.contains(index + 1) else { return nil }
+        return arguments[index + 1]
+    }
+}
+
+private actor PickerManualResolutionRunner: CLIRunning {
+    private(set) var requests: [CLIExecutionRequest] = []
+    private static let fingerprint =
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+    func run(_ request: CLIExecutionRequest) async -> CLIExecutionResult {
+        requests.append(request)
+        if request.arguments.suffix(4).elementsEqual([
+            "claude", "picker", "status", "--json",
+        ]) {
+            return pickerDiagnosticsResult(userFileSync: "blocked")
+        }
+        let operationID = argumentValue(
+            "--operation-id",
+            request.arguments)
+            ?? request.arguments.last
+            ?? ""
+        let reconciling = request.arguments.contains("reconcile")
+        let object: [String: Any] = [
+            "ok": reconciling,
+            "operation_id": operationID,
+            "operation": "add_claude_picker_model",
+            "client": "claude-code",
+            "key": "model_picker",
+            "requested_target": "org/b",
+            "desired_config_hash": "sha256:picker-updated",
+            "active_config_hash": reconciling
+                ? "sha256:picker-updated"
+                : "sha256:picker-initial",
+            "active_token": reconciling ? "picker-boot:2" : "picker-boot:1",
+            "applied": reconciling,
+            "reconciliation_required": !reconciling,
+            "reconciliation_action": reconciling
+                ? ""
+                : "mutation_reconcile_then_manual_claude_settings_resolution",
+            "outcome": reconciling ? "applied" : "manual_resolution_required",
+            "identity_strength": "exact",
+            "request_fingerprint": Self.fingerprint,
+            "error": reconciling ? NSNull() : [
+                "code": "manual_resolution_required",
+                "message": "Claude settings require manual resolution",
+                "retryable": false,
+            ],
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: object)
+        return CLIExecutionResult(
+            status: reconciling ? 0 : 1,
+            standardOutput: String(decoding: data, as: UTF8.self),
+            standardError: "",
+            timedOut: false)
+    }
+
+    private func argumentValue(
+        _ flag: String,
+        _ arguments: [String]
+    ) -> String? {
+        guard let index = arguments.firstIndex(of: flag),
+              arguments.indices.contains(index + 1) else { return nil }
+        return arguments[index + 1]
+    }
+}
+
+private func pickerDiagnosticsResult(
+    userFileSync: String = "synced"
+) -> CLIExecutionResult {
+    let data = try! JSONSerialization.data(withJSONObject: [
+        "enabled": true,
+        "configuration": "enabled",
+        "user_file_sync": userFileSync,
+        "known_policy": "no_known_conflict",
+        "allowlist_policy": "no_known_conflict",
+        "managed_policy": "unverified",
+        "replacement_mode": "append",
+        "runtime_verification": "unverified",
+        "configured_rows": 2,
+        "installed_rows": 2,
+        "settings_path": "/tmp/claude/settings.json",
+        "legacy_discovery_enabled": false,
+    ])
+    return CLIExecutionResult(
+        status: 0,
+        standardOutput: String(decoding: data, as: UTF8.self),
+        standardError: "",
+        timedOut: false)
+}
+
+@MainActor
+private final class PickerLoginItemService: LoginItemServicing {
+    var status: SMAppService.Status = .notRegistered
+    func reconcileAtLaunch() {}
+    func toggle() {}
+    func openSystemSettings() {}
+}
+
+final class ClaudeModelPickerTests: XCTestCase {
+    func testClientStatusDecodesOrderedAliasOnlyPickerProjection() throws {
+        let client = try XCTUnwrap(ClientStatus(dict: [
+            "name": "claude-code",
+            "model_picker": [
+                "enabled": true,
+                "models": [
+                    [
+                        "alias": "claude-baseten-kimi-k2-5",
+                        "slug": "moonshotai/Kimi-K2.5",
+                        "label": "Kimi K2.5 via Baseten",
+                        "description": "Served by Baseten.",
+                    ],
+                    [
+                        "alias": "claude-baseten-glm-5-2",
+                        "slug": "zai-org/GLM-5.2",
+                        "label": "GLM 5.2 via Baseten",
+                        "description": "Served by Baseten.",
+                    ],
+                ],
+            ],
+        ]))
+
+        XCTAssertEqual(client.modelPicker?.enabled, true)
+        XCTAssertEqual(client.modelPicker?.models.map(\.alias), [
+            "claude-baseten-kimi-k2-5",
+            "claude-baseten-glm-5-2",
+        ])
+        XCTAssertEqual(
+            client.modelPicker?.models.last?.label,
+            "GLM 5.2 via Baseten")
+    }
+
+    func testPickerDiagnosticsDecodeIndependentStatusAxes() throws {
+        let diagnostics = try XCTUnwrap(ClaudeModelPickerDiagnostics(json: """
+        {
+          "enabled": true,
+          "configuration": "enabled",
+          "user_file_sync": "out_of_sync",
+          "known_policy": "possible_allowlist_conflict",
+          "allowlist_policy": "possible_conflict",
+          "managed_policy": "unverified",
+          "replacement_mode": "replace",
+          "runtime_verification": "unverified",
+          "configured_rows": 3,
+          "installed_rows": 2,
+          "settings_path": "/private/path/not-presented",
+          "legacy_discovery_enabled": true,
+          "saved_model": "claude-baseten-old",
+          "saved_model_unconfigured": true,
+          "message": "Configured rows are not all installed."
+        }
+        """))
+
+        XCTAssertTrue(diagnostics.enabled)
+        XCTAssertEqual(diagnostics.userFileSync, "out_of_sync")
+        XCTAssertEqual(diagnostics.configuration, "enabled")
+        XCTAssertEqual(
+            diagnostics.knownPolicy,
+            "possible_allowlist_conflict")
+        XCTAssertEqual(diagnostics.runtimeVerification, "unverified")
+        XCTAssertEqual(diagnostics.allowlistPolicy, "possible_conflict")
+        XCTAssertEqual(diagnostics.managedPolicy, "unverified")
+        XCTAssertEqual(diagnostics.replacementMode, "replace")
+        XCTAssertEqual(diagnostics.configuredRows, 3)
+        XCTAssertEqual(diagnostics.installedRows, 2)
+        XCTAssertTrue(diagnostics.legacyDiscoveryEnabled)
+        XCTAssertEqual(diagnostics.savedModel, "claude-baseten-old")
+        XCTAssertTrue(diagnostics.savedModelUnconfigured)
+        XCTAssertEqual(
+            claudeModelPickerDiagnosticLabel(
+                key: "runtime",
+                value: diagnostics.runtimeVerification),
+            "Unverified")
+    }
+
+    func testConfiguredRowStatePrefersAllowlistConflictOtherwiseRuntime()
+    {
+        XCTAssertEqual(
+            claudeModelPickerConfiguredRowState(
+                allowlistPolicy: "possible_conflict",
+                knownPolicy: "possible_allowlist_conflict"),
+            "Possible allowlist conflict")
+        XCTAssertEqual(
+            claudeModelPickerConfiguredRowState(
+                allowlistPolicy: "no_known_conflict",
+                knownPolicy: "no_known_conflict"),
+            "Runtime unverified")
+    }
+
+    func testMalformedPickerProjectionFailsClosedWithoutDroppingRows() throws {
+        let client = try XCTUnwrap(ClientStatus(dict: [
+            "name": "claude-code",
+            "model_picker": [
+                "enabled": true,
+                "models": [
+                    [
+                        "alias": "claude-baseten-glm-5-2",
+                        "slug": "zai-org/GLM-5.2",
+                    ],
+                    ["alias": "missing-slug"],
+                ],
+            ],
+        ]))
+
+        XCTAssertNil(client.modelPicker)
+    }
+
+    func testProjectionSubtractsSelectedSlugsDeduplicatesAndSorts() throws {
+        let status = try pickerStatus([
+            pickerRow(
+                alias: "claude-baseten-glm-5-2",
+                slug: "zai-org/GLM-5.2",
+                label: "GLM 5.2 via Baseten"),
+        ])
+        let projection = projectClaudeModelPicker(
+            status: status,
+            liveState: .ready([
+                liveModel("zai-org/GLM-5.2", "GLM 5.2"),
+                liveModel("zeta/Zed", "Zed"),
+                liveModel("alpha/Alpha", "Alpha"),
+                liveModel("alpha/Alpha", "Duplicate Alpha"),
+            ]))
+
+        XCTAssertEqual(projection.configured.map(\.slug), [
+            "zai-org/GLM-5.2",
+        ])
+        XCTAssertEqual(projection.availableToAdd.map(\.slug), [
+            "alpha/Alpha",
+            "zeta/Zed",
+        ])
+    }
+
+    func testOfflineProjectionKeepsConfiguredRowsAndDisablesAdditions()
+        throws {
+        let status = try pickerStatus([
+            pickerRow(
+                alias: "claude-baseten-glm-5-2",
+                slug: "zai-org/GLM-5.2",
+                label: "GLM 5.2 via Baseten"),
+        ])
+
+        for state in [
+            LiveModelCatalogLoadState.idle,
+            .loading,
+            .signedOut(.notSignedIn),
+            .error("unavailable"),
+        ] {
+            let projection = projectClaudeModelPicker(
+                status: status,
+                liveState: state)
+            XCTAssertEqual(projection.configured, status.models)
+            XCTAssertTrue(projection.availableToAdd.isEmpty)
+        }
+    }
+
+    func testAddPreviewDecodesCoreOwnedExactPresentation() throws {
+        let preview = try XCTUnwrap(ClaudeModelPickerAddPreview(json: """
+        {
+          "alias": "claude-baseten-glm-5-2",
+          "slug": "zai-org/GLM-5.2",
+          "label": "GLM 5.2 via Baseten",
+          "description": "Served by Baseten."
+        }
+        """))
+
+        XCTAssertEqual(preview.alias, "claude-baseten-glm-5-2")
+        XCTAssertEqual(preview.slug, "zai-org/GLM-5.2")
+        XCTAssertEqual(preview.label, "GLM 5.2 via Baseten")
+        XCTAssertEqual(preview.description, "Served by Baseten.")
+        XCTAssertNil(ClaudeModelPickerAddPreview(
+            json: "{\"slug\":\"zai-org/GLM-5.2\"}"))
+    }
+
+    func testAddPreviewDecodesStructuredAmbiguousAliasChoices() throws {
+        let outcome = try XCTUnwrap(ClaudeModelPickerAddPreviewOutcome(
+            json: """
+            {
+              "ok": false,
+              "slug": "org/model",
+              "alias_choices": [
+                {
+                  "alias": "claude-baseten-a",
+                  "slug": "org/model",
+                  "label": "Model via Baseten",
+                  "description": "Served by Baseten."
+                },
+                {
+                  "alias": "claude-baseten-b",
+                  "slug": "org/model",
+                  "label": "Model via Baseten",
+                  "description": "Served by Baseten."
+                }
+              ],
+              "error": {
+                "code": "ambiguous_alias",
+                "message": "select one",
+                "retryable": false
+              }
+            }
+            """,
+            status: 1,
+            explicitAlias: nil))
+
+        guard case .aliasChoices(let slug, let choices) = outcome else {
+            return XCTFail("expected structured alias choices")
+        }
+        XCTAssertEqual(slug, "org/model")
+        XCTAssertEqual(
+            choices.map(\.alias),
+            ["claude-baseten-a", "claude-baseten-b"])
+        XCTAssertNil(ClaudeModelPickerAddPreviewOutcome(
+            json: "{\"ok\":false,\"error\":{\"code\":\"ambiguous_alias\"}}",
+            status: 1,
+            explicitAlias: nil))
+    }
+
+    func testEnablePreviewPreservesCoreOwnedExactOrderAndPresentation()
+        throws {
+        let preview = try XCTUnwrap(ClaudeModelPickerEnablePreview(json: """
+        {
+          "models": [
+            {
+              "alias": "claude-baseten-z",
+              "slug": "org/z",
+              "label": "Z via Baseten",
+              "description": "Served by Baseten."
+            },
+            {
+              "alias": "claude-baseten-a",
+              "slug": "org/a",
+              "label": "A via Baseten",
+              "description": "Served by Baseten."
+            }
+          ]
+        }
+        """))
+
+        XCTAssertEqual(
+            preview.models.map(\.alias),
+            ["claude-baseten-z", "claude-baseten-a"])
+        XCTAssertEqual(preview.models.first?.label, "Z via Baseten")
+        XCTAssertNil(ClaudeModelPickerEnablePreview(
+            json: "{\"models\":[]}"))
+    }
+
+    func testMoveCommandsSupportBothDirectionsIncludingFinalPosition()
+        throws {
+        let rows = [
+            pickerRow(alias: "a", slug: "org/a", label: "A"),
+            pickerRow(alias: "b", slug: "org/b", label: "B"),
+            pickerRow(alias: "c", slug: "org/c", label: "C"),
+        ]
+
+        XCTAssertEqual(claudeModelPickerMoveUpCommand(rows: rows, index: 1), [
+            "move", "b", "--before", "a",
+        ])
+        XCTAssertEqual(claudeModelPickerMoveDownCommand(
+            rows: rows,
+            index: 1), [
+                "move", "c", "--before", "b",
+            ])
+        XCTAssertNil(claudeModelPickerMoveUpCommand(rows: rows, index: 0))
+        XCTAssertNil(claudeModelPickerMoveDownCommand(rows: rows, index: 2))
+    }
+
+    func testMutationCommandsAndReceiptOperationsMatchCLIContract() {
+        XCTAssertEqual(
+            ClaudeModelPickerMutationKind.enable(
+                convertReplacementMode: false).command,
+            ["claude", "picker", "enable"])
+        XCTAssertEqual(
+            ClaudeModelPickerMutationKind.add(
+                slug: "org/model",
+                alias: nil).command,
+            ["claude", "picker", "add", "org/model"])
+        XCTAssertEqual(
+            ClaudeModelPickerMutationKind.add(
+                slug: "org/model",
+                alias: "claude-baseten-model").command,
+            [
+                "claude", "picker", "add", "org/model",
+                "--alias", "claude-baseten-model",
+            ])
+        XCTAssertEqual(
+            ClaudeModelPickerMutationKind.add(
+                slug: "org/model",
+                alias: "claude-baseten-model").requestedTarget,
+            "org/model via claude-baseten-model")
+        XCTAssertEqual(
+            ClaudeModelPickerMutationKind.remove(alias: "alias").command,
+            ["claude", "picker", "remove", "alias"])
+        XCTAssertEqual(
+            ClaudeModelPickerMutationKind.move(
+                alias: "b",
+                before: "a").command,
+            ["claude", "picker", "move", "b", "--before", "a"])
+        XCTAssertEqual(
+            ClaudeModelPickerMutationKind.move(
+                alias: "b",
+                before: "a").requestedTarget,
+            "b before a")
+        XCTAssertEqual(
+            ClaudeModelPickerMutationKind.sync(
+                convertReplacementMode: false).command,
+            ["claude", "picker", "sync"])
+        XCTAssertEqual(
+            ClaudeModelPickerMutationKind.enable(
+                convertReplacementMode: true).command,
+            [
+                "claude", "picker", "enable",
+                "--convert-replacement-mode",
+            ])
+        XCTAssertEqual(
+            ClaudeModelPickerMutationKind.add(
+                slug: "org/model",
+                alias: nil)
+                .receiptOperation,
+            "add_claude_picker_model")
+    }
+
+    func testReceiptDecodesReconcileThenManualSettingsAction() throws {
+        let receipt = try XCTUnwrap(GlobalMutationReceipt(json: """
+        {
+          "ok": false,
+          "operation_id": "op-manual",
+          "operation": "remove_claude_picker_model",
+          "client": "claude-code",
+          "key": "model_picker",
+          "requested_target": "claude-baseten-model",
+          "applied": false,
+          "reconciliation_required": true,
+          "reconciliation_action": "mutation_reconcile_then_manual_claude_settings_resolution",
+          "outcome": "manual_resolution_required",
+          "warnings": [
+            "The saved default still references this alias."
+          ],
+          "error": {
+            "code": "manual_resolution_required",
+            "message": "manual resolution required",
+            "retryable": false
+          }
+        }
+        """))
+
+        XCTAssertEqual(
+            receipt.reconciliationAction,
+            "mutation_reconcile_then_manual_claude_settings_resolution")
+        XCTAssertTrue(receipt.reconciliationRequired)
+        XCTAssertFalse(receipt.applied)
+        XCTAssertEqual(receipt.errorCode, "manual_resolution_required")
+        XCTAssertFalse(receipt.errorRetryable)
+        XCTAssertEqual(receipt.warnings, [
+            "The saved default still references this alias.",
+        ])
+    }
+
+    func testMutationConfirmationUsesActiveOrderedProjection() throws {
+        let before = try pickerStatus([
+            pickerRow(alias: "a", slug: "org/a", label: "A"),
+            pickerRow(alias: "b", slug: "org/b", label: "B"),
+        ])
+        let afterMove = try pickerStatus([
+            pickerRow(alias: "b", slug: "org/b", label: "B"),
+            pickerRow(alias: "a", slug: "org/a", label: "A"),
+        ])
+
+        XCTAssertTrue(claudeModelPickerMutationConfirmed(
+            .move(alias: "b", before: "a"),
+            status: afterMove))
+        XCTAssertFalse(claudeModelPickerMutationConfirmed(
+            .move(alias: "b", before: "a"),
+            status: before))
+        XCTAssertTrue(claudeModelPickerMutationConfirmed(
+            .remove(alias: "b"),
+            status: try pickerStatus([
+                pickerRow(alias: "a", slug: "org/a", label: "A"),
+            ])))
+        XCTAssertFalse(claudeModelPickerMutationConfirmed(
+            .add(slug: "org/c", alias: nil),
+            status: afterMove))
+    }
+
+    @MainActor
+    func testStateDispatchesCASMutationAndConfirmsFreshAdminProjection()
+        async throws {
+        let initial = adminStatus(
+            generation: 1,
+            hash: "sha256:picker-initial",
+            rows: [
+                pickerRow(alias: "a", slug: "org/a", label: "A"),
+            ])
+        let updated = adminStatus(
+            generation: 2,
+            hash: "sha256:picker-updated",
+            rows: [
+                pickerRow(alias: "a", slug: "org/a", label: "A"),
+                pickerRow(alias: "b", slug: "org/b", label: "B"),
+            ])
+        let reader = PickerSequencedAdminReader([initial, updated])
+        let runner = PickerMutationRunner()
+        let state = BasetenSwitchState(
+            variant: AppVariant.resolve(
+                infoDictionary: [:],
+                homeDirectory: "/tmp/baseten-switch-picker-tests",
+                environment: [
+                    "BASETEN_SWITCH_GATEWAY_BIN": "/usr/bin/true",
+                    "BASETEN_SWITCH_CONFIG_PATH": "/tmp/picker-gateway.yaml",
+                ]),
+            reader: reader,
+            modelCatalogReader: PickerCatalogReader(),
+            cliRunner: runner,
+            loginItemService: PickerLoginItemService(),
+            startPolling: false)
+
+        await state.refresh()
+        state.ensureModelCatalogLoaded()
+        await state.waitForModelCatalogRefresh()
+        XCTAssertTrue(state.canMutateClaudeModelPicker)
+
+        let enablePreview = await state.previewClaudeModelPickerEnable()
+        XCTAssertEqual(enablePreview?.models.map(\.alias), [
+            "claude-baseten-a", "claude-baseten-b",
+        ])
+
+        let outcome = await state.previewClaudeModelPickerAdd(slug: "org/b")
+        guard case .preview(let preview, let explicitAlias) = outcome else {
+            return XCTFail("expected an exact preview")
+        }
+        XCTAssertEqual(preview.alias, "claude-baseten-b")
+        XCTAssertEqual(preview.label, "B via Baseten")
+        XCTAssertNil(explicitAlias)
+
+        await state.setClaudeModelPicker(.add(slug: "org/b", alias: nil))
+
+        let requests = await runner.requests
+        XCTAssertEqual(requests.count, 4)
+        XCTAssertEqual(requests[0].arguments.suffix(5), [
+            "claude", "picker", "enable", "--dry-run", "--json",
+        ])
+        XCTAssertEqual(requests[1].arguments.suffix(6), [
+            "claude", "picker", "add", "org/b", "--dry-run", "--json",
+        ])
+        let request = requests[2]
+        XCTAssertEqual(
+            argumentValue("--if-active-token", request.arguments),
+            "picker-boot:1")
+        XCTAssertEqual(
+            argumentValue("--if-config-hash", request.arguments),
+            "sha256:picker-initial")
+        XCTAssertTrue(request.arguments.suffix(4).elementsEqual([
+            "claude", "picker", "add", "org/b",
+        ]))
+        XCTAssertTrue(requests[3].arguments.suffix(4).elementsEqual([
+            "claude", "picker", "status", "--json",
+        ]))
+        XCTAssertEqual(
+            state.claudeModelPickerDiagnostics?.userFileSync,
+            "synced")
+        XCTAssertNil(state.pendingClaudeModelPicker)
+        XCTAssertNil(state.lastError)
+        XCTAssertEqual(
+            state.clients.first?.modelPicker?.models.map(\.alias),
+            ["a", "b"])
+        XCTAssertTrue(
+            state.claudeModelPickerNotice?.hasPrefix("Saved.") == true)
+        XCTAssertEqual(state.claudeModelPickerWarnings, [
+            "Claude Code may require reopening /model.",
+        ])
+        state.stop()
+    }
+
+    @MainActor
+    func testSettingsPendingUsesPickerSyncInsteadOfGenericReconcile()
+        async throws {
+        let initial = adminStatus(
+            generation: 1,
+            hash: "sha256:picker-initial",
+            rows: [
+                pickerRow(alias: "a", slug: "org/a", label: "A"),
+            ])
+        let updated = adminStatus(
+            generation: 2,
+            hash: "sha256:picker-updated",
+            rows: [
+                pickerRow(alias: "a", slug: "org/a", label: "A"),
+                pickerRow(alias: "b", slug: "org/b", label: "B"),
+            ])
+        let reader = PickerSequencedAdminReader([
+            initial,
+            updated,
+            updated,
+        ])
+        let runner = PickerSettingsRecoveryRunner()
+        let state = BasetenSwitchState(
+            variant: AppVariant.resolve(
+                infoDictionary: [:],
+                homeDirectory: "/tmp/baseten-switch-picker-recovery-tests",
+                environment: [
+                    "BASETEN_SWITCH_GATEWAY_BIN": "/usr/bin/true",
+                    "BASETEN_SWITCH_CONFIG_PATH": "/tmp/picker-gateway.yaml",
+                ]),
+            reader: reader,
+            modelCatalogReader: PickerCatalogReader(),
+            cliRunner: runner,
+            loginItemService: PickerLoginItemService(),
+            startPolling: false)
+
+        await state.refresh()
+        state.ensureModelCatalogLoaded()
+        await state.waitForModelCatalogRefresh()
+        await state.setClaudeModelPicker(.add(slug: "org/b", alias: nil))
+
+        let requests = await runner.requests
+        XCTAssertEqual(requests.count, 3)
+        XCTAssertTrue(requests[0].arguments.suffix(4).elementsEqual([
+            "claude", "picker", "add", "org/b",
+        ]))
+        XCTAssertTrue(requests[1].arguments.suffix(3).elementsEqual([
+            "claude", "picker", "sync",
+        ]))
+        XCTAssertTrue(requests[2].arguments.suffix(4).elementsEqual([
+            "claude", "picker", "status", "--json",
+        ]))
+        XCTAssertFalse(requests.flatMap(\.arguments).contains("reconcile"))
+        XCTAssertNil(state.lastError)
+        XCTAssertTrue(
+            state.claudeModelPickerNotice?.hasPrefix("Saved.") == true)
+        state.stop()
+    }
+
+    @MainActor
+    func testManualSettingsActionReconcilesRouterThenRemainsUnconfirmed()
+        async throws {
+        let initial = adminStatus(
+            generation: 1,
+            hash: "sha256:picker-initial",
+            rows: [
+                pickerRow(alias: "a", slug: "org/a", label: "A"),
+            ])
+        let updated = adminStatus(
+            generation: 2,
+            hash: "sha256:picker-updated",
+            rows: [
+                pickerRow(alias: "a", slug: "org/a", label: "A"),
+                pickerRow(alias: "b", slug: "org/b", label: "B"),
+            ])
+        let reader = PickerSequencedAdminReader([
+            initial,
+            updated,
+            updated,
+        ])
+        let runner = PickerManualResolutionRunner()
+        let state = BasetenSwitchState(
+            variant: AppVariant.resolve(
+                infoDictionary: [:],
+                homeDirectory: "/tmp/baseten-switch-picker-manual-tests",
+                environment: [
+                    "BASETEN_SWITCH_GATEWAY_BIN": "/usr/bin/true",
+                    "BASETEN_SWITCH_CONFIG_PATH": "/tmp/picker-gateway.yaml",
+                ]),
+            reader: reader,
+            modelCatalogReader: PickerCatalogReader(),
+            cliRunner: runner,
+            loginItemService: PickerLoginItemService(),
+            startPolling: false)
+
+        await state.refresh()
+        state.ensureModelCatalogLoaded()
+        await state.waitForModelCatalogRefresh()
+        await state.setClaudeModelPicker(.add(slug: "org/b", alias: nil))
+
+        let requests = await runner.requests
+        XCTAssertEqual(requests.count, 3)
+        XCTAssertTrue(requests[0].arguments.suffix(4).elementsEqual([
+            "claude", "picker", "add", "org/b",
+        ]))
+        XCTAssertTrue(requests[1].arguments.suffix(4).elementsEqual([
+            "--json", "mutation", "reconcile",
+            argumentValue("--operation-id", requests[0].arguments) ?? "",
+        ]))
+        XCTAssertTrue(requests[2].arguments.suffix(4).elementsEqual([
+            "claude", "picker", "status", "--json",
+        ]))
+        XCTAssertFalse(requests.flatMap(\.arguments).contains("sync"))
+        XCTAssertNil(state.claudeModelPickerNotice)
+        XCTAssertTrue(
+            state.lastError?.contains("manual resolution") == true)
+        XCTAssertEqual(
+            state.claudeModelPickerDiagnostics?.userFileSync,
+            "blocked")
+        state.stop()
+    }
+
+    private func pickerStatus(
+        _ rows: [ClaudeModelPickerRow]
+    ) throws -> ClaudeModelPickerStatus {
+        try XCTUnwrap(ClaudeModelPickerStatus(dict: [
+            "enabled": true,
+            "models": rows.map {
+                [
+                    "alias": $0.alias,
+                    "slug": $0.slug,
+                    "label": $0.label,
+                    "description": $0.description,
+                ]
+            },
+        ]))
+    }
+
+    private func pickerRow(
+        alias: String,
+        slug: String,
+        label: String
+    ) -> ClaudeModelPickerRow {
+        ClaudeModelPickerRow(dict: [
+            "alias": alias,
+            "slug": slug,
+            "label": label,
+            "description": "Served by Baseten.",
+        ])!
+    }
+
+    private func liveModel(
+        _ slug: String,
+        _ displayName: String
+    ) -> LiveModelCatalogEntry {
+        LiveModelCatalogEntry(dict: [
+            "slug": slug,
+            "display_name": displayName,
+        ])!
+    }
+
+    private func adminStatus(
+        generation: Int,
+        hash: String,
+        rows: [ClaudeModelPickerRow]
+    ) -> AdminStatusSnapshot {
+        AdminStatusSnapshot(dict: [
+            "router_boot_id": "picker-boot",
+            "active_generation": generation,
+            "active_config_hash": hash,
+            "desired_config_hash": hash,
+            "capabilities": ["global_routing"],
+            "health": "ready",
+            "config_path": "/tmp/picker-gateway.yaml",
+            "reload": ["state": "ready", "error": ""],
+            "global_routing_enabled": true,
+            "clients": [[
+                "name": "claude-code",
+                "enabled": true,
+                "protocol_shape": "anthropic",
+                "model_picker": [
+                    "enabled": true,
+                    "models": rows.map {
+                        [
+                            "alias": $0.alias,
+                            "slug": $0.slug,
+                            "label": $0.label,
+                            "description": $0.description,
+                        ]
+                    },
+                ],
+            ]],
+        ])
+    }
+
+    private func argumentValue(
+        _ flag: String,
+        _ arguments: [String]
+    ) -> String? {
+        guard let index = arguments.firstIndex(of: flag),
+              arguments.indices.contains(index + 1) else { return nil }
+        return arguments[index + 1]
+    }
+}

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/ClaudeModelPickerTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/ClaudeModelPickerTests.swift
@@ -526,18 +526,17 @@ final class ClaudeModelPickerTests: XCTestCase {
             "Unverified")
     }
 
-    func testConfiguredRowStatePrefersAllowlistConflictOtherwiseRuntime()
+    func testConfiguredRowStateOnlyShowsAllowlistConflict()
     {
         XCTAssertEqual(
             claudeModelPickerConfiguredRowState(
                 allowlistPolicy: "possible_conflict",
                 knownPolicy: "possible_allowlist_conflict"),
             "Possible allowlist conflict")
-        XCTAssertEqual(
+        XCTAssertNil(
             claudeModelPickerConfiguredRowState(
                 allowlistPolicy: "no_known_conflict",
-                knownPolicy: "no_known_conflict"),
-            "Runtime unverified")
+                knownPolicy: "no_known_conflict"))
     }
 
     func testRetrySyncRequiresActionableOutOfSyncConfiguredPicker() {

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/ClaudeModelPickerTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/ClaudeModelPickerTests.swift
@@ -81,28 +81,201 @@ private actor PickerMutationRunner: CLIRunning {
         }
         let operationID = argumentValue("--operation-id", request.arguments)
             ?? ""
-        let slug = request.arguments.last ?? ""
+        let removing = request.arguments.contains("remove")
+        let target = request.arguments.last ?? ""
+        let configHash = removing
+            ? "sha256:picker-removed"
+            : "sha256:picker-updated"
         let object: [String: Any] = [
             "ok": true,
             "operation_id": operationID,
-            "operation": "add_claude_picker_model",
+            "operation": removing
+                ? "remove_claude_picker_model"
+                : "add_claude_picker_model",
             "client": "claude-code",
             "key": "model_picker",
-            "requested_target": slug,
-            "desired_config_hash": "sha256:picker-updated",
-            "active_config_hash": "sha256:picker-updated",
-            "active_token": "picker-boot:2",
+            "requested_target": target,
+            "desired_config_hash": configHash,
+            "active_config_hash": configHash,
+            "active_token": removing ? "picker-boot:3" : "picker-boot:2",
             "applied": true,
             "reconciliation_required": false,
             "outcome": "applied",
-            "warnings": [
-                "Claude Code may require reopening /model.",
-            ],
+            "warnings": removing
+                ? ["The saved default still references this alias."]
+                : [],
             "error": NSNull(),
         ]
         let data = try! JSONSerialization.data(withJSONObject: object)
         return CLIExecutionResult(
             status: 0,
+            standardOutput: String(decoding: data, as: UTF8.self),
+            standardError: "",
+            timedOut: false)
+    }
+
+    private func argumentValue(
+        _ flag: String,
+        _ arguments: [String]
+    ) -> String? {
+        guard let index = arguments.firstIndex(of: flag),
+              arguments.indices.contains(index + 1) else { return nil }
+        return arguments[index + 1]
+    }
+}
+
+private actor PickerAmbiguousAliasRunner: CLIRunning {
+    private(set) var requests: [CLIExecutionRequest] = []
+
+    func run(_ request: CLIExecutionRequest) async -> CLIExecutionResult {
+        requests.append(request)
+        if request.arguments.suffix(4).elementsEqual([
+            "claude", "picker", "status", "--json",
+        ]) {
+            return pickerDiagnosticsResult()
+        }
+        if request.arguments.contains("--dry-run") {
+            if let alias = argumentValue("--alias", request.arguments) {
+                return jsonResult(status: 0, object: [
+                    "alias": alias,
+                    "slug": "org/model",
+                    "label": "Model via Baseten",
+                    "description": "Served by Baseten.",
+                ])
+            }
+            return jsonResult(status: 1, object: [
+                "ok": false,
+                "slug": "org/model",
+                "alias_choices": [
+                    [
+                        "alias": "claude-baseten-a",
+                        "slug": "org/model",
+                        "label": "Model via Baseten",
+                        "description": "Served by Baseten.",
+                    ],
+                    [
+                        "alias": "claude-baseten-b",
+                        "slug": "org/model",
+                        "label": "Model via Baseten",
+                        "description": "Served by Baseten.",
+                    ],
+                ],
+                "error": [
+                    "code": "ambiguous_alias",
+                    "message": "select one",
+                    "retryable": false,
+                ],
+            ])
+        }
+
+        let operationID = argumentValue("--operation-id", request.arguments)
+            ?? ""
+        return jsonResult(status: 0, object: [
+            "ok": true,
+            "operation_id": operationID,
+            "operation": "add_claude_picker_model",
+            "client": "claude-code",
+            "key": "model_picker",
+            "requested_target":
+                "org/model via claude-baseten-b",
+            "desired_config_hash": "sha256:picker-ambiguous-updated",
+            "active_config_hash": "sha256:picker-ambiguous-updated",
+            "active_token": "picker-boot:2",
+            "applied": true,
+            "reconciliation_required": false,
+            "outcome": "applied",
+            "warnings": [],
+            "error": NSNull(),
+        ])
+    }
+
+    private func jsonResult(
+        status: Int32,
+        object: [String: Any]
+    ) -> CLIExecutionResult {
+        let data = try! JSONSerialization.data(withJSONObject: object)
+        return CLIExecutionResult(
+            status: status,
+            standardOutput: String(decoding: data, as: UTF8.self),
+            standardError: "",
+            timedOut: false)
+    }
+
+    private func argumentValue(
+        _ flag: String,
+        _ arguments: [String]
+    ) -> String? {
+        guard let index = arguments.firstIndex(of: flag),
+              arguments.indices.contains(index + 1) else { return nil }
+        return arguments[index + 1]
+    }
+}
+
+private actor PickerPreviewFailureRunner: CLIRunning {
+    private let malformed: Bool
+
+    init(malformed: Bool = false) {
+        self.malformed = malformed
+    }
+
+    func run(_ request: CLIExecutionRequest) async -> CLIExecutionResult {
+        guard request.arguments.contains("--dry-run") else {
+            return CLIExecutionResult(
+                status: 1,
+                standardOutput: "",
+                standardError: "unexpected command",
+                timedOut: false)
+        }
+        if malformed {
+            return CLIExecutionResult(
+                status: 1,
+                standardOutput: "not json",
+                standardError: "",
+                timedOut: false)
+        }
+        let data = try! JSONSerialization.data(withJSONObject: [
+            "ok": false,
+            "error": [
+                "code": ClaudeModelPickerContextMinimumFailure.code,
+                "message": "Choose a model with at least 200000 tokens.",
+                "retryable": false,
+            ],
+        ])
+        return CLIExecutionResult(
+            status: 1,
+            standardOutput: String(decoding: data, as: UTF8.self),
+            standardError: "",
+            timedOut: false)
+    }
+}
+
+private actor PickerMutationContextFailureRunner: CLIRunning {
+    func run(_ request: CLIExecutionRequest) async -> CLIExecutionResult {
+        if request.arguments.suffix(4).elementsEqual([
+            "claude", "picker", "status", "--json",
+        ]) {
+            return pickerDiagnosticsResult()
+        }
+        let operationID = argumentValue(
+            "--operation-id",
+            request.arguments) ?? ""
+        let data = try! JSONSerialization.data(withJSONObject: [
+            "ok": false,
+            "operation_id": operationID,
+            "operation": "add_claude_picker_model",
+            "client": "claude-code",
+            "key": "model_picker",
+            "requested_target": "org/b",
+            "applied": false,
+            "reconciliation_required": false,
+            "error": [
+                "code": ClaudeModelPickerContextMinimumFailure.code,
+                "message": "Choose a model with at least 200000 tokens.",
+                "retryable": false,
+            ],
+        ])
+        return CLIExecutionResult(
+            status: 1,
             standardOutput: String(decoding: data, as: UTF8.self),
             standardError: "",
             timedOut: false)
@@ -281,12 +454,14 @@ final class ClaudeModelPickerTests: XCTestCase {
                         "slug": "moonshotai/Kimi-K2.5",
                         "label": "Kimi K2.5 via Baseten",
                         "description": "Served by Baseten.",
+                        "context_tokens": 1_048_576,
                     ],
                     [
                         "alias": "claude-baseten-glm-5-2",
                         "slug": "zai-org/GLM-5.2",
                         "label": "GLM 5.2 via Baseten",
                         "description": "Served by Baseten.",
+                        "context_tokens": 200_000,
                     ],
                 ],
             ],
@@ -296,6 +471,10 @@ final class ClaudeModelPickerTests: XCTestCase {
         XCTAssertEqual(client.modelPicker?.models.map(\.alias), [
             "claude-baseten-kimi-k2-5",
             "claude-baseten-glm-5-2",
+        ])
+        XCTAssertEqual(client.modelPicker?.models.map(\.contextTokens), [
+            1_048_576,
+            200_000,
         ])
         XCTAssertEqual(
             client.modelPicker?.models.last?.label,
@@ -319,6 +498,7 @@ final class ClaudeModelPickerTests: XCTestCase {
           "legacy_discovery_enabled": true,
           "saved_model": "claude-baseten-old",
           "saved_model_unconfigured": true,
+          "saved_model_context_mismatch": true,
           "message": "Configured rows are not all installed."
         }
         """))
@@ -338,6 +518,7 @@ final class ClaudeModelPickerTests: XCTestCase {
         XCTAssertTrue(diagnostics.legacyDiscoveryEnabled)
         XCTAssertEqual(diagnostics.savedModel, "claude-baseten-old")
         XCTAssertTrue(diagnostics.savedModelUnconfigured)
+        XCTAssertTrue(diagnostics.savedModelContextMismatch)
         XCTAssertEqual(
             claudeModelPickerDiagnosticLabel(
                 key: "runtime",
@@ -357,6 +538,29 @@ final class ClaudeModelPickerTests: XCTestCase {
                 allowlistPolicy: "no_known_conflict",
                 knownPolicy: "no_known_conflict"),
             "Runtime unverified")
+    }
+
+    func testRetrySyncRequiresActionableOutOfSyncConfiguredPicker() {
+        XCTAssertTrue(claudeModelPickerCanRetrySync(
+            userFileSync: "out_of_sync",
+            canEditConfiguredRows: true,
+            hasConfiguredPicker: true))
+        XCTAssertFalse(claudeModelPickerCanRetrySync(
+            userFileSync: "synced",
+            canEditConfiguredRows: true,
+            hasConfiguredPicker: true))
+        XCTAssertFalse(claudeModelPickerCanRetrySync(
+            userFileSync: "blocked",
+            canEditConfiguredRows: true,
+            hasConfiguredPicker: true))
+        XCTAssertFalse(claudeModelPickerCanRetrySync(
+            userFileSync: "out_of_sync",
+            canEditConfiguredRows: false,
+            hasConfiguredPicker: true))
+        XCTAssertFalse(claudeModelPickerCanRetrySync(
+            userFileSync: "out_of_sync",
+            canEditConfiguredRows: true,
+            hasConfiguredPicker: false))
     }
 
     func testMalformedPickerProjectionFailsClosedWithoutDroppingRows() throws {
@@ -441,6 +645,34 @@ final class ClaudeModelPickerTests: XCTestCase {
         XCTAssertEqual(preview.description, "Served by Baseten.")
         XCTAssertNil(ClaudeModelPickerAddPreview(
             json: "{\"slug\":\"zai-org/GLM-5.2\"}"))
+    }
+
+    func testExactAddAndRemoveActionsMapDirectlyToMutations() throws {
+        let preview = try XCTUnwrap(ClaudeModelPickerAddPreview(json: """
+        {
+          "alias": "claude-baseten-choice",
+          "slug": "org/model",
+          "label": "Model via Baseten",
+          "description": "Served by Baseten."
+        }
+        """))
+
+        XCTAssertEqual(
+            claudeModelPickerAddMutation(
+                preview: preview,
+                explicitAlias: "claude-baseten-choice"),
+            .add(
+                slug: "org/model",
+                alias: "claude-baseten-choice"))
+        XCTAssertEqual(
+            claudeModelPickerRemoveMutation(alias: "claude-baseten-choice"),
+            .remove(alias: "claude-baseten-choice"))
+    }
+
+    func testRestartNoticeCopyIsExact() {
+        XCTAssertEqual(
+            claudeModelPickerRestartNotice,
+            "Restart Claude Code to see additions or removals.")
     }
 
     func testAddPreviewDecodesStructuredAmbiguousAliasChoices() throws {
@@ -653,7 +885,84 @@ final class ClaudeModelPickerTests: XCTestCase {
     }
 
     @MainActor
-    func testStateDispatchesCASMutationAndConfirmsFreshAdminProjection()
+    func testContextMinimumFailureUsesActionableMessageForAddAndEnablePreviews()
+        async throws {
+        let state = previewFailureState(runner: PickerPreviewFailureRunner())
+
+        await state.refresh()
+        state.ensureModelCatalogLoaded()
+        await state.waitForModelCatalogRefresh()
+
+        let addPreview = await state.previewClaudeModelPickerAdd(slug: "org/b")
+        XCTAssertNil(addPreview)
+        XCTAssertEqual(
+            state.lastError,
+            "Choose a model with at least 200000 tokens.")
+        XCTAssertEqual(
+            claudeModelPickerAddPreviewErrorMessage(state.lastError),
+            "Choose a model with at least 200000 tokens.")
+
+        let enablePreview = await state.previewClaudeModelPickerEnable()
+        XCTAssertNil(enablePreview)
+        XCTAssertEqual(
+            state.lastError,
+            "Choose a model with at least 200000 tokens.")
+        state.stop()
+    }
+
+    func testAddPreviewInlineErrorFallsBackWhenStateHasNoMessage() {
+        XCTAssertEqual(
+            claudeModelPickerAddPreviewErrorMessage(nil),
+            "Switch could not generate an exact preview for this model. No changes were made.")
+        XCTAssertEqual(
+            claudeModelPickerAddPreviewErrorMessage("  \n  "),
+            "Switch could not generate an exact preview for this model. No changes were made.")
+    }
+
+    @MainActor
+    func testMalformedPreviewFailureUsesGenericMessages() async throws {
+        let state = previewFailureState(
+            runner: PickerPreviewFailureRunner(malformed: true))
+
+        await state.refresh()
+        state.ensureModelCatalogLoaded()
+        await state.waitForModelCatalogRefresh()
+
+        let addPreview = await state.previewClaudeModelPickerAdd(slug: "org/b")
+        XCTAssertNil(addPreview)
+        XCTAssertEqual(
+            state.lastError,
+            "Switch could not generate a safe model picker preview.")
+
+        let enablePreview = await state.previewClaudeModelPickerEnable()
+        XCTAssertNil(enablePreview)
+        XCTAssertEqual(
+            state.lastError,
+            "Switch could not generate a safe model picker setup preview.")
+        state.stop()
+    }
+
+    @MainActor
+    func testMutationTimeContextMinimumFailureUsesActionableMessage()
+        async throws {
+        let state = previewFailureState(
+            runner: PickerMutationContextFailureRunner())
+
+        await state.refresh()
+        state.ensureModelCatalogLoaded()
+        await state.waitForModelCatalogRefresh()
+        await state.setClaudeModelPicker(.add(slug: "org/b", alias: nil))
+
+        XCTAssertEqual(
+            state.lastError,
+            "Choose a model with at least 200000 tokens.")
+        XCTAssertNil(state.claudeModelPickerNotice)
+        XCTAssertNil(state.pendingClaudeModelPicker)
+        state.stop()
+    }
+
+    @MainActor
+    func testExactPreviewDispatchesAddThenDirectRemovePreservesWarnings()
         async throws {
         let initial = adminStatus(
             generation: 1,
@@ -668,7 +977,13 @@ final class ClaudeModelPickerTests: XCTestCase {
                 pickerRow(alias: "a", slug: "org/a", label: "A"),
                 pickerRow(alias: "b", slug: "org/b", label: "B"),
             ])
-        let reader = PickerSequencedAdminReader([initial, updated])
+        let removed = adminStatus(
+            generation: 3,
+            hash: "sha256:picker-removed",
+            rows: [
+                pickerRow(alias: "a", slug: "org/a", label: "A"),
+            ])
+        let reader = PickerSequencedAdminReader([initial, updated, removed])
         let runner = PickerMutationRunner()
         let state = BasetenSwitchState(
             variant: AppVariant.resolve(
@@ -733,11 +1048,118 @@ final class ClaudeModelPickerTests: XCTestCase {
         XCTAssertEqual(
             state.clients.first?.modelPicker?.models.map(\.alias),
             ["a", "b"])
-        XCTAssertTrue(
-            state.claudeModelPickerNotice?.hasPrefix("Saved.") == true)
+        XCTAssertEqual(state.claudeModelPickerNotice, "Added to /model.")
+        XCTAssertTrue(state.claudeModelPickerWarnings.isEmpty)
+
+        await state.setClaudeModelPicker(.remove(alias: "b"))
+
+        let requestsAfterRemove = await runner.requests
+        XCTAssertEqual(requestsAfterRemove.count, 6)
+        XCTAssertTrue(requestsAfterRemove[4].arguments.suffix(4)
+            .elementsEqual([
+                "claude", "picker", "remove", "b",
+            ]))
+        XCTAssertTrue(requestsAfterRemove[5].arguments.suffix(4)
+            .elementsEqual([
+                "claude", "picker", "status", "--json",
+            ]))
+        XCTAssertEqual(
+            state.clients.first?.modelPicker?.models.map(\.alias),
+            ["a"])
+        XCTAssertEqual(
+            state.claudeModelPickerNotice,
+            "Saved. The routing alias remains available to existing sessions.")
         XCTAssertEqual(state.claudeModelPickerWarnings, [
-            "Claude Code may require reopening /model.",
+            "The saved default still references this alias.",
         ])
+        state.stop()
+    }
+
+    @MainActor
+    func testAmbiguousAliasSelectionRepeatsPreviewWithAliasThenAdds()
+        async throws {
+        let initial = adminStatus(
+            generation: 1,
+            hash: "sha256:picker-ambiguous-initial",
+            rows: [
+                pickerRow(alias: "existing", slug: "org/existing", label: "Existing"),
+            ])
+        let updated = adminStatus(
+            generation: 2,
+            hash: "sha256:picker-ambiguous-updated",
+            rows: [
+                pickerRow(alias: "existing", slug: "org/existing", label: "Existing"),
+                pickerRow(
+                    alias: "claude-baseten-b",
+                    slug: "org/model",
+                    label: "Model"),
+            ])
+        let reader = PickerSequencedAdminReader([initial, updated])
+        let runner = PickerAmbiguousAliasRunner()
+        let state = BasetenSwitchState(
+            variant: AppVariant.resolve(
+                infoDictionary: [:],
+                homeDirectory: "/tmp/baseten-switch-picker-alias-tests",
+                environment: [
+                    "BASETEN_SWITCH_GATEWAY_BIN": "/usr/bin/true",
+                    "BASETEN_SWITCH_CONFIG_PATH": "/tmp/picker-gateway.yaml",
+                ]),
+            reader: reader,
+            modelCatalogReader: PickerCatalogReader(),
+            cliRunner: runner,
+            loginItemService: PickerLoginItemService(),
+            startPolling: false)
+
+        await state.refresh()
+        state.ensureModelCatalogLoaded()
+        await state.waitForModelCatalogRefresh()
+
+        let ambiguous = await state.previewClaudeModelPickerAdd(
+            slug: "org/model")
+        guard case .aliasChoices(let slug, let choices) = ambiguous else {
+            return XCTFail("expected alias choices")
+        }
+        XCTAssertEqual(slug, "org/model")
+        XCTAssertEqual(choices.map(\.alias), [
+            "claude-baseten-a", "claude-baseten-b",
+        ])
+
+        let exact = await state.previewClaudeModelPickerAdd(
+            slug: slug,
+            alias: choices[1].alias)
+        guard case .preview(let preview, let explicitAlias) = exact else {
+            return XCTFail("expected exact preview after alias choice")
+        }
+        XCTAssertEqual(explicitAlias, "claude-baseten-b")
+        let mutation = claudeModelPickerAddMutation(
+            preview: preview,
+            explicitAlias: explicitAlias)
+        XCTAssertEqual(
+            mutation,
+            .add(slug: "org/model", alias: "claude-baseten-b"))
+
+        await state.setClaudeModelPicker(mutation)
+
+        let requests = await runner.requests
+        XCTAssertEqual(requests.count, 4)
+        XCTAssertEqual(requests[0].arguments.suffix(6), [
+            "claude", "picker", "add", "org/model", "--dry-run", "--json",
+        ])
+        XCTAssertEqual(requests[1].arguments.suffix(8), [
+            "claude", "picker", "add", "org/model", "--dry-run", "--json",
+            "--alias", "claude-baseten-b",
+        ])
+        XCTAssertEqual(requests[2].arguments.suffix(6), [
+            "claude", "picker", "add", "org/model", "--alias",
+            "claude-baseten-b",
+        ])
+        XCTAssertTrue(requests[3].arguments.suffix(4).elementsEqual([
+            "claude", "picker", "status", "--json",
+        ]))
+        XCTAssertEqual(
+            state.clients.first?.modelPicker?.models.map(\.alias),
+            ["existing", "claude-baseten-b"])
+        XCTAssertEqual(state.claudeModelPickerNotice, "Added to /model.")
         state.stop()
     }
 
@@ -795,8 +1217,7 @@ final class ClaudeModelPickerTests: XCTestCase {
         ]))
         XCTAssertFalse(requests.flatMap(\.arguments).contains("reconcile"))
         XCTAssertNil(state.lastError)
-        XCTAssertTrue(
-            state.claudeModelPickerNotice?.hasPrefix("Saved.") == true)
+        XCTAssertEqual(state.claudeModelPickerNotice, "Added to /model.")
         state.stop()
     }
 
@@ -877,6 +1298,31 @@ final class ClaudeModelPickerTests: XCTestCase {
                 ]
             },
         ]))
+    }
+
+    @MainActor
+    private func previewFailureState(
+        runner: any CLIRunning
+    ) -> BasetenSwitchState {
+        let initial = adminStatus(
+            generation: 1,
+            hash: "sha256:picker-preview-failure",
+            rows: [
+                pickerRow(alias: "a", slug: "org/a", label: "A"),
+            ])
+        return BasetenSwitchState(
+            variant: AppVariant.resolve(
+                infoDictionary: [:],
+                homeDirectory: "/tmp/baseten-switch-picker-preview-failure-tests",
+                environment: [
+                    "BASETEN_SWITCH_GATEWAY_BIN": "/usr/bin/true",
+                    "BASETEN_SWITCH_CONFIG_PATH": "/tmp/picker-gateway.yaml",
+                ]),
+            reader: PickerSequencedAdminReader([initial]),
+            modelCatalogReader: PickerCatalogReader(),
+            cliRunner: runner,
+            loginItemService: PickerLoginItemService(),
+            startPolling: false)
     }
 
     private func pickerRow(

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/ClaudeModelPickerTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/ClaudeModelPickerTests.swift
@@ -562,6 +562,47 @@ final class ClaudeModelPickerTests: XCTestCase {
             hasConfiguredPicker: false))
     }
 
+    func testPickerDiagnosticsAreHiddenWhenHealthy() {
+        XCTAssertFalse(claudeModelPickerHasDiagnosticIssues(
+            userFileSync: "synced",
+            allowlistPolicy: "no_known_conflict"))
+        XCTAssertFalse(claudeModelPickerShowsSyncDiagnostic(
+            userFileSync: "synced"))
+        XCTAssertFalse(claudeModelPickerShowsAllowlistDiagnostic(
+            allowlistPolicy: "no_known_conflict"))
+    }
+
+    func testPickerDiagnosticsOnlyExposeUnhealthyAxes() {
+        XCTAssertTrue(claudeModelPickerHasDiagnosticIssues(
+            userFileSync: "out_of_sync",
+            allowlistPolicy: "no_known_conflict"))
+        XCTAssertTrue(claudeModelPickerShowsSyncDiagnostic(
+            userFileSync: "out_of_sync"))
+        XCTAssertFalse(claudeModelPickerShowsAllowlistDiagnostic(
+            allowlistPolicy: "no_known_conflict"))
+
+        XCTAssertTrue(claudeModelPickerHasDiagnosticIssues(
+            userFileSync: "synced",
+            allowlistPolicy: "possible_conflict"))
+        XCTAssertFalse(claudeModelPickerShowsSyncDiagnostic(
+            userFileSync: "synced"))
+        XCTAssertTrue(claudeModelPickerShowsAllowlistDiagnostic(
+            allowlistPolicy: "possible_conflict"))
+
+        XCTAssertTrue(claudeModelPickerHasDiagnosticIssues(
+            userFileSync: "synced",
+            allowlistPolicy: "no_known_conflict",
+            hasMessage: true))
+        XCTAssertTrue(claudeModelPickerHasDiagnosticIssues(
+            userFileSync: "synced",
+            allowlistPolicy: "no_known_conflict",
+            savedModelUnconfigured: true))
+        XCTAssertTrue(claudeModelPickerHasDiagnosticIssues(
+            userFileSync: "synced",
+            allowlistPolicy: "no_known_conflict",
+            savedModelContextMismatch: true))
+    }
+
     func testEnableConfirmsOnlyWhenReplacementModeMustBeConverted() {
         XCTAssertEqual(
             claudeModelPickerEnableDecision(replacementMode: nil),

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/FallbackPolicyTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/FallbackPolicyTests.swift
@@ -1,0 +1,283 @@
+import XCTest
+@testable import BasetenSwitch
+
+final class FallbackPolicyTests: XCTestCase {
+    func testAdminStatusDecodesResolvedPolicyAndClaudeTarget() throws {
+        let status = AdminStatusSnapshot(dict: [
+            "capabilities": ["global_routing", "fallback_policy"],
+            "fallback_policy": [
+                "on_baseten_429": true,
+                "on_baseten_5xx": false,
+            ],
+            "clients": [[
+                "name": "claude-code",
+                "baseten_model_fallback": [
+                    "configured_model": "claude-opus-5",
+                    "resolved_model": "claude-opus-5",
+                    "display_name": "Opus",
+                    "provider_ready": true,
+                    "ready": true,
+                    "reason": NSNull(),
+                    "available_models": [
+                        [
+                            "model": "claude-opus-5",
+                            "display_name": "Opus",
+                        ],
+                        [
+                            "model": "claude-sonnet-5",
+                            "display_name": "Sonnet",
+                        ],
+                    ],
+                ],
+            ]],
+        ])
+
+        XCTAssertEqual(
+            status.fallbackPolicy,
+            FallbackPolicyStatus(
+                onBaseten429: true,
+                onBaseten5xx: false))
+        let fallback = try XCTUnwrap(
+            status.clients.first?.basetenModelFallback)
+        XCTAssertEqual(fallback.resolvedModel, "claude-opus-5")
+        XCTAssertEqual(fallback.displayName, "Opus")
+        XCTAssertTrue(fallback.providerReady)
+        XCTAssertTrue(fallback.ready)
+        XCTAssertNil(fallback.reason)
+        XCTAssertEqual(fallback.availableModels, [
+            BasetenModelFallbackOption(
+                model: "claude-opus-5",
+                displayName: "Opus"),
+            BasetenModelFallbackOption(
+                model: "claude-sonnet-5",
+                displayName: "Sonnet"),
+        ])
+    }
+
+    func testMissingOrMalformedPolicyDoesNotDecodeAsOff() {
+        XCTAssertNil(AdminStatusSnapshot(dict: [:]).fallbackPolicy)
+        XCTAssertNil(AdminStatusSnapshot(dict: [
+            "fallback_policy": ["on_baseten_429": false],
+        ]).fallbackPolicy)
+    }
+
+    func testFallbackMutationCommandsUseTypedConfigNamespace() {
+        XCTAssertEqual(
+            fallbackPolicyDispatchArgs(
+                trigger: .http429,
+                enabled: false),
+            ["config", "fallback", "429", "off"])
+        XCTAssertEqual(
+            fallbackPolicyDispatchArgs(
+                trigger: .http5xx,
+                enabled: true),
+            ["config", "fallback", "5xx", "on"])
+        XCTAssertEqual(
+            basetenModelFallbackDispatchArgs(
+                client: "claude-code",
+                model: "claude-opus-5"),
+            [
+                "config", "fallback", "model", "claude-code",
+                "claude-opus-5",
+            ])
+    }
+
+    func testNativeTargetSelectorUsesServerOptionsAndExcludesAliases() throws {
+        let client = try XCTUnwrap(ClientStatus(dict: [
+            "name": "claude-code",
+            "baseten_model_fallback": [
+                "configured_model": "claude-opus-5",
+                "resolved_model": "claude-opus-5",
+                "display_name": "Opus",
+                "provider_ready": true,
+                "ready": true,
+                "available_models": [
+                    [
+                        "model": "claude-opus-5",
+                        "display_name": "Opus",
+                    ],
+                    [
+                        "model": "claude-sonnet-5",
+                        "display_name": "Sonnet",
+                    ],
+                    [
+                        "model": "claude-haiku-4-5",
+                        "display_name": "Haiku",
+                    ],
+                ],
+            ],
+            "families": [
+                [
+                    "family": "sonnet",
+                    "configured_target": "native",
+                    "effective_route": "anthropic",
+                    "effective_model": "claude-sonnet-5",
+                ],
+                [
+                    "family": "haiku",
+                    "configured_target": "zai-org/GLM-5.3-Flash",
+                    "effective_route": "baseten",
+                    "effective_model": "zai-org/GLM-5.3-Flash",
+                ],
+            ],
+        ]))
+
+        XCTAssertEqual(
+            claudeNativeFallbackOptions(client: client),
+            [
+                ClaudeNativeFallbackOption(
+                    label: "Opus",
+                    model: "claude-opus-5"),
+                ClaudeNativeFallbackOption(
+                    label: "Sonnet",
+                    model: "claude-sonnet-5"),
+                ClaudeNativeFallbackOption(
+                    label: "Haiku",
+                    model: "claude-haiku-4-5"),
+            ])
+        XCTAssertFalse(
+            claudeNativeFallbackOptions(client: client).contains(where: {
+                $0.model == "claude-baseten-glm-5-3"
+                    || $0.model == "anthropic-baseten-kimi"
+                    || $0.model == "claude-sonnet-4-6"
+            }))
+        XCTAssertFalse(isAcceptedClaudeNativeModelID("opus"))
+        XCTAssertFalse(
+            isAcceptedClaudeNativeModelID("zai-org/GLM-5.3-Flash"))
+        XCTAssertFalse(
+            isAcceptedClaudeNativeModelID("claude-baseten-glm-5-3"))
+        XCTAssertFalse(
+            isAcceptedClaudeNativeModelID("anthropic-baseten-kimi"))
+        XCTAssertTrue(isAcceptedClaudeNativeModelID("claude-opus-5"))
+        XCTAssertTrue(isAcceptedClaudeNativeModelID("claude-3-7-sonnet"))
+    }
+
+    func testNativeTargetSelectorFailsClosedOnServerAlias() throws {
+        let client = try XCTUnwrap(ClientStatus(dict: [
+            "name": "claude-code",
+            "baseten_model_fallback": [
+                "configured_model": "claude-opus-5",
+                "resolved_model": "claude-opus-5",
+                "display_name": "Opus",
+                "provider_ready": true,
+                "ready": true,
+                "available_models": [
+                    [
+                        "model": "claude-sonnet-5",
+                        "display_name": "Sonnet",
+                    ],
+                    [
+                        "model": "claude-baseten-glm-5-3",
+                        "display_name": "Invalid alias",
+                    ],
+                ],
+            ],
+        ]))
+        XCTAssertEqual(
+            claudeNativeFallbackOptions(client: client),
+            [ClaudeNativeFallbackOption(
+                label: "Opus",
+                model: "claude-opus-5")])
+        XCTAssertTrue(
+            client.basetenModelFallback?.availableModels.isEmpty == true)
+    }
+
+    func testOldRouterSelectorFallsBackOnlyToCurrentTarget() throws {
+        let client = try XCTUnwrap(ClientStatus(dict: [
+            "name": "claude-code",
+            "baseten_model_fallback": [
+                "configured_model": "claude-opus-5",
+                "resolved_model": "claude-opus-5",
+                "display_name": "Opus",
+                "provider_ready": true,
+                "ready": true,
+            ],
+            "families": [[
+                "family": "sonnet",
+                "configured_target": "native",
+                "effective_route": "anthropic",
+                "effective_model": "claude-sonnet-5",
+            ]],
+        ]))
+        XCTAssertEqual(
+            claudeNativeFallbackOptions(client: client),
+            [ClaudeNativeFallbackOption(
+                label: "Opus",
+                model: "claude-opus-5")])
+    }
+
+    func testFallbackTargetStatusKeepsReadinessIndependentFromPolicy() throws {
+        let client = try XCTUnwrap(ClientStatus(dict: [
+            "name": "claude-code",
+            "baseten_model_fallback": [
+                "configured_model": "claude-opus-5",
+                "resolved_model": "claude-opus-5",
+                "display_name": "Opus",
+                "provider_ready": true,
+                "ready": true,
+            ],
+        ]))
+        XCTAssertEqual(
+            basetenFallbackTargetStatusLine(
+                fallback: client.basetenModelFallback,
+                policy: FallbackPolicyStatus(
+                    onBaseten429: false,
+                    onBaseten5xx: false),
+                desiredMatchesActive: true,
+                supportsFallbackPolicy: true),
+            "Ready · 429 Off · 5xx Off")
+    }
+
+    func testSuppressedReasonDecodesFromTelemetryWireName() throws {
+        let data = Data("""
+        {
+          "attempted": false,
+          "count": 0,
+          "trigger": null,
+          "suppressed_reason": "native_target_unconfigured"
+        }
+        """.utf8)
+        let fallback = try JSONDecoder().decode(
+            RequestFallback.self,
+            from: data)
+        XCTAssertFalse(fallback.attempted)
+        XCTAssertNil(fallback.trigger)
+        XCTAssertEqual(
+            fallback.suppressedReason,
+            "native_target_unconfigured")
+    }
+
+    func testStructuredAndLegacyMutationWarningsDecodeTogether() throws {
+        let receipt = try XCTUnwrap(GlobalMutationReceipt(json: """
+        {
+          "warnings": [
+            {"code": "cross_provider_history_may_be_incompatible"},
+            "legacy warning",
+            {"message": "ignored without code"}
+          ]
+        }
+        """))
+        XCTAssertEqual(receipt.warnings, [
+            "cross_provider_history_may_be_incompatible",
+            "legacy warning",
+        ])
+    }
+
+    func testUnsupportedPolicyUsesUnavailablePresentation() {
+        XCTAssertEqual(
+            automaticFallbackUnavailableMessage(
+                supportsFallbackPolicy: false,
+                policy: nil),
+            "Update the local gateway to configure automatic fallback.")
+        XCTAssertEqual(
+            automaticFallbackUnavailableMessage(
+                supportsFallbackPolicy: true,
+                policy: nil),
+            "Update the local gateway to configure automatic fallback.")
+        XCTAssertNil(automaticFallbackUnavailableMessage(
+            supportsFallbackPolicy: true,
+            policy: FallbackPolicyStatus(
+                onBaseten429: false,
+                onBaseten5xx: false)))
+    }
+}

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/FallbackPolicyTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/FallbackPolicyTests.swift
@@ -88,21 +88,21 @@ final class FallbackPolicyTests: XCTestCase {
             "baseten_model_fallback": [
                 "configured_model": "claude-opus-5",
                 "resolved_model": "claude-opus-5",
-                "display_name": "Opus",
+                "display_name": "Claude Opus 5",
                 "provider_ready": true,
                 "ready": true,
                 "available_models": [
                     [
                         "model": "claude-opus-5",
-                        "display_name": "Opus",
+                        "display_name": "Claude Opus 5",
                     ],
                     [
                         "model": "claude-sonnet-5",
-                        "display_name": "Sonnet",
+                        "display_name": "Claude Sonnet 5",
                     ],
                     [
                         "model": "claude-haiku-4-5",
-                        "display_name": "Haiku",
+                        "display_name": "Claude Haiku 4.5",
                     ],
                 ],
             ],
@@ -126,13 +126,13 @@ final class FallbackPolicyTests: XCTestCase {
             claudeNativeFallbackOptions(client: client),
             [
                 ClaudeNativeFallbackOption(
-                    label: "Opus",
+                    label: "Claude Opus 5",
                     model: "claude-opus-5"),
                 ClaudeNativeFallbackOption(
-                    label: "Sonnet",
+                    label: "Claude Sonnet 5",
                     model: "claude-sonnet-5"),
                 ClaudeNativeFallbackOption(
-                    label: "Haiku",
+                    label: "Claude Haiku 4.5",
                     model: "claude-haiku-4-5"),
             ])
         XCTAssertFalse(
@@ -150,6 +150,31 @@ final class FallbackPolicyTests: XCTestCase {
             isAcceptedClaudeNativeModelID("anthropic-baseten-kimi"))
         XCTAssertTrue(isAcceptedClaudeNativeModelID("claude-opus-5"))
         XCTAssertTrue(isAcceptedClaudeNativeModelID("claude-3-7-sonnet"))
+    }
+
+    func testNativeTargetSelectorPrefersAvailableVersionedDisplayName()
+        throws
+    {
+        let client = try XCTUnwrap(ClientStatus(dict: [
+            "name": "claude-code",
+            "baseten_model_fallback": [
+                "configured_model": "claude-opus-5",
+                "resolved_model": "claude-opus-5",
+                "display_name": "Opus",
+                "provider_ready": true,
+                "ready": true,
+                "available_models": [[
+                    "model": "claude-opus-5",
+                    "display_name": "Claude Opus 5",
+                ]],
+            ],
+        ]))
+
+        XCTAssertEqual(
+            claudeNativeFallbackOptions(client: client),
+            [ClaudeNativeFallbackOption(
+                label: "Claude Opus 5",
+                model: "claude-opus-5")])
     }
 
     func testFallbackTargetEditorPresentationStartsWithCurrentModel() throws {
@@ -186,6 +211,44 @@ final class FallbackPolicyTests: XCTestCase {
         XCTAssertNil(ClaudeNativeFallbackEditorDraft(
             options: [],
             currentModel: "claude-sonnet-5"))
+    }
+
+    func testFallbackTargetEditorRequiresExplicitReplacementForOlderCurrent() {
+        let draft = ClaudeNativeFallbackEditorDraft(
+            options: [ClaudeNativeFallbackOption(
+                label: "Claude Opus 5",
+                model: "claude-opus-5")],
+            currentModel: "claude-opus-4-8")
+
+        XCTAssertNotNil(draft)
+        XCTAssertEqual(draft?.selectedModel, "")
+        XCTAssertEqual(
+            claudeNativeFallbackSelectionDetail(
+                selectedModel: "",
+                currentModel: "claude-opus-4-8"),
+            "Your configured fallback is not one of the current choices. Select a model to replace it.")
+    }
+
+    func testFallbackTargetEditorCopyDistinguishesUnconfiguredClient() {
+        XCTAssertEqual(
+            claudeNativeFallbackSelectionDetail(
+                selectedModel: "",
+                currentModel: ""),
+            "No fallback model is configured. Select a model to continue.")
+        XCTAssertNil(claudeNativeFallbackSelectionDetail(
+            selectedModel: "claude-opus-5",
+            currentModel: ""))
+    }
+
+    func testFallbackCatalogUnavailableDetailOnlyAppearsWithoutChoices() {
+        XCTAssertEqual(
+            claudeNativeFallbackCatalogDetail(options: []),
+            "Fallback model choices will appear when the model catalog is available.")
+        XCTAssertNil(claudeNativeFallbackCatalogDetail(options: [
+            ClaudeNativeFallbackOption(
+                label: "Claude Opus 5",
+                model: "claude-opus-5"),
+        ]))
     }
 
     func testFallbackTargetEditorStateUsesPresentedModel() {
@@ -228,14 +291,12 @@ final class FallbackPolicyTests: XCTestCase {
         ]))
         XCTAssertEqual(
             claudeNativeFallbackOptions(client: client),
-            [ClaudeNativeFallbackOption(
-                label: "Opus",
-                model: "claude-opus-5")])
+            [])
         XCTAssertTrue(
             client.basetenModelFallback?.availableModels.isEmpty == true)
     }
 
-    func testOldRouterSelectorFallsBackOnlyToCurrentTarget() throws {
+    func testOldRouterSelectorHasNoValidatedChoices() throws {
         let client = try XCTUnwrap(ClientStatus(dict: [
             "name": "claude-code",
             "baseten_model_fallback": [
@@ -254,9 +315,7 @@ final class FallbackPolicyTests: XCTestCase {
         ]))
         XCTAssertEqual(
             claudeNativeFallbackOptions(client: client),
-            [ClaudeNativeFallbackOption(
-                label: "Opus",
-                model: "claude-opus-5")])
+            [])
     }
 
     func testFallbackTargetStatusKeepsReadinessIndependentFromPolicy() throws {
@@ -304,14 +363,14 @@ final class FallbackPolicyTests: XCTestCase {
         let receipt = try XCTUnwrap(GlobalMutationReceipt(json: """
         {
           "warnings": [
-            {"code": "cross_provider_history_may_be_incompatible"},
+            {"code": "capable_router_activation_required"},
             "legacy warning",
             {"message": "ignored without code"}
           ]
         }
         """))
         XCTAssertEqual(receipt.warnings, [
-            "cross_provider_history_may_be_incompatible",
+            "capable_router_activation_required",
             "legacy warning",
         ])
     }

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/FallbackPolicyTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/FallbackPolicyTests.swift
@@ -152,6 +152,59 @@ final class FallbackPolicyTests: XCTestCase {
         XCTAssertTrue(isAcceptedClaudeNativeModelID("claude-3-7-sonnet"))
     }
 
+    func testFallbackTargetEditorPresentationStartsWithCurrentModel() throws {
+        let options = [
+            ClaudeNativeFallbackOption(
+                label: "Opus",
+                model: "claude-opus-5"),
+            ClaudeNativeFallbackOption(
+                label: "Sonnet",
+                model: "claude-sonnet-5"),
+        ]
+
+        var presentedDraft: ClaudeNativeFallbackEditorDraft?
+        XCTAssertNil(presentedDraft)
+
+        let draftID = UUID()
+        presentedDraft = ClaudeNativeFallbackEditorDraft(
+            options: options,
+            currentModel: "claude-sonnet-5",
+            id: draftID)
+        let draft = try XCTUnwrap(presentedDraft)
+        XCTAssertEqual(
+            draft.selectedModel,
+            "claude-sonnet-5")
+        XCTAssertEqual(
+            draft.id,
+            draftID)
+
+        presentedDraft = nil
+        XCTAssertNil(presentedDraft)
+    }
+
+    func testFallbackTargetEditorDoesNotPresentWithoutOptions() {
+        XCTAssertNil(ClaudeNativeFallbackEditorDraft(
+            options: [],
+            currentModel: "claude-sonnet-5"))
+    }
+
+    func testFallbackTargetEditorStateUsesPresentedModel() {
+        let options = [
+            ClaudeNativeFallbackOption(
+                label: "Opus",
+                model: "claude-opus-5"),
+            ClaudeNativeFallbackOption(
+                label: "Sonnet",
+                model: "claude-sonnet-5"),
+        ]
+
+        XCTAssertEqual(
+            initialClaudeNativeFallbackSelection(
+                options: options,
+                currentModel: "claude-sonnet-5"),
+            "claude-sonnet-5")
+    }
+
     func testNativeTargetSelectorFailsClosedOnServerAlias() throws {
         let client = try XCTUnwrap(ClientStatus(dict: [
             "name": "claude-code",

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/RequestPresentationTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/RequestPresentationTests.swift
@@ -27,6 +27,48 @@ final class RequestPresentationTests: XCTestCase {
             "Image input unsupported")
     }
 
+    func testSuppressedFallbackUsesSettingAndTargetCopy() {
+        let disabled429 = RequestFallback(
+            attempted: false,
+            suppressedReason: "policy_disabled_http_429")
+        XCTAssertEqual(
+            requestFallbackReason(disabled429),
+            "Disabled by setting")
+        XCTAssertEqual(
+            requestFallbackHelp(disabled429),
+            "Automatic fallback for HTTP 429 is disabled by setting.")
+
+        let disabled5xx = RequestFallback(
+            attempted: false,
+            suppressedReason: "policy_disabled_http_5xx")
+        XCTAssertEqual(
+            requestFallbackReason(disabled5xx),
+            "Disabled by setting")
+        XCTAssertEqual(
+            requestFallbackHelp(disabled5xx),
+            "Automatic fallback for HTTP 5xx is disabled by setting.")
+
+        let missingTarget = RequestFallback(
+            attempted: false,
+            suppressedReason: "native_target_unconfigured")
+        XCTAssertEqual(
+            requestFallbackReason(missingTarget),
+            "Fallback target not configured")
+        XCTAssertFalse(RequestItem(
+            eventID: "suppressed",
+            completedAt: Date(),
+            client: "claude-code",
+            configuredRoute: "baseten",
+            effectiveProvider: "baseten",
+            requestedModel: "claude-baseten-glm",
+            servedModel: "zai-org/GLM",
+            status: 429,
+            durationMs: 1,
+            terminationReason: "completed",
+            subagent: false,
+            fallback: disabled429).isFallback)
+    }
+
     func testRouteAndModelLabelsShowRequestedToServedPath() throws {
         let item = requestItem()
         let primary = try XCTUnwrap(item.primary)

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/RuntimeCoordinationTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/RuntimeCoordinationTests.swift
@@ -1568,7 +1568,7 @@ final class RuntimeCoordinationTests: XCTestCase {
         XCTAssertEqual(environment["HOME"], "/Users/test")
         XCTAssertEqual(
             environment["PATH"],
-            "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin")
+            "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/test/.local/bin")
         XCTAssertFalse(environment["PATH"]?.contains("/attacker") ?? true)
         XCTAssertEqual(
             environment["BASETEN_SWITCH_CONFIG_PATH"],
@@ -1578,6 +1578,21 @@ final class RuntimeCoordinationTests: XCTestCase {
         XCTAssertNil(environment["ANTHROPIC_AUTH_TOKEN"])
         XCTAssertNil(environment["UNRELATED"])
         XCTAssertNil(environment["SSH_AUTH_SOCK"])
+    }
+
+    func testCLIEnvironmentDoesNotAddRelativeOrEmptyHomeToPath() {
+        let systemPath =
+            "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        let relative = allowlistedCLIEnvironment(
+            ambient: ["HOME": "relative/home"],
+            overrides: [:])
+        let empty = allowlistedCLIEnvironment(
+            ambient: ["HOME": ""],
+            overrides: [:])
+
+        XCTAssertEqual(relative["PATH"], systemPath)
+        XCTAssertEqual(empty["PATH"], systemPath)
+        XCTAssertFalse(relative["PATH"]?.contains("relative") ?? true)
     }
 
     func testPreviewRuntimeFilesystemAcceptsPrivateRegularTree() throws {


### PR DESCRIPTION
## What

- Add independent controls for automatic native fallback after Baseten HTTP 429 and HTTP 5xx responses.
- Add a configurable native fallback model for requests that explicitly select a Baseten alias or model slug. Native-origin requests continue to use their requested model.
- Add Claude Code `/model` picker management in the CLI and macOS app, including catalog-backed add, remove, reorder, enable, disable, and sync flows.
- Let users enable the picker with no Baseten models selected, then add only the models they want.
- Populate fallback choices from the model catalog and show only the latest model in each supported Claude family.
- Apply known context limits to picker rows, preserve 1M context selection, and reject models below Claude Codes 200K picker minimum before changing configuration.
- Add migration, validation, hot-reload, rollback, status, and telemetry support for the new settings.

## Why

Baseten rate limits and server errors should not interrupt Claude Code when a native fallback is available. The fallback behavior also needs to be visible and configurable, including for models selected directly from the Baseten catalog.

## Testing

- `scripts/check.sh`
- Native macOS Stable UI E2E for enabling an empty picker without a confirmation dialog or default model additions
- Verified the resulting Claude Code setting contains an empty append-mode picker and the app reports synchronized state
- Completed a real Claude Code request through the Stable gateway after enabling the empty picker
- Verified that a known sub-200K model is rejected without changing gateway or Claude Code settings

## Security and privacy

Eligible fallback sends the current request to the configured protocol-native provider using the existing provider credentials. The CLI and macOS app edit the local gateway configuration and Claude Code user settings with validation, backups, hot reload, and rollback. Telemetry adds bounded fallback-source and suppression-reason fields; it does not add prompt or response bodies. No new dependencies, remote assets, or network destinations are introduced.