### PR TITLE
Automate Homebrew formula updates after releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,10 @@ jobs:
 
       - name: Run the hermetic repository gate
         run: scripts/check.sh --offline
+
+      - name: Verify release and Homebrew publication contracts
+        run: |
+          scripts/release/test-release-contract.sh
+          scripts/release/test-release-workflow.sh
+          scripts/release/test-render-formula.sh
+          scripts/release/test-publish-homebrew.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
     name: Build, attest, and publish beta prerelease
     runs-on: macos-15
     environment: release
+    outputs:
+      release_commit: ${{ steps.release-tag.outputs.commit }}
     permissions:
       contents: write
       id-token: write
@@ -46,6 +48,7 @@ jobs:
           cache-dependency-path: gateway/go.sum
 
       - name: Verify exact signed release tag
+        id: release-tag
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
           RELEASE_TAG_SIGNING_PUBLIC_KEY: ${{ vars.RELEASE_TAG_SIGNING_PUBLIC_KEY }}
@@ -86,14 +89,17 @@ jobs:
             || { printf 'checkout is not the selected tag commit\n' >&2; exit 1; }
           [[ "$(git describe --tags --exact-match HEAD)" == "$RELEASE_TAG" ]] \
             || { printf 'HEAD is not exactly the selected tag\n' >&2; exit 1; }
+          printf 'commit=%s\n' "$(git rev-parse 'HEAD^{commit}')" >>"$GITHUB_OUTPUT"
 
       - name: Run repository release gate
         run: scripts/check.sh --offline
 
       - name: Verify release workflow and formula contracts
         run: |
+          scripts/release/test-release-contract.sh
           scripts/release/test-release-workflow.sh
           scripts/release/test-render-formula.sh
+          scripts/release/test-publish-homebrew.sh
 
       - name: Build ad-hoc signed beta release assets
         env:
@@ -179,3 +185,40 @@ jobs:
           rm -f \
             "$RUNNER_TEMP/release-tag-signing-key.pub" \
             "$RUNNER_TEMP/release-tag-allowed-signers"
+
+  update-homebrew:
+    name: Publish Homebrew formula
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Check out the verified release commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.prepare.outputs.release_commit }}
+          persist-credentials: false
+
+      - name: Download the formula from this release run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: baseten-switch-${{ inputs.release_tag }}-homebrew
+          path: ${{ runner.temp }}/homebrew-release
+
+      - name: Create token for the Homebrew tap
+        id: tap-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.APP_HOMEBREW_UPDATER_CLIENT_ID }}
+          private-key: ${{ secrets.APP_HOMEBREW_UPDATER_PRIVATE_KEY }}
+          owner: basetenlabs
+          repositories: homebrew-baseten
+          permission-contents: write
+
+      - name: Publish the formula on tap main
+        env:
+          GH_TOKEN: ${{ steps.tap-token.outputs.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          FORMULA_PATH: ${{ runner.temp }}/homebrew-release/homebrew-tap/Formula/baseten-switch.rb
+        run: scripts/release/publish-homebrew.sh --tag "$RELEASE_TAG" --formula "$FORMULA_PATH"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,19 @@ full gate includes a live identity refresh against the maintainer's existing
 Baseten CLI credential store. It must not be run with credentials supplied by
 an untrusted pull request.
 
+For release workflow or packaging changes, also run the contracts required by
+the macOS CI job:
+
+```sh
+scripts/release/test-release-contract.sh
+scripts/release/test-release-workflow.sh
+scripts/release/test-render-formula.sh
+scripts/release/test-publish-homebrew.sh
+```
+
+See [RELEASING.md](RELEASING.md) for release configuration, publication, and
+Homebrew update recovery.
+
 ## Pull requests
 
 Keep changes focused and include tests for user-visible behavior. Describe any

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,78 @@
+# Releasing Baseten Switch
+
+The [release workflow](.github/workflows/release.yml) publishes a beta release
+and then updates `Formula/baseten-switch.rb` directly on `main` in
+[`basetenlabs/homebrew-baseten`](https://github.com/basetenlabs/homebrew-baseten).
+It does not require a separate tap pull request.
+
+## Configuration
+
+Configure these Actions variables for signed-tag verification:
+
+- `RELEASE_TAG_SIGNING_PUBLIC_KEY`
+- `RELEASE_TAG_SIGNING_PRINCIPAL`
+- `RELEASE_TAG_SIGNING_FINGERPRINT`
+
+Provide these Actions secrets to the `update-homebrew` job through repository
+or organization secrets:
+
+- `APP_HOMEBREW_UPDATER_CLIENT_ID`: the updater GitHub App's client ID.
+- `APP_HOMEBREW_UPDATER_PRIVATE_KEY`: that App's private key.
+
+The App installation must have `contents: write` access to
+`basetenlabs/homebrew-baseten` and permission to update its `main` branch
+directly under the tap's rules. The workflow requests a token limited to that
+repository and permission. A declared App permission or a configured secret
+does not establish that the installation has accepted permission changes or
+can bypass a pull request rule. Confirm those settings before a release.
+See GitHub's [App token action](https://github.com/actions/create-github-app-token#usage).
+
+The `prepare` job uses the `release` environment and its configured protection
+rules. The dependent updater adds no second environment approval. Source
+release publication uses `GITHUB_TOKEN`; tap updates use the App token.
+
+## Publish
+
+1. Run `scripts/check.sh` and the [release contracts](CONTRIBUTING.md)
+   against the release candidate. Review the final source and release notes.
+2. Create and push an annotated, SSH-signed `v<major>.<minor>.<patch>` tag using
+   the configured signing identity.
+3. Run **Publish beta release** in GitHub Actions. Supply the exact tag, a
+   period-separated numeric macOS build number, and the approved license SPDX
+   identifier. Complete the `release` environment approval when required.
+4. Verify that both `prepare` and `update-homebrew` succeed.
+
+Pushing a tag does not start this workflow. The manually dispatched `prepare`
+job verifies the tag, runs the release checks, builds and scans the universal
+macOS archive, renders the formula, attests the ZIP, and publishes the GitHub
+prerelease. Only then does `update-homebrew` publish the formula preserved by
+that same run.
+
+The GitHub release can be available before the tap update finishes. Publication
+is complete when the updater verifies the intended formula on tap `main`.
+Publishing does not upgrade installed clients or restart their gateways.
+Users follow the [upgrade instructions](README.md#upgrade) when ready.
+
+## Recover a failed tap update
+
+If `prepare` succeeded and `update-homebrew` failed, resolve the reported App
+access or tap conflict, then choose **Re-run failed jobs** on the original run:
+
+```sh
+gh run rerun RUN_ID --failed --repo basetenlabs/baseten-switch
+```
+
+This retries the updater without rebuilding or recreating the published
+release. GitHub supports [rerunning failed jobs](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/re-run-workflows-and-jobs#re-running-failed-jobs)
+for 30 days after the original run; the formula artifact has the same retention
+period. Keep release tags and assets immutable. The publication job refuses to
+replace an existing release, so rerunning every job is not the recovery path.
+
+The updater handles concurrent formula changes with the file's GitHub SHA.
+It makes at most three write attempts, reading and validating the current
+formula again before retrying a conflict. After any failed write, it checks
+whether the intended formula was published despite the error. Other failures
+stop the job.
+An identical formula is a successful no-op. A newer version already in the tap,
+or different formula bytes for the same version, stops the update for review.
+An older run cannot overwrite a newer formula.

--- a/scripts/release/publish-homebrew.sh
+++ b/scripts/release/publish-homebrew.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Publish one canonical formula without replacing a newer release in the tap.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec ruby - "$SCRIPT_DIR" "$@" <<'RUBY'
+require "base64"
+require "digest"
+require "json"
+require "open3"
+require "optparse"
+require "tmpdir"
+
+class PublicationError < StandardError; end
+class APIError < PublicationError
+  attr_reader :conflict
+
+  def initialize(message, conflict = false)
+    super(message)
+    @conflict = conflict
+  end
+end
+
+TAP_PATH = "Formula/baseten-switch.rb"
+TAP_API = "repos/basetenlabs/homebrew-baseten/contents/#{TAP_PATH}"
+MAX_WRITES = 3
+
+def require_condition(condition, message)
+  raise PublicationError, message unless condition
+end
+
+def version(tag)
+  require_condition(tag.match?(/\Av[0-9]+\.[0-9]+\.[0-9]+\z/), "invalid release tag")
+  tag.delete_prefix("v").split(".").map { |part| Integer(part, 10) }
+end
+
+def field(content, name)
+  values = content.scan(/^  #{Regexp.escape(name)} "([^"\r\n]+)"$/).flatten
+  require_condition(values.length == 1, "formula must contain exactly one #{name} field")
+  values.first
+end
+
+def formula_metadata(content)
+  require_condition(content.bytesize <= 65_536 && content.valid_encoding?, "invalid formula content")
+  url = field(content, "url")
+  tag = url[%r{\Ahttps://github\.com/basetenlabs/baseten-switch/releases/download/(v[0-9]+\.[0-9]+\.[0-9]+)/}, 1]
+  require_condition(!tag.nil?, "formula release URL is not canonical")
+  expected_url = "https://github.com/basetenlabs/baseten-switch/releases/download/#{tag}/baseten-switch_#{tag.delete_prefix('v')}_darwin_universal.zip"
+  require_condition(url == expected_url, "formula release URL is not canonical")
+  checksum = field(content, "sha256")
+  require_condition(checksum.match?(/\A[0-9a-f]{64}\z/), "invalid formula SHA256")
+  [tag, version(tag), checksum]
+end
+
+def validate_candidate(script_dir, tag, content)
+  candidate_tag, candidate_version, checksum = formula_metadata(content)
+  require_condition(candidate_tag == tag, "formula does not match the selected release tag")
+  license = field(content, "license")
+  Dir.mktmpdir("baseten-switch-formula-") do |directory|
+    expected = File.join(directory, "baseten-switch.rb")
+    _stdout, _stderr, status = Open3.capture3(
+      File.join(script_dir, "render-formula.sh"),
+      "--tag", tag, "--sha256", checksum, "--approved-license-spdx", license,
+      "--output", expected, "--patch-output", File.join(directory, "formula.patch")
+    )
+    require_condition(status.success? && File.binread(expected) == content,
+                      "candidate does not match the canonical formula renderer")
+  end
+  candidate_version
+end
+
+def api(method, endpoint, payload = nil)
+  arguments = ["gh", "api", "--hostname", "github.com", "--method", method,
+               "--header", "Accept: application/vnd.github+json",
+               "--header", "X-GitHub-Api-Version: 2022-11-28", endpoint]
+  arguments += ["--input", "-"] if payload
+  stdout, stderr, status = Open3.capture3(
+    { "GH_DEBUG" => nil, "GH_HOST" => nil }, *arguments,
+    stdin_data: payload ? JSON.generate(payload) : ""
+  )
+  unless status.success?
+    code = stderr[/\(HTTP ([0-9]{3})\)/, 1]
+    detail = code ? "HTTP #{code}" : "request failed"
+    raise APIError.new("tap #{method} #{detail}", ["409", "422"].include?(code))
+  end
+  result = JSON.parse(stdout)
+  require_condition(result.is_a?(Hash), "tap API returned an invalid response")
+  result
+rescue JSON::ParserError
+  raise APIError, "tap #{method} returned invalid JSON"
+end
+
+def read_current
+  current = api("GET", "#{TAP_API}?ref=main")
+  require_condition(current["type"] == "file" && current["path"] == TAP_PATH &&
+                    current["encoding"] == "base64" && current["sha"].is_a?(String) &&
+                    current["sha"].match?(/\A[0-9a-f]{40}\z/) && current["content"].is_a?(String),
+                    "tap API did not return the existing formula")
+  content = Base64.strict_decode64(current["content"].delete("\r\n"))
+  require_condition(Digest::SHA1.hexdigest("blob #{content.bytesize}\0#{content}") == current["sha"],
+                    "tap formula does not match its file SHA")
+  [current["sha"], content]
+rescue ArgumentError
+  raise PublicationError, "tap formula is not valid base64"
+end
+
+def check_version(current, candidate, candidate_version)
+  _tag, current_version, _checksum = formula_metadata(current)
+  comparison = candidate_version <=> current_version
+  require_condition(comparison >= 0, "refusing to downgrade the Homebrew formula")
+  require_condition(comparison != 0 || current == candidate,
+                    "refusing to replace different formula content for the same version")
+  comparison.zero?
+end
+
+begin
+  script_dir = ARGV.shift
+  options = {}
+  parser = OptionParser.new do |arguments|
+    arguments.banner = "Usage: publish-homebrew.sh --tag v<major>.<minor>.<patch> --formula PATH"
+    ["tag", "formula"].each do |name|
+      arguments.on("--#{name} VALUE") do |value|
+        require_condition(!options.key?(name), "duplicate --#{name} argument")
+        options[name] = value
+      end
+    end
+    arguments.on("-h", "--help") { puts arguments; exit }
+  end
+  parser.parse!
+  require_condition(ARGV.empty? && options.keys.sort == ["formula", "tag"], "--tag and --formula are required")
+  version(options["tag"])
+  candidate = File.binread(options["formula"], 65_537)
+  candidate_version = validate_candidate(script_dir, options["tag"], candidate)
+  require_condition(!ENV.fetch("GH_TOKEN", "").empty?, "GH_TOKEN is required")
+
+  previous_error = nil
+  writes = 0
+  loop do
+    sha, current = read_current
+    if check_version(current, candidate, candidate_version)
+      puts "Homebrew formula already matches #{options['tag']}."
+      break
+    end
+    raise previous_error if previous_error && (!previous_error.conflict || writes >= MAX_WRITES)
+
+    writes += 1
+    begin
+      api("PUT", TAP_API,
+          "message" => "Update baseten-switch to #{options['tag']}", "branch" => "main",
+          "sha" => sha, "content" => Base64.strict_encode64(candidate))
+      _observed_sha, observed = read_current
+      if observed == candidate
+        puts "Published Homebrew formula for #{options['tag']}."
+        break
+      end
+      check_version(observed, candidate, candidate_version)
+      raise APIError, "tap update was not observed after publication"
+    rescue APIError => error
+      # Re-read before retrying or reporting an ambiguous write failure. A
+      # completed write is a no-op; a newer release can never be overwritten.
+      previous_error = error
+    end
+  end
+rescue PublicationError => error
+  warn "publish-homebrew: #{error.message}"
+  exit 1
+rescue OptionParser::ParseError, SystemCallError, ArgumentError
+  warn "publish-homebrew: invalid arguments, unreadable input, or unavailable command"
+  exit 1
+end
+RUBY

--- a/scripts/release/test-publish-homebrew.sh
+++ b/scripts/release/test-publish-homebrew.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# Exercise tap publication against a local GitHub API fixture. No network or
+# credential store is used, and the fixture accepts only the expected endpoints.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ruby - "$SCRIPT_DIR/publish-homebrew.sh" "$SCRIPT_DIR/render-formula.sh" <<'RUBY'
+require "base64"
+require "digest"
+require "fileutils"
+require "json"
+require "open3"
+require "tmpdir"
+
+publisher, renderer = ARGV
+tap_path = "repos/basetenlabs/homebrew-baseten/contents/Formula/baseten-switch.rb"
+checksum = "0123456789abcdef" * 4
+other_checksum = "fedcba9876543210" * 4
+tag = "v1.2.3"
+cases = 0
+
+def check(condition, message)
+  abort "FAIL: #{message}" unless condition
+end
+
+Dir.mktmpdir("switch-homebrew-test.") do |root|
+  bin = File.join(root, "bin")
+  FileUtils.mkdir_p(bin)
+  fake_gh = File.join(bin, "gh")
+  File.write(fake_gh, <<~'FAKE')
+    #!/usr/bin/env ruby
+    require "base64"
+    require "digest"
+    require "json"
+
+    state_path = ENV.fetch("HOMEBREW_TEST_STATE")
+    log_path = ENV.fetch("HOMEBREW_TEST_LOG")
+    args = ARGV.dup
+    abort "fixture only supports gh api" unless args.shift == "api"
+    method = "GET"
+    endpoint = nil
+    payload = nil
+    hostname = nil
+    until args.empty?
+      argument = args.shift
+      case argument
+      when "--method", "-X"
+        method = args.shift
+      when "--header", "-H"
+        args.shift
+      when "--hostname"
+        hostname = args.shift
+      when "--input"
+        input = args.shift
+        payload = JSON.parse(input == "-" ? STDIN.read : File.read(input))
+      else
+        abort "unsupported fixture argument" if argument.start_with?("-") || endpoint
+        endpoint = argument
+      end
+    end
+    abort "publication did not pin the public API host" unless hostname == "github.com"
+    File.open(log_path, "a") { |f| f.puts JSON.generate({"method" => method, "endpoint" => endpoint, "payload" => payload}) }
+    state = JSON.parse(File.read(state_path))
+    blob_sha = ->(text) { Digest::SHA1.hexdigest("blob #{text.bytesize}\0#{text}") }
+    save = -> { File.write(state_path, JSON.generate(state)) }
+    fail_http = ->(status) {
+      puts JSON.generate({"message" => "Synthetic API failure"})
+      warn "gh: Synthetic API failure (HTTP #{status})"
+      exit 1
+    }
+    tap = "repos/basetenlabs/homebrew-baseten/contents/Formula/baseten-switch.rb"
+    if method == "GET" && endpoint == "#{tap}?ref=main"
+      fail_http.call(404) if state["fault"] == "missing_formula"
+      if state["fault"] == "malformed_contents"
+        puts '{"type":"file","encoding":"base64","content":"!not-base64!","sha":"invalid"}'
+      else
+        puts JSON.generate({"type" => "file", "path" => "Formula/baseten-switch.rb", "encoding" => "base64", "content" => state.fetch("formula"), "sha" => state.fetch("sha")})
+      end
+    elsif method == "PUT" && endpoint == tap
+      abort "tap mutation was not limited to one file on main" unless payload && payload.keys.sort == %w[branch content message sha] && payload["branch"] == "main"
+      abort "tap mutation did not include the current blob SHA" unless payload["sha"] == state["sha"]
+      content = Base64.strict_decode64(payload.fetch("content"))
+      abort "tap mutation contained unexpected formula bytes" unless content == Base64.strict_decode64(state.fetch("candidate"))
+      state["attempts"] += 1
+      save.call
+      fail_http.call(500) if state["fault"] == "write_failure"
+      if state["fault"] == "unapplied_write"
+        puts JSON.generate({"content" => {"sha" => blob_sha.call(content)}, "commit" => {"sha" => "d" * 40}})
+        exit 0
+      end
+      conflict = state["fault"] == "conflict_forever" || (state["fault"].start_with?("conflict_") && state["attempts"] == 1)
+      if conflict
+        state["formula"] = state.fetch("conflict_formula") if state["fault"] == "conflict_once"
+        state["formula"] = state["candidate"] if state["fault"] == "conflict_same"
+        state["formula"] = state.fetch("newer_formula") if state["fault"] == "conflict_newer"
+        state["sha"] = blob_sha.call(Base64.strict_decode64(state.fetch("formula")))
+        save.call
+        fail_http.call(409)
+      end
+      state["formula"] = payload.fetch("content")
+      state["sha"] = blob_sha.call(content)
+      state["commits"] += 1
+      save.call
+      fail_http.call(500) if state["fault"] == "lost_write_response"
+      puts JSON.generate({"content" => {"sha" => state["sha"], "path" => "Formula/baseten-switch.rb"}, "commit" => {"sha" => "d" * 40}})
+    else
+      abort "unexpected endpoint or method in publication fixture"
+    end
+  FAKE
+  File.chmod(0755, fake_gh)
+
+  formula_number = 0
+  render = lambda do |version, digest|
+    formula_number += 1
+    output = File.join(root, "rendered-#{formula_number}.rb")
+    stdout, stderr, status = Open3.capture3(renderer, "--tag", version, "--sha256", digest,
+      "--approved-license-spdx", "MIT", "--output", output, "--patch-output", "#{output}.patch")
+    check(status.success?, "fixture renderer failed: #{stderr}#{stdout}")
+    File.read(output)
+  end
+  candidate = render.call(tag, checksum)
+  old = render.call("v1.2.1", other_checksum)
+  conflict_formula = render.call("v1.2.2", other_checksum)
+  newer = render.call("v2.0.0", other_checksum)
+  same_version_other_checksum = render.call(tag, other_checksum)
+  formula_path = File.join(root, "candidate.rb")
+  state_path = File.join(root, "state.json")
+  log_path = File.join(root, "calls.jsonl")
+  environment = {
+    "PATH" => "#{bin}:#{ENV.fetch('PATH')}",
+    "GH_TOKEN" => "synthetic-test-token",
+    "HOMEBREW_TEST_STATE" => state_path,
+    "HOMEBREW_TEST_LOG" => log_path,
+  }
+  base_state = {
+    "formula" => Base64.strict_encode64(old), "candidate" => Base64.strict_encode64(candidate),
+    "newer_formula" => Base64.strict_encode64(newer),
+    "conflict_formula" => Base64.strict_encode64(conflict_formula),
+    "sha" => Digest::SHA1.hexdigest("blob #{old.bytesize}\0#{old}"),
+    "fault" => "", "attempts" => 0, "commits" => 0,
+  }
+  setup = lambda do |state = base_state, formula = candidate|
+    state = state.dup
+    existing = Base64.strict_decode64(state.fetch("formula"))
+    state["sha"] = Digest::SHA1.hexdigest("blob #{existing.bytesize}\0#{existing}")
+    File.write(state_path, JSON.generate(state))
+    File.write(formula_path, formula)
+    File.write(log_path, "")
+  end
+  current = -> { JSON.parse(File.read(state_path)) }
+  calls = -> { File.readlines(log_path).map { |line| JSON.parse(line) } }
+  invoke = lambda do |arguments = ["--tag", tag, "--formula", formula_path], env = environment|
+    Open3.capture3(env, publisher, *arguments)
+  end
+  expect_success = lambda do |name|
+    stdout, stderr, status = invoke.call
+    check(status.success?, "#{name}: #{stderr}#{stdout}")
+    cases += 1
+  end
+  expect_rejected = lambda do |name, arguments = ["--tag", tag, "--formula", formula_path], env = environment|
+    before = current.call
+    stdout, stderr, status = invoke.call(arguments, env)
+    check(!status.success?, "#{name}: unexpectedly succeeded: #{stdout}#{stderr}")
+    after = current.call
+    check(after["formula"] == before["formula"] && after["commits"] == before["commits"], "#{name}: changed the tap")
+    cases += 1
+  end
+
+  setup.call
+  expect_success.call("updates an existing formula")
+  check(current.call["formula"] == Base64.strict_encode64(candidate), "updated formula does not match release")
+  check(current.call["commits"] == 1 && current.call["attempts"] == 1, "update did not make exactly one commit")
+  writes = calls.call.select { |call| call["method"] != "GET" }
+  check(writes.length == 1 && writes.first["endpoint"] == tap_path, "update mutated more than the formula")
+  expect_success.call("rerun of completed update")
+  check(current.call["commits"] == 1 && current.call["attempts"] == 1, "identical rerun wrote another commit")
+
+  {
+    "downgrade" => newer,
+    "same version with changed checksum" => same_version_other_checksum,
+    "same version with changed formula" => candidate.sub('license "MIT"', 'license "Apache-2.0"'),
+    "unrecognized existing formula" => "class Unexpected < Formula\nend\n",
+  }.each do |name, existing|
+    setup.call(base_state.merge("formula" => Base64.strict_encode64(existing)))
+    expect_rejected.call(name)
+    check(current.call["attempts"] == 0, "#{name}: attempted a write")
+  end
+
+  {
+    "noncanonical URL" => candidate.sub("https://github.com/", "https://example.invalid/"),
+    "changed asset name" => candidate.sub("darwin_universal.zip", "darwin_arm64.zip"),
+    "invalid checksum" => candidate.sub(checksum, "not-a-checksum"),
+    "injected Ruby" => candidate + "system('false')\n",
+    "duplicate checksum" => candidate.sub("  sha256", "  sha256 \"#{checksum}\"\n  sha256"),
+  }.each do |name, formula|
+    setup.call(base_state, formula)
+    expect_rejected.call(name)
+    check(current.call["attempts"] == 0, "#{name}: attempted a write")
+  end
+
+  [
+    ["missing tag", ["--formula", formula_path]],
+    ["invalid tag", ["--tag", "v1.2.3/other", "--formula", formula_path]],
+    ["missing formula", ["--tag", tag]],
+    ["missing formula file", ["--tag", tag, "--formula", File.join(root, "absent.rb")]],
+    ["duplicate option", ["--tag", tag, "--tag", tag, "--formula", formula_path]],
+    ["unknown option", ["--tag", tag, "--formula", formula_path, "--branch", "other"]],
+  ].each do |name, arguments|
+    setup.call
+    expect_rejected.call(name, arguments)
+    check(current.call["attempts"] == 0, "#{name}: attempted a write")
+  end
+  setup.call
+  expect_rejected.call("missing token", ["--tag", tag, "--formula", formula_path], environment.merge("GH_TOKEN" => nil))
+
+  %w[missing_formula malformed_contents write_failure unapplied_write].each do |fault|
+    setup.call(base_state.merge("fault" => fault))
+    expect_rejected.call(fault)
+  end
+
+  setup.call(base_state.merge("fault" => "lost_write_response"))
+  expect_success.call("verifies a successful update after its response is lost")
+  check(current.call["commits"] == 1 && current.call["attempts"] == 1, "lost response caused a duplicate write")
+
+  setup.call(base_state.merge("fault" => "conflict_once"))
+  expect_success.call("retries a stale SHA after refetching")
+  check(current.call["commits"] == 1 && current.call["attempts"] == 2, "SHA conflict did not produce one successful update")
+  shas = calls.call.select { |call| call["method"] == "PUT" }.map { |call| call["payload"]["sha"] }
+  check(shas.uniq.length == 2, "SHA conflict reused stale content SHA")
+
+  setup.call(base_state.merge("fault" => "conflict_same"))
+  expect_success.call("concurrent publisher already wrote identical formula")
+  check(current.call["attempts"] == 1 && current.call["commits"] == 0, "converged update was written again")
+
+  setup.call(base_state.merge("fault" => "conflict_newer"))
+  _, _, status = invoke.call
+  check(!status.success?, "concurrent newer release was not rejected")
+  check(current.call["formula"] == Base64.strict_encode64(newer) && current.call["attempts"] == 1 && current.call["commits"] == 0,
+    "retry replaced a concurrent newer release")
+  cases += 1
+
+  setup.call(base_state.merge("fault" => "conflict_forever"))
+  expect_rejected.call("bounded repeated SHA conflicts")
+  check(current.call["attempts"].between?(2, 3), "SHA retries are not bounded")
+  state = current.call.merge("fault" => "")
+  File.write(state_path, JSON.generate(state))
+  expect_success.call("safe rerun after conflicts stop")
+  check(current.call["commits"] == 1, "rerun did not complete exactly one update")
+end
+
+puts "PASS: Homebrew publication contract (#{cases} local fixture cases)"
+RUBY

--- a/scripts/release/test-release-workflow.sh
+++ b/scripts/release/test-release-workflow.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Workflow expressions and shell variables below are matched as literal source.
+# shellcheck disable=SC2016
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -74,8 +76,73 @@ grep -Fq '"dist/baseten-switch_${version}_darwin_universal.zip"' "$WORKFLOW" \
 grep -Fq '"dist/checksums.txt"' "$WORKFLOW" \
     || fail "release does not upload checksums"
 
-if grep -Eiq -- 'APPLE_|NOTARY|NOTARIZ|SBOM|CYCLONEDX|RELEASE_TAG_SIGNING_PUBLIC_KEY_BASE64|gpg --batch|--draft|--clobber|gh release edit|gh release upload|gh release delete|git push|brew tap' "$WORKFLOW"; then
-    fail "workflow contains replacement, publication, tap mutation, or release mutation behavior"
+if grep -Eiq -- 'APPLE_|NOTARY|NOTARIZ|SBOM|CYCLONEDX|RELEASE_TAG_SIGNING_PUBLIC_KEY_BASE64|gpg --batch|--draft|--clobber|gh release edit|gh release upload|gh release delete|git push|[[:space:]]brew[[:space:]]+tap([[:space:]]|$)|gh pr ' "$WORKFLOW"; then
+    fail "workflow contains unsupported signing, asset replacement, or unscoped publication behavior"
 fi
 
-printf 'PASS: pinned manual beta prerelease workflow contract\n'
+ruby - "$WORKFLOW" "$REPO_DIR/.github/workflows/ci.yml" <<'RUBY'
+require "yaml"
+
+def check(condition, message)
+  abort "FAIL: #{message}" unless condition
+end
+
+workflow = YAML.load_file(ARGV.fetch(0))
+ci = YAML.load_file(ARGV.fetch(1))
+jobs = workflow.fetch("jobs")
+prepare = jobs.fetch("prepare")
+publisher = jobs.fetch("update-homebrew")
+check(Array(publisher["needs"]) == ["prepare"] && !publisher.key?("if"),
+      "Homebrew publication must require successful release preparation")
+check(publisher.fetch("permissions") == {"contents" => "read", "actions" => "read"},
+      "Homebrew job must keep its workflow token read-only")
+steps = publisher.fetch("steps")
+checkout = steps.find { |step| step.fetch("uses", "").start_with?("actions/checkout@") }
+check(checkout && checkout.fetch("with")["ref"] == '${{ needs.prepare.outputs.release_commit }}' &&
+      checkout.fetch("with")["persist-credentials"] == false,
+      "Homebrew source must be the verified release commit without persisted credentials")
+check(prepare.fetch("outputs")["release_commit"] == '${{ steps.release-tag.outputs.commit }}',
+      "release source output is not bound to tag verification")
+verification = prepare.fetch("steps").find { |step| step["id"] == "release-tag" }
+check(verification && verification.fetch("run").include?('git verify-tag "$RELEASE_TAG"') &&
+      verification.fetch("run").include?('git rev-parse "HEAD^{commit}"'),
+      "published source commit must come from signed tag verification")
+
+download = steps.find { |step| step.fetch("uses", "").start_with?("actions/download-artifact@") }
+upload = prepare.fetch("steps").find { |step| step.fetch("uses", "").start_with?("actions/upload-artifact@") }
+check(download && upload && download.fetch("with")["name"] == upload.fetch("with")["name"] &&
+      download.fetch("with").keys.sort == ["name", "path"],
+      "Homebrew formula must come from the matching artifact in this release run")
+check(download.fetch("with")["name"] == 'baseten-switch-${{ inputs.release_tag }}-homebrew',
+      "Homebrew artifact must match the selected release")
+token_steps = steps.select { |step| step.fetch("uses", "").start_with?("actions/create-github-app-token@") }
+check(token_steps.length == 1, "Homebrew publication requires one scoped app token")
+token = token_steps.first
+token_inputs = token.fetch("with")
+check(token_inputs == {
+  "client-id" => '${{ secrets.APP_HOMEBREW_UPDATER_CLIENT_ID }}',
+  "private-key" => '${{ secrets.APP_HOMEBREW_UPDATER_PRIVATE_KEY }}',
+  "owner" => "basetenlabs", "repositories" => "homebrew-baseten", "permission-contents" => "write",
+}, "Homebrew app token must be limited to writing contents in the tap")
+publish_steps = steps.select { |step| step.fetch("run", "").include?("scripts/release/publish-homebrew.sh") }
+check(publish_steps.length == 1, "Homebrew job must invoke the canonical publisher once")
+publish = publish_steps.first
+check(steps.index(download) < steps.index(token) && steps.index(token) < steps.index(publish),
+      "Homebrew app token must be created after the formula download and before publication")
+check(publish.fetch("env")["GH_TOKEN"] == "${{ steps.#{token.fetch('id')}.outputs.token }}" &&
+      !publisher.fetch("env", {}).key?("GH_TOKEN"),
+      "tap token must be scoped to the publication step")
+check(publish.fetch("env")["RELEASE_TAG"] == '${{ inputs.release_tag }}' &&
+      publish.fetch("env")["FORMULA_PATH"] == "#{download.fetch('with').fetch('path')}/homebrew-tap/Formula/baseten-switch.rb",
+      "publisher must consume the formula downloaded for the selected release")
+
+%w[test-release-contract.sh test-release-workflow.sh test-render-formula.sh test-publish-homebrew.sh].each do |script|
+  command = "scripts/release/#{script}"
+  check(prepare.fetch("steps").any? { |step| step.fetch("run", "").lines.any? { |line| line.strip == command } },
+        "release gate omitted #{script}")
+  check(ci.fetch("jobs").values.any? { |job| job.fetch("steps").any? { |step| step.fetch("run", "").lines.any? { |line| line.strip == command } } },
+        "normal CI omitted #{script}")
+end
+RUBY
+
+printf 'PASS: manual beta release and scoped Homebrew publication workflow contract\n'


### PR DESCRIPTION
## What

After a successful beta release, a separate job updates `Formula/baseten-switch.rb` directly on the Homebrew tap's `main` branch. It uses the formula from that release run and the exact source commit validated by signed-tag verification. The existing manual release trigger and release environment approval remain in place.

The updater rejects downgrades and different content for the same version, uses the current file SHA for concurrent updates, and verifies the result. Identical reruns do not write another commit. A failed updater job can be rerun without rebuilding or replacing the published release.

## Why

Keep the Homebrew formula synchronized with published releases without a separate formula pull request and approval.

## Testing

- Full `scripts/check.sh`: source secret scan, Go build/vet/tests across 29 packages, 317 Swift tests, identity refresh, and isolated gateway, door and lifecycle checks passed.
- All four release contract scripts passed, including 28 local API fixture cases for Homebrew updates, invalid inputs, conflicts, failures and reruns.
- Actionlint, ShellCheck, the pinned Go vulnerability scan and committed-source secret scan passed.
- Verified the downloaded formula path against an existing release workflow artifact.

A [live permission probe](https://github.com/basetenlabs/baseten-switch/actions/runs/34003583047) successfully used the configured, repository-scoped App token to advance tap `main` without a pull request. The [resulting empty commit](https://github.com/basetenlabs/homebrew-baseten/commit/7343edca0554a990cdeafbdb1d393559e9d1a42c) preserved the complete repository tree and the Switch formula. No release or version upgrade was performed; that full publishing path remains untested live.

## Security and privacy

The updater's workflow token is read-only. A separate GitHub App token is restricted to `homebrew-baseten` with contents-write permission and is used only by the publishing step. API writes target only the existing Switch formula on `main`; API bodies and credentials are excluded from logs.

The two added official GitHub Actions, artifact download and App token creation, are pinned to full commit SHAs. They transfer the generated formula between jobs and create a short-lived repository-scoped token. The publisher uses Ruby standard libraries and the GitHub CLI; no gateway runtime packages or network destinations are added. The App must be authorized to update the tap under its repository rules.
