### PR TITLE
Add explicit reasoning On and Off controls

### DIFF
--- a/config/schema.md
+++ b/config/schema.md
@@ -92,13 +92,14 @@ clients:
       baseten:
         zai-org/GLM-5.2:
           reasoning:
-            mode: follow_harness
+            mode: on
 ```
 
 `reasoning.mode` accepts:
 
 | Mode | Optional fields | Effect |
 |---|---|---|
+| `on` | none | Apply the selected protocol adapter's reviewed On encoding on the Baseten attempt. |
 | `off` | none | Apply the selected protocol adapter's validated Off encoding on the Baseten attempt. |
 | `follow_harness` | none | Preserve or translate the harness's semantic reasoning choice when the active protocol adapter supports it. |
 | `fixed` | `effort` (required) | Force the exact catalog-advertised effort value. |
@@ -111,19 +112,32 @@ projection.
 
 `global.model_options` is not accepted. Model options are client-scoped.
 
-An absent override uses the runtime safe default. Every model whose catalog
-semantic capability and the selected client's protocol adapter intersect on a
-validated Off control defaults to Off. A model without a validated Off control
-defaults to passthrough, which may leave provider reasoning on. Therefore the
-canonical `gateway.example.yaml` intentionally omits `model_options`. Users add
-an override only to follow harness reasoning or choose a catalog-supported
-fixed effort.
+An absent override uses the runtime safe default. A catalog toggle on the
+reviewed Messages adapter defaults to Off. An exact reviewed compatibility can
+also define an Off default for a known, reasoning-capable model. All other
+models default to passthrough. Therefore the canonical `gateway.example.yaml`
+intentionally omits `model_options`. Users add an override only to enable,
+disable, follow harness reasoning, or choose a catalog-supported fixed effort.
+On Claude Messages, `zai-org/GLM-5.2-Fast` is an exact reviewed compatibility
+and defaults to Off when its catalog metadata reports reasoning support.
 
 Available modes depend on both the selected model's catalog capabilities and
 the client's protocol. The UI exposes only controls that the active
-combination supports. Claude Messages supports Off and `follow_harness` for
-catalog models with a reasoning toggle, but not categorical effort values.
-Other protocols expose exact catalog efforts only when they can encode them.
+combination supports. Claude Messages supports On, Off, and `follow_harness`
+for catalog models with a reasoning toggle, but not categorical effort values.
+An exact reviewed adapter compatibility may expose On and Off, and may select
+Off as that model's safe default, without changing its catalog metadata. The
+full app offers only projected On and Off choices. Saved legacy
+`follow_harness` and `fixed` policies remain visible and resettable but are not
+new UI choices. Other protocols expose exact catalog efforts only when they can
+encode them.
+
+On and Off replace only the top-level Messages `thinking` object with the
+reviewed enabled or disabled form. Other request fields remain unchanged,
+including Claude Code's separate `output_config.effort` field. Switch does not
+map that field to a provider effort or guarantee distinct effort behavior. See
+the [Claude Code gateway protocol](https://code.claude.com/docs/en/llm-gateway-protocol)
+and the [Baseten Messages reference](https://docs.baseten.co/reference/inference-api/messages).
 
 Resetting a model removes its explicit override and recomputes the safe
 default. The full app labels this action `Reset to Safe Default`. A model with
@@ -287,6 +301,7 @@ credential reports `auth_type: api_key` with `signed_in: false` and
 The typed provider/model commands are:
 
 ```sh
+baseten-switch claude reasoning baseten zai-org/GLM-5.2-Fast on
 baseten-switch claude reasoning baseten zai-org/GLM-5.2 off
 baseten-switch claude reasoning baseten zai-org/GLM-5.2 follow-harness
 baseten-switch codex reasoning baseten deepseek-ai/DeepSeek-V4-Pro effort high
@@ -298,7 +313,7 @@ Default: it removes the model-specific override, prunes empty parent mappings,
 and lets the runtime recompute the catalog-and-adapter safe default. It is
 offline-safe because removal needs no catalog lookup.
 
-`off`, `follow-harness`, and `effort` require a healthy router. The gateway
+`on`, `off`, `follow-harness`, and `effort` require a healthy router. The gateway
 validates the choice against one catalog snapshot and the selected client's
 adapter. It does not inspect or warn about another client.
 

--- a/gateway/cmd/baseten-switch/claude_adapter.go
+++ b/gateway/cmd/baseten-switch/claude_adapter.go
@@ -93,7 +93,7 @@ var (
 
 func cmdClaude(args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: baseten-switch claude on|off|status|picker <status|enable|list|add|remove|move|sync|disable>|subagents [<model>|on|inherit]|route [<family> <target|default>]|reasoning baseten <model> off|follow-harness|effort <value>|default  (start/stop are aliases for on/off)")
+		fmt.Fprintln(os.Stderr, "usage: baseten-switch claude on|off|status|picker <status|enable|list|add|remove|move|sync|disable>|subagents [<model>|on|inherit]|route [<family> <target|default>]|reasoning baseten <model> on|off|follow-harness|effort <value>|default  (start/stop are aliases for on/off)")
 		return 2
 	}
 	if replayed, rc := preflightClaudeTerminalReplay(args); replayed {

--- a/gateway/cmd/baseten-switch/codex_adapter.go
+++ b/gateway/cmd/baseten-switch/codex_adapter.go
@@ -75,7 +75,7 @@ const (
 
 func cmdCodex(args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: baseten-switch codex on|off|status|route <baseten-slug>|reasoning baseten <model> off|follow-harness|effort <value>|default  (start/stop are aliases for on/off)")
+		fmt.Fprintln(os.Stderr, "usage: baseten-switch codex on|off|status|route <baseten-slug>|reasoning baseten <model> on|off|follow-harness|effort <value>|default  (start/stop are aliases for on/off)")
 		return 2
 	}
 	if replayed, rc := preflightCodexTerminalReplay(args); replayed {

--- a/gateway/cmd/baseten-switch/main.go
+++ b/gateway/cmd/baseten-switch/main.go
@@ -340,7 +340,7 @@ Plain doctor is read-only. --fix cannot be combined with --json.
   baseten-switch claude picker status|enable [--dry-run --json] [--convert-replacement-mode]|list|add <slug> [--alias <alias>] [--dry-run --json]|remove <alias>|move <alias> --before <alias>|sync [--convert-replacement-mode]|disable
   baseten-switch claude subagents [<model>|on|inherit]
   baseten-switch claude route [<family> <target|default>]
-  baseten-switch claude reasoning baseten <model> off|follow-harness|effort <value>|default
+  baseten-switch claude reasoning baseten <model> on|off|follow-harness|effort <value>|default
 
 on sets ANTHROPIC_BASE_URL, CLAUDE_CODE_ATTRIBUTION_HEADER, and
 ENABLE_TOOL_SEARCH in ~/.claude/settings.json, and backs up prior values. off
@@ -365,7 +365,7 @@ for the final Baseten model.
 	{"codex", "Manage the opt-in Codex gateway profile", `Usage:
   baseten-switch codex on|off|status
   baseten-switch codex route <baseten-slug>
-  baseten-switch codex reasoning baseten <model> off|follow-harness|effort <value>|default
+  baseten-switch codex reasoning baseten <model> on|off|follow-harness|effort <value>|default
 
 on writes the managed $CODEX_HOME/baseten.config.toml overlay and points its
 provider at the gateway door. It refuses to modify an existing overlay that is

--- a/gateway/cmd/baseten-switch/reasoning.go
+++ b/gateway/cmd/baseten-switch/reasoning.go
@@ -14,7 +14,7 @@ import (
 	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
 )
 
-const reasoningUsage = "usage: baseten-switch <claude|codex> reasoning baseten <model> off|follow-harness|effort <value>|default"
+const reasoningUsage = "usage: baseten-switch <claude|codex> reasoning baseten <model> on|off|follow-harness|effort <value>|default"
 
 type reasoningCommandOptions struct {
 	Mutation mutationOptions
@@ -191,6 +191,11 @@ func parseReasoningPolicy(args []string) (string, string, config.ReasoningPolicy
 			return provider, modelID, config.ReasoningPolicy{}, false, fmt.Errorf("default accepts no value")
 		}
 		return provider, modelID, config.ReasoningPolicy{}, true, nil
+	case "on":
+		if len(args) != 3 {
+			return provider, modelID, config.ReasoningPolicy{}, false, fmt.Errorf("on accepts no value")
+		}
+		return provider, modelID, config.ReasoningPolicy{Mode: config.ReasoningOn}, false, nil
 	case "off":
 		if len(args) != 3 {
 			return provider, modelID, config.ReasoningPolicy{}, false, fmt.Errorf("off accepts no value")

--- a/gateway/cmd/baseten-switch/reasoning_test.go
+++ b/gateway/cmd/baseten-switch/reasoning_test.go
@@ -41,6 +41,7 @@ func TestParseReasoningPolicy(t *testing.T) {
 		wantDefault bool
 		wantErr     bool
 	}{
+		{args: []string{"baseten", "zai-org/GLM-5.2-Fast", "on"}, want: config.ReasoningPolicy{Mode: config.ReasoningOn}},
 		{args: []string{"baseten", "zai-org/GLM-5.2", "off"}, want: config.ReasoningPolicy{Mode: config.ReasoningOff}},
 		{args: []string{"baseten", "zai-org/GLM-5.2", "follow-harness"}, want: config.ReasoningPolicy{Mode: config.ReasoningFollowHarness}},
 		{args: []string{"baseten", "deepseek-ai/DeepSeek-V4-Pro", "effort", "high"}, want: config.ReasoningPolicy{Mode: config.ReasoningFixed, Effort: "high"}},
@@ -48,6 +49,7 @@ func TestParseReasoningPolicy(t *testing.T) {
 		{args: []string{"openai", "gpt-5", "off"}, wantErr: true},
 		{args: []string{"baseten", "model", "effort"}, wantErr: true},
 		{args: []string{"baseten", "model", "off", "high"}, wantErr: true},
+		{args: []string{"baseten", "model", "on", "medium"}, wantErr: true},
 	}
 	for _, tc := range tests {
 		t.Run(strings.Join(tc.args, "_"), func(t *testing.T) {
@@ -62,7 +64,7 @@ func TestParseReasoningPolicy(t *testing.T) {
 	}
 }
 
-func TestReasoningDefaultIsOfflineSafeAndSkipsPreflight(t *testing.T) {
+func TestReasoningDefaultResetsFastOnOverrideAndSkipsPreflight(t *testing.T) {
 	path := writeSwitchFixture(t, `global:
   routing_enabled: true
 clients:
@@ -70,18 +72,18 @@ clients:
     enabled: true
     bind_addr: 127.0.0.1:18081
     protocol_shape: anthropic
-    default_model: zai-org/GLM-5.2
+    default_model: zai-org/GLM-5.2-Fast
     model_options:
       baseten:
-        "zai-org/GLM-5.2":
+        "zai-org/GLM-5.2-Fast":
           reasoning:
-            mode: follow_harness
+            mode: on
 `)
 	preflight := &failingReasoningPreflight{}
 	installReasoningPreflight(t, preflight)
 	var out strings.Builder
 	rc := runClientReasoning(mutationSurfaceClaude, "claude-code", []string{
-		"baseten", "zai-org/GLM-5.2", "default",
+		"baseten", "zai-org/GLM-5.2-Fast", "default",
 		"--operation-id", "reasoning-default-test",
 	}, &out)
 	if rc != 0 {
@@ -97,7 +99,7 @@ clients:
 	if strings.Contains(string(body), "model_options:") {
 		t.Fatalf("default did not remove the client override:\n%s", body)
 	}
-	if !strings.Contains(out.String(), "claude-code reasoning: baseten/zai-org/GLM-5.2 -> default") {
+	if !strings.Contains(out.String(), "claude-code reasoning: baseten/zai-org/GLM-5.2-Fast -> default") {
 		t.Fatalf("output = %q", out.String())
 	}
 }

--- a/gateway/cmd/gateway/admin_reasoning_preflight.go
+++ b/gateway/cmd/gateway/admin_reasoning_preflight.go
@@ -196,18 +196,10 @@ func validateReasoningPreflightPolicy(
 		)
 	}
 	switch request.Policy.Mode {
-	case config.ReasoningOff:
-		for _, option := range capability.Options {
-			if option.Type == pricing.ReasoningToggle ||
-				(option.Type == pricing.ReasoningEffort &&
-					catalogEffortHasDisabled(option.Values)) {
-				return nil
-			}
-		}
-		return fmt.Errorf(
-			"model %q does not advertise a reasoning-off control",
-			request.Model,
-		)
+	case config.ReasoningOn, config.ReasoningOff:
+		// The selected client's reviewed adapter projection performs the wire
+		// capability check after this catalog support check.
+		return nil
 	case config.ReasoningFollowHarness:
 		if len(capability.Options) == 0 {
 			return fmt.Errorf(
@@ -238,15 +230,6 @@ func validateReasoningPreflightPolicy(
 			request.Policy.Mode,
 		)
 	}
-}
-
-func catalogEffortHasDisabled(values []*string) bool {
-	for _, value := range values {
-		if value == nil || *value == "none" {
-			return true
-		}
-	}
-	return false
 }
 
 type reasoningPreflightConfiguredClient struct {

--- a/gateway/cmd/gateway/admin_reasoning_test.go
+++ b/gateway/cmd/gateway/admin_reasoning_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/basetenlabs/baseten-switch/gateway/internal/config"
 	"github.com/basetenlabs/baseten-switch/gateway/internal/pricing"
+	"github.com/basetenlabs/baseten-switch/gateway/internal/reasoning"
 )
 
 const adminReasoningCatalogFixture = `{
@@ -36,6 +37,15 @@ const adminReasoningCatalogFixture = `{
         "family": "glm",
         "reasoning": true,
         "reasoning_options": [{"type": "toggle"}]
+      },
+      "zai-org/GLM-5.2-Fast": {
+        "id": "zai-org/GLM-5.2-Fast",
+        "name": "GLM 5.2 Fast",
+        "family": "glm",
+        "reasoning": true,
+        "reasoning_options": [
+          {"type": "effort", "values": ["none", "high", "max"]}
+        ]
       },
       "moonshotai/Kimi-K2.7-Code": {
         "id": "moonshotai/Kimi-K2.7-Code",
@@ -118,9 +128,10 @@ func TestClientReasoningProjectionDeduplicatesReachableTargets(t *testing.T) {
 		glm.Configured.Mode != "default" ||
 		glm.Effective.Mode != "off" ||
 		glm.Source != "compatibility_default" ||
-		len(glm.AvailableModes) != 2 ||
+		len(glm.AvailableModes) != 3 ||
 		glm.AvailableModes[0] != "off" ||
-		glm.AvailableModes[1] != "follow_harness" ||
+		glm.AvailableModes[1] != "on" ||
+		glm.AvailableModes[2] != "follow_harness" ||
 		!glm.Available ||
 		glm.UnavailableReason != "" ||
 		glm.Error != "" {
@@ -131,9 +142,10 @@ func TestClientReasoningProjectionDeduplicatesReachableTargets(t *testing.T) {
 		kimi.Effective.Mode != "off" ||
 		kimi.Source != "compatibility_default" ||
 		!kimi.Available ||
-		len(kimi.AvailableModes) != 2 ||
+		len(kimi.AvailableModes) != 3 ||
 		kimi.AvailableModes[0] != "off" ||
-		kimi.AvailableModes[1] != "follow_harness" {
+		kimi.AvailableModes[1] != "on" ||
+		kimi.AvailableModes[2] != "follow_harness" {
 		t.Fatalf("Kimi projection = %+v", kimi)
 	}
 	deepseek := models["deepseek-ai/DeepSeek-V4-Pro"].Reasoning
@@ -164,21 +176,28 @@ func TestClientReasoningProjectionDefaultsFromCapabilityAndAdapter(
 			model:      "zai-org/GLM-5.2",
 			wantMode:   "off",
 			wantSource: "compatibility_default",
-			wantModes:  []string{"off", "follow_harness"},
+			wantModes:  []string{"off", "on", "follow_harness"},
 		},
 		{
 			name:       "Kimi toggle",
 			model:      "moonshotai/Kimi-K2.7-Code",
 			wantMode:   "off",
 			wantSource: "compatibility_default",
-			wantModes:  []string{"off", "follow_harness"},
+			wantModes:  []string{"off", "on", "follow_harness"},
 		},
 		{
 			name:       "Nemotron toggle",
 			model:      "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
 			wantMode:   "off",
 			wantSource: "compatibility_default",
-			wantModes:  []string{"off", "follow_harness"},
+			wantModes:  []string{"off", "on", "follow_harness"},
+		},
+		{
+			name:       "reviewed Messages binary control defaults exact effort model Off",
+			model:      "zai-org/GLM-5.2-Fast",
+			wantMode:   "off",
+			wantSource: "compatibility_default",
+			wantModes:  []string{"off", "on"},
 		},
 		{
 			name:       "effort only is read-only passthrough",
@@ -224,6 +243,32 @@ func TestClientReasoningProjectionDefaultsFromCapabilityAndAdapter(
 				t.Fatalf("projection = %+v", status)
 			}
 		})
+	}
+}
+
+func TestClientReasoningProjectionFastExplicitOn(t *testing.T) {
+	snapshot := adminReasoningSnapshot(t, time.Now().UTC())
+	rc := resolvedClientConfig{
+		Name:          "claude-code",
+		ProtocolShape: "anthropic",
+		Route:         "baseten",
+		DefaultModel:  "zai-org/GLM-5.2-Fast",
+	}
+	status := projectClientReasoningPolicy(
+		rc,
+		snapshot,
+		pricing.ProviderBaseten,
+		"zai-org/GLM-5.2-Fast",
+		reasoning.StoredPolicy{Present: true, Mode: reasoning.ModeOn},
+	)
+	if !status.Available ||
+		status.Effective.Mode != "on" ||
+		status.Source != "user_config" ||
+		!slices.Equal(status.AvailableModes, []string{"off", "on"}) ||
+		len(status.AvailableEfforts) != 0 ||
+		status.UnavailableReason != "" ||
+		status.Error != "" {
+		t.Fatalf("projection = %+v", status)
 	}
 }
 
@@ -311,9 +356,10 @@ func TestClientReasoningProjectionStaleRemainsUsableAndUnknownIsLoud(
 	)[pricing.ProviderBaseten]["zai-org/GLM-5.2"].Reasoning
 	if stale == nil ||
 		!stale.Available ||
-		len(stale.AvailableModes) != 2 ||
+		len(stale.AvailableModes) != 3 ||
 		stale.AvailableModes[0] != "off" ||
-		stale.AvailableModes[1] != "follow_harness" ||
+		stale.AvailableModes[1] != "on" ||
+		stale.AvailableModes[2] != "follow_harness" ||
 		stale.UnavailableReason != "" ||
 		stale.Error != "" {
 		t.Fatalf("stale validated projection = %+v", stale)
@@ -521,9 +567,10 @@ func TestReasoningPreflightChecksOnlyRequestedClient(t *testing.T) {
 		claude.Reachability[0] != "explicit_raw_slug" ||
 		len(claude.FailureBehaviors) != 1 ||
 		claude.FailureBehaviors[0] != "local_error" ||
-		len(claude.AvailableModes) != 2 ||
+		len(claude.AvailableModes) != 3 ||
 		claude.AvailableModes[0] != "off" ||
-		claude.AvailableModes[1] != "follow_harness" ||
+		claude.AvailableModes[1] != "on" ||
+		claude.AvailableModes[2] != "follow_harness" ||
 		claude.UnavailableReason != "" ||
 		claude.Error != "" {
 		t.Fatalf("Claude impact = %+v", claude)
@@ -548,6 +595,11 @@ func TestReasoningPreflightRejectsInvalidPolicyStructure(t *testing.T) {
 		policy string
 		want   string
 	}{
+		{
+			name:   "on with effort",
+			policy: `{"mode":"on","effort":"medium"}`,
+			want:   `mode "on" forbids effort`,
+		},
 		{
 			name:   "off with effort",
 			policy: `{"mode":"off","effort":"high"}`,

--- a/gateway/cmd/gateway/reasoning_policy.go
+++ b/gateway/cmd/gateway/reasoning_policy.go
@@ -73,6 +73,9 @@ func applyBasetenReasoningPolicy(
 		telemetry.catalogRevision = &catalogRevision
 	}
 	switch decision.Mode {
+	case reasoning.ModeOn:
+		enabled := true
+		telemetry.effectiveEnabled = &enabled
 	case reasoning.ModeOff:
 		enabled := false
 		telemetry.effectiveEnabled = &enabled

--- a/gateway/cmd/gateway/reasoning_policy_test.go
+++ b/gateway/cmd/gateway/reasoning_policy_test.go
@@ -62,6 +62,108 @@ func assertGatewayThinkingDisabled(t *testing.T, body []byte) {
 	}
 }
 
+func assertGatewayThinkingEnabled(t *testing.T, body []byte) {
+	t.Helper()
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("decode transformed body: %v\nbody: %s", err, body)
+	}
+	if string(envelope["thinking"]) != `{"type":"enabled"}` {
+		t.Fatalf(
+			"transformed thinking = %s, want exactly {\"type\":\"enabled\"}",
+			envelope["thinking"],
+		)
+	}
+}
+
+func TestReasoningPolicyFastExplicitOnPreservesEffortAndReportsNoEffectiveEffort(
+	t *testing.T,
+) {
+	g := reasoningTestGateway(t)
+	if err := g.pricing.ReplaceModelsDev(
+		[]byte(adminReasoningCatalogFixture),
+		time.Now().UTC(),
+		`"fast-explicit-on"`,
+	); err != nil {
+		t.Fatal(err)
+	}
+	rc := resolvedAnthropicBasetenDefaultReasoning(t)
+	rc.DefaultModel = "zai-org/GLM-5.2-Fast"
+	rc.ModelOptions = config.ModelOptions{
+		pricing.ProviderBaseten: {
+			"zai-org/GLM-5.2-Fast": {
+				Reasoning: &config.ReasoningPolicy{Mode: config.ReasoningOn},
+			},
+		},
+	}
+	body := []byte(`{
+		"model":"claude-example-model",
+		"output_config":{"effort":"medium"},
+		"messages":[{"role":"user","content":"hello"}]
+	}`)
+	got, telemetry, err := applyBasetenReasoningPolicy(
+		g.pricing.Capture(),
+		rc,
+		body,
+		"zai-org/GLM-5.2-Fast",
+		"messages",
+		"anthropic",
+		reasoning.InspectAnthropicMessages(body),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertGatewayThinkingEnabled(t, got)
+	if !bytes.Contains(got, []byte(`"effort":"medium"`)) {
+		t.Fatalf("transformed body = %s, want unchanged effort", got)
+	}
+	if telemetry.policyMode == nil || *telemetry.policyMode != "on" ||
+		telemetry.effectiveEnabled == nil || !*telemetry.effectiveEnabled ||
+		telemetry.effectiveEffort != nil {
+		t.Fatalf("telemetry = %+v", telemetry)
+	}
+}
+
+func TestReasoningPolicyFastDefaultsOffAndPreservesEffort(t *testing.T) {
+	g := reasoningTestGateway(t)
+	if err := g.pricing.ReplaceModelsDev(
+		[]byte(adminReasoningCatalogFixture),
+		time.Now().UTC(),
+		`"fast-default-off"`,
+	); err != nil {
+		t.Fatal(err)
+	}
+	rc := resolvedAnthropicBasetenDefaultReasoning(t)
+	rc.DefaultModel = "zai-org/GLM-5.2-Fast"
+	body := []byte(`{
+		"model":"claude-example-model",
+		"output_config":{"effort":"medium"},
+		"messages":[{"role":"user","content":"hello"}]
+	}`)
+	got, telemetry, err := applyBasetenReasoningPolicy(
+		g.pricing.Capture(),
+		rc,
+		body,
+		"zai-org/GLM-5.2-Fast",
+		"messages",
+		"anthropic",
+		reasoning.InspectAnthropicMessages(body),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertGatewayThinkingDisabled(t, got)
+	if !bytes.Contains(got, []byte(`"effort":"medium"`)) {
+		t.Fatalf("transformed body = %s, want unchanged effort", got)
+	}
+	if telemetry.policyMode == nil || *telemetry.policyMode != "off" ||
+		telemetry.policySource == nil || *telemetry.policySource != "compatibility_default" ||
+		telemetry.effectiveEnabled == nil || *telemetry.effectiveEnabled ||
+		telemetry.effectiveEffort != nil {
+		t.Fatalf("telemetry = %+v", telemetry)
+	}
+}
+
 func TestReasoningPolicyMappedToggleDefaultsOff(t *testing.T) {
 	g := reasoningTestGateway(t)
 	rc := resolvedAnthropicBasetenDefaultReasoning(t)
@@ -698,106 +800,146 @@ func TestReasoningPolicyChangesResolvedClientHash(t *testing.T) {
 	}
 }
 
-func TestReasoningPolicyMappedOffRuntimeFallbackPreservesNativeBody(
-	t *testing.T,
-) {
-	var basetenHits atomic.Int32
-	var basetenBody []byte
-	baseten := httptest.NewServer(http.HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {
-			basetenHits.Add(1)
-			basetenBody, _ = io.ReadAll(r.Body)
-			w.WriteHeader(http.StatusInternalServerError)
+func TestReasoningPolicyRuntimeFallbackPreservesNativeBody(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		targetModel    string
+		stored         *config.ReasoningPolicy
+		wantMode       string
+		wantEnabled    bool
+		wantSource     string
+		assertThinking func(*testing.T, []byte)
+	}{
+		{
+			name:           "Fast default Off",
+			targetModel:    "zai-org/GLM-5.2-Fast",
+			wantMode:       "off",
+			wantEnabled:    false,
+			wantSource:     "compatibility_default",
+			assertThinking: assertGatewayThinkingDisabled,
 		},
-	))
-	defer baseten.Close()
+		{
+			name:           "explicit On",
+			targetModel:    "zai-org/GLM-5.2-Fast",
+			stored:         &config.ReasoningPolicy{Mode: config.ReasoningOn},
+			wantMode:       "on",
+			wantEnabled:    true,
+			wantSource:     "user_config",
+			assertThinking: assertGatewayThinkingEnabled,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var basetenHits atomic.Int32
+			var basetenBody []byte
+			baseten := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					basetenHits.Add(1)
+					basetenBody, _ = io.ReadAll(r.Body)
+					w.WriteHeader(http.StatusInternalServerError)
+				},
+			))
+			defer baseten.Close()
 
-	var nativeBody []byte
-	native := httptest.NewServer(http.HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {
-			nativeBody, _ = io.ReadAll(r.Body)
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{
-				"id":"msg_native",
-				"type":"message",
-				"role":"assistant",
-				"content":[{"type":"text","text":"native"}],
+			var nativeBody []byte
+			native := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					nativeBody, _ = io.ReadAll(r.Body)
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{
+						"id":"msg_native",
+						"type":"message",
+						"role":"assistant",
+						"content":[{"type":"text","text":"native"}],
+						"model":"claude-example-model",
+						"usage":{"input_tokens":1,"output_tokens":1}
+					}`))
+				},
+			))
+			defer native.Close()
+
+			cfg := testConfig(t, baseten.URL, native.URL)
+			rc := resolvedAnthropicBasetenDefaultReasoning(t)
+			rc.DefaultModel = tc.targetModel
+			rc.FallbackRoute = "anthropic"
+			if tc.stored != nil {
+				rc.ModelOptions = config.ModelOptions{
+					pricing.ProviderBaseten: {
+						tc.targetModel: {Reasoning: tc.stored},
+					},
+				}
+			}
+			g, adminListener, _ := newGateway(t, cfg, rc)
+			defer adminListener.Close()
+			if err := g.pricing.ReplaceModelsDev(
+				[]byte(adminReasoningCatalogFixture),
+				time.Now().UTC(),
+				`"runtime-fallback"`,
+			); err != nil {
+				t.Fatal(err)
+			}
+			stop := start(t, g)
+			defer stop()
+
+			body := []byte(`{
 				"model":"claude-opus-4-8",
-				"usage":{"input_tokens":1,"output_tokens":1}
-			}`))
-		},
-	))
-	defer native.Close()
-
-	cfg := testConfig(t, baseten.URL, native.URL)
-	rc := resolvedAnthropicBasetenDefaultReasoning(t)
-	rc.FallbackRoute = "anthropic"
-	g, adminListener, _ := newGateway(t, cfg, rc)
-	defer adminListener.Close()
-	stop := start(t, g)
-	defer stop()
-
-	body := []byte(`{
-		"model":"claude-opus-4-8",
-		"thinking":{"type":"enabled","budget_tokens":32000},
-		"messages":[{"role":"user","content":"hello"}]
-	}`)
-	req, _ := http.NewRequest(
-		http.MethodPost,
-		clientURL(g, "claude-code", "/v1/messages"),
-		bytes.NewReader(body),
-	)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer tok")
-	response, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer response.Body.Close()
-	if response.StatusCode != http.StatusOK {
-		responseBody, _ := io.ReadAll(response.Body)
-		t.Fatalf("status = %d body = %s", response.StatusCode, responseBody)
-	}
-	if basetenHits.Load() != 1 {
-		t.Fatalf("Baseten hits = %d, want 1", basetenHits.Load())
-	}
-	assertGatewayThinkingDisabled(t, basetenBody)
-	if !bytes.Equal(nativeBody, body) {
-		t.Fatalf(
-			"native fallback body changed\ngot:  %s\nwant: %s",
-			nativeBody,
-			body,
-		)
-	}
-	rows := waitForRows(t, cfg.TelemetryDir, 1, 2*time.Second)
-	row := rows[0]
-	if row.RequestedReasoningPresent == nil ||
-		!*row.RequestedReasoningPresent {
-		t.Fatalf(
-			"fallback requested_reasoning_present = %v, want true",
-			row.RequestedReasoningPresent,
-		)
-	}
-	if row.ReasoningPolicyMode == nil ||
-		*row.ReasoningPolicyMode != "off" ||
-		row.EffectiveReasoningEnabled == nil ||
-		*row.EffectiveReasoningEnabled ||
-		row.ReasoningPolicySource == nil ||
-		*row.ReasoningPolicySource != "compatibility_default" {
-		t.Fatalf(
-			"runtime fallback policy: mode=%v enabled=%v source=%v",
-			row.ReasoningPolicyMode,
-			row.EffectiveReasoningEnabled,
-			row.ReasoningPolicySource,
-		)
-	}
-	if row.Fallback.Trigger == nil ||
-		*row.Fallback.Trigger != "http_500" {
-		t.Fatalf("fallback trigger = %v, want http_500", row.Fallback.Trigger)
+				"thinking":{"type":"adaptive","display":"omitted"},
+				"output_config":{"effort":"medium"},
+				"messages":[{"role":"user","content":"hello"}]
+			}`)
+			req, _ := http.NewRequest(
+				http.MethodPost,
+				clientURL(g, "claude-code", "/v1/messages"),
+				bytes.NewReader(body),
+			)
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer tok")
+			response, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer response.Body.Close()
+			if response.StatusCode != http.StatusOK {
+				responseBody, _ := io.ReadAll(response.Body)
+				t.Fatalf("status = %d body = %s", response.StatusCode, responseBody)
+			}
+			if basetenHits.Load() != 1 {
+				t.Fatalf("Baseten hits = %d, want 1", basetenHits.Load())
+			}
+			tc.assertThinking(t, basetenBody)
+			if !bytes.Contains(basetenBody, []byte(`"effort":"medium"`)) {
+				t.Fatalf("Baseten body = %s, want unchanged effort", basetenBody)
+			}
+			if !bytes.Equal(nativeBody, body) {
+				t.Fatalf(
+					"native fallback body changed\ngot:  %s\nwant: %s",
+					nativeBody,
+					body,
+				)
+			}
+			row := waitForRows(t, cfg.TelemetryDir, 1, 2*time.Second)[0]
+			if row.ReasoningPolicyMode == nil ||
+				*row.ReasoningPolicyMode != tc.wantMode ||
+				row.EffectiveReasoningEnabled == nil ||
+				*row.EffectiveReasoningEnabled != tc.wantEnabled ||
+				row.EffectiveReasoningEffort != nil ||
+				row.ReasoningPolicySource == nil ||
+				*row.ReasoningPolicySource != tc.wantSource {
+				t.Fatalf(
+					"runtime fallback policy: mode=%v enabled=%v effort=%v source=%v",
+					row.ReasoningPolicyMode,
+					row.EffectiveReasoningEnabled,
+					row.EffectiveReasoningEffort,
+					row.ReasoningPolicySource,
+				)
+			}
+			if row.Fallback.Trigger == nil || *row.Fallback.Trigger != "http_500" {
+				t.Fatalf("fallback trigger = %v, want http_500", row.Fallback.Trigger)
+			}
+		})
 	}
 }
 
-func TestReasoningPolicyConfiguredOffOpenAIShapesPreflightFallbackHTTP(
+func TestReasoningPolicyConfiguredBinaryModeOpenAIShapesPreflightFallbackHTTP(
 	t *testing.T,
 ) {
 	for _, tc := range []struct {
@@ -805,6 +947,7 @@ func TestReasoningPolicyConfiguredOffOpenAIShapesPreflightFallbackHTTP(
 		clientName string
 		path       string
 		body       []byte
+		mode       config.ReasoningMode
 	}{
 		{
 			name:       "Chat Completions",
@@ -813,6 +956,7 @@ func TestReasoningPolicyConfiguredOffOpenAIShapesPreflightFallbackHTTP(
 			body: []byte(
 				`{"model":"gpt-5","messages":[{"role":"user","content":"hello"}],"reasoning_effort":"high"}`,
 			),
+			mode: config.ReasoningOff,
 		},
 		{
 			name:       "Responses",
@@ -821,6 +965,16 @@ func TestReasoningPolicyConfiguredOffOpenAIShapesPreflightFallbackHTTP(
 			body: []byte(
 				`{"model":"gpt-5","input":"hello","reasoning":{"effort":"high"}}`,
 			),
+			mode: config.ReasoningOff,
+		},
+		{
+			name:       "Responses On",
+			clientName: "codex",
+			path:       "/v1/responses",
+			body: []byte(
+				`{"model":"gpt-5","input":"hello","reasoning":{"effort":"high"}}`,
+			),
+			mode: config.ReasoningOn,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -852,7 +1006,7 @@ func TestReasoningPolicyConfiguredOffOpenAIShapesPreflightFallbackHTTP(
 				pricing.ProviderBaseten: {
 					"zai-org/GLM-5.2": {
 						Reasoning: &config.ReasoningPolicy{
-							Mode: config.ReasoningOff,
+							Mode: tc.mode,
 						},
 					},
 				},

--- a/gateway/internal/config/config.go
+++ b/gateway/internal/config/config.go
@@ -216,6 +216,7 @@ type Door struct {
 type ReasoningMode string
 
 const (
+	ReasoningOn            ReasoningMode = "on"
 	ReasoningOff           ReasoningMode = "off"
 	ReasoningFollowHarness ReasoningMode = "follow_harness"
 	ReasoningFixed         ReasoningMode = "fixed"
@@ -602,7 +603,7 @@ func validateModelOptions(
 // gateway.yaml, admin preflight, and typed mutation callers.
 func ValidateReasoningPolicy(policy ReasoningPolicy) error {
 	switch policy.Mode {
-	case ReasoningOff, ReasoningFollowHarness:
+	case ReasoningOn, ReasoningOff, ReasoningFollowHarness:
 		if policy.Effort != "" {
 			return fmt.Errorf(
 				"reasoning mode %q forbids effort",

--- a/gateway/internal/config/reasoning_edit_test.go
+++ b/gateway/internal/config/reasoning_edit_test.go
@@ -52,6 +52,27 @@ func TestSetClientModelReasoningPolicyCreatesNestedMappingsAndPreservesBytes(t *
 	}
 }
 
+func TestSetClientModelReasoningPolicyRoundTripsOn(t *testing.T) {
+	path := writeReasoningEditConfig(t, "global:\n  routing_enabled: true\nclients:\n  - name: claude-code\n    enabled: true\n    protocol_shape: anthropic\n    default_model: zai-org/GLM-5.2-Fast\n")
+	if err := SetClientModelReasoningPolicy(
+		path,
+		"claude-code",
+		"baseten",
+		"zai-org/GLM-5.2-Fast",
+		ReasoningPolicy{Mode: ReasoningOn},
+	); err != nil {
+		t.Fatal(err)
+	}
+	file, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := file.Clients[0].ModelOptions["baseten"]["zai-org/GLM-5.2-Fast"].Reasoning
+	if got == nil || got.Mode != ReasoningOn || got.Effort != "" {
+		t.Fatalf("reasoning policy = %#v", got)
+	}
+}
+
 func TestSetClientModelReasoningPolicyExpandsEmptyMappings(t *testing.T) {
 	tests := []struct {
 		name string
@@ -154,6 +175,7 @@ func TestClientReasoningPolicyRejectsUnsafeValuesWithoutWriting(t *testing.T) {
 		{name: "newline", client: "claude-code", provider: "baseten", model: "bad\nkey", policy: ReasoningPolicy{Mode: ReasoningOff}},
 		{name: "fixed missing effort", client: "claude-code", provider: "baseten", model: "org/model", policy: ReasoningPolicy{Mode: ReasoningFixed}},
 		{name: "off with effort", client: "claude-code", provider: "baseten", model: "org/model", policy: ReasoningPolicy{Mode: ReasoningOff, Effort: "high"}},
+		{name: "on with effort", client: "claude-code", provider: "baseten", model: "org/model", policy: ReasoningPolicy{Mode: ReasoningOn, Effort: "medium"}},
 		{name: "unsafe effort", client: "claude-code", provider: "baseten", model: "org/model", policy: ReasoningPolicy{Mode: ReasoningFixed, Effort: "high\ninjected: true"}},
 	}
 	for _, tc := range tests {

--- a/gateway/internal/config/reasoning_test.go
+++ b/gateway/internal/config/reasoning_test.go
@@ -11,6 +11,7 @@ func TestValidateRoutingPolicyAcceptsClientReasoningModes(t *testing.T) {
 		name   string
 		policy ReasoningPolicy
 	}{
+		{name: "on", policy: ReasoningPolicy{Mode: ReasoningOn}},
 		{name: "off", policy: ReasoningPolicy{Mode: ReasoningOff}},
 		{name: "follow harness", policy: ReasoningPolicy{Mode: ReasoningFollowHarness}},
 		{name: "fixed effort", policy: ReasoningPolicy{Mode: ReasoningFixed, Effort: "high"}},
@@ -94,6 +95,20 @@ func TestValidateRoutingPolicyRejectsInvalidClientReasoningStructure(t *testing.
 				},
 			},
 			want: `mode "fixed" requires effort`,
+		},
+		{
+			name: "on with effort",
+			options: ModelOptions{
+				"baseten": {
+					"zai-org/GLM-5.2-Fast": ModelOption{
+						Reasoning: &ReasoningPolicy{
+							Mode:   ReasoningOn,
+							Effort: "medium",
+						},
+					},
+				},
+			},
+			want: `mode "on" forbids effort`,
 		},
 		{
 			name: "off with effort",

--- a/gateway/internal/reasoning/reasoning.go
+++ b/gateway/internal/reasoning/reasoning.go
@@ -16,6 +16,7 @@ type Mode string
 
 const (
 	ModePassthrough   Mode = "passthrough"
+	ModeOn            Mode = "on"
 	ModeOff           Mode = "off"
 	ModeFollowHarness Mode = "follow_harness"
 	ModeFixed         Mode = "fixed"
@@ -85,6 +86,22 @@ type Decision struct {
 type AdapterAvailability struct {
 	Modes   []Mode
 	Efforts []string
+}
+
+type messagesCompatibility struct {
+	Provider         string
+	CanonicalModelID string
+	ExplicitOnOff    bool
+	DefaultOff       bool
+}
+
+var reviewedMessagesCompatibility = []messagesCompatibility{
+	{
+		Provider:         "baseten",
+		CanonicalModelID: "zai-org/GLM-5.2-Fast",
+		ExplicitOnOff:    true,
+		DefaultOff:       true,
+	},
 }
 
 // PolicyError is a local request preflight error. Gateway routing may advance
@@ -184,7 +201,7 @@ func Resolve(in Input) (Decision, error) {
 			)
 		}
 		return decision, nil
-	case ModeOff:
+	case ModeOn, ModeOff:
 		if !in.Capability.Known || !in.Capability.Supported {
 			return Decision{}, policyError(
 				in,
@@ -192,11 +209,11 @@ func Resolve(in Input) (Decision, error) {
 				"the exact target has no validated reasoning capability",
 			)
 		}
-		if !supportsMessagesOff(in) {
+		if !supportsMessagesExplicitOnOff(in) {
 			return Decision{}, policyError(
 				in,
 				decision.Mode,
-				"Messages Off requires a toggle capability",
+				"Messages On and Off require a reviewed binary control",
 			)
 		}
 		return decision, nil
@@ -223,7 +240,7 @@ func EffectivePolicy(in Input) Decision {
 			Source: SourceConfigured,
 		}
 	}
-	if supportsMessagesOff(in) {
+	if supportsMessagesDefaultOff(in) {
 		return Decision{
 			Mode:   ModeOff,
 			Source: SourceCompatibilityDefault,
@@ -249,10 +266,11 @@ func ReviewedAdapterAvailability(in Input) AdapterAvailability {
 		!in.Capability.Supported {
 		return availability
 	}
-	if supportsMessagesOff(in) {
+	if supportsMessagesExplicitOnOff(in) {
 		availability.Modes = append(
 			availability.Modes,
 			ModeOff,
+			ModeOn,
 		)
 	}
 	if supportsMessagesFollowHarness(in) {
@@ -264,12 +282,42 @@ func ReviewedAdapterAvailability(in Input) AdapterAvailability {
 	return availability
 }
 
-func supportsMessagesOff(in Input) bool {
-	return in.Provider == "baseten" &&
-		in.WireShape == WireAnthropicMessages &&
-		in.Capability.Known &&
-		in.Capability.Supported &&
-		in.Capability.Toggle
+func supportsMessagesDefaultOff(in Input) bool {
+	if in.Provider != "baseten" ||
+		in.WireShape != WireAnthropicMessages ||
+		!in.Capability.Known ||
+		!in.Capability.Supported {
+		return false
+	}
+	if in.Capability.Toggle {
+		return true
+	}
+	compatibility, ok := reviewedMessagesCompatibilityFor(in)
+	return ok && compatibility.ExplicitOnOff && compatibility.DefaultOff
+}
+
+func supportsMessagesExplicitOnOff(in Input) bool {
+	if in.Provider != "baseten" ||
+		in.WireShape != WireAnthropicMessages ||
+		!in.Capability.Known ||
+		!in.Capability.Supported {
+		return false
+	}
+	if in.Capability.Toggle {
+		return true
+	}
+	compatibility, ok := reviewedMessagesCompatibilityFor(in)
+	return ok && compatibility.ExplicitOnOff
+}
+
+func reviewedMessagesCompatibilityFor(in Input) (messagesCompatibility, bool) {
+	for _, compatibility := range reviewedMessagesCompatibility {
+		if compatibility.Provider == in.Provider &&
+			compatibility.CanonicalModelID == in.CanonicalModelID {
+			return compatibility, true
+		}
+	}
+	return messagesCompatibility{}, false
 }
 
 func supportsMessagesFollowHarness(in Input) bool {
@@ -333,15 +381,15 @@ func InspectAnthropicMessages(body []byte) RequestedReasoning {
 // ApplyAnthropicMessages applies a reviewed same-shape Messages policy.
 // Passthrough preserves the original bytes. Follow Harness preserves reviewed
 // enabled and disabled controls, and normalizes Claude's adaptive control to
-// the Baseten Messages toggle shape. Off replaces only the top-level reasoning
-// control. Every transform retains all other JSON fields.
+// the Baseten Messages toggle shape. On and Off replace only the top-level
+// reasoning control. Every transform retains all other JSON fields.
 func ApplyAnthropicMessages(body []byte, decision Decision) ([]byte, error) {
 	switch decision.Mode {
 	case ModePassthrough:
 		return body, nil
 	case ModeFollowHarness:
 		return normalizeAnthropicAdaptiveThinking(body)
-	case ModeOff:
+	case ModeOn, ModeOff:
 		var envelope map[string]json.RawMessage
 		if err := json.Unmarshal(body, &envelope); err != nil ||
 			envelope == nil {
@@ -355,7 +403,11 @@ func ApplyAnthropicMessages(body []byte, decision Decision) ([]byte, error) {
 				Reason:    reason,
 			}
 		}
-		envelope["thinking"] = json.RawMessage(`{"type":"disabled"}`)
+		thinking := json.RawMessage(`{"type":"disabled"}`)
+		if decision.Mode == ModeOn {
+			thinking = json.RawMessage(`{"type":"enabled"}`)
+		}
+		envelope["thinking"] = thinking
 		transformed, err := json.Marshal(envelope)
 		if err != nil {
 			return nil, &PolicyError{

--- a/gateway/internal/reasoning/reasoning_test.go
+++ b/gateway/internal/reasoning/reasoning_test.go
@@ -18,6 +18,18 @@ func glmInput() Input {
 	}
 }
 
+func glmFastEffortInput() Input {
+	return Input{
+		Provider:         "baseten",
+		CanonicalModelID: "zai-org/GLM-5.2-Fast",
+		WireShape:        WireAnthropicMessages,
+		Capability: Capability{
+			Known: true, Supported: true,
+			Efforts: []string{"none", "high", "max"},
+		},
+	}
+}
+
 func TestResolveCompatibilityAndConfiguredPolicies(t *testing.T) {
 	t.Run("toggle models default off independent of identity", func(t *testing.T) {
 		for _, model := range []string{
@@ -63,6 +75,120 @@ func TestResolveCompatibilityAndConfiguredPolicies(t *testing.T) {
 				got.Source != SourceInternalPassthrough {
 				t.Fatalf("decision = %+v, want passthrough", got)
 			}
+		}
+	})
+
+	t.Run("reviewed exact compatibility defaults off", func(t *testing.T) {
+		got, err := Resolve(glmFastEffortInput())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Mode != ModeOff || got.Source != SourceCompatibilityDefault {
+			t.Fatalf("decision = %+v, want compatibility Off", got)
+		}
+	})
+
+	t.Run("reviewed default compatibility is exact and validated", func(t *testing.T) {
+		for _, tc := range []struct {
+			name   string
+			mutate func(*Input)
+		}{
+			{name: "neighboring model", mutate: func(in *Input) { in.CanonicalModelID += "-Preview" }},
+			{name: "other provider", mutate: func(in *Input) { in.Provider = "example" }},
+			{name: "other wire", mutate: func(in *Input) { in.WireShape = WireOpenAIResponses }},
+			{name: "unknown metadata", mutate: func(in *Input) { in.Capability = Capability{} }},
+			{name: "unsupported metadata", mutate: func(in *Input) { in.Capability.Supported = false }},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				in := glmFastEffortInput()
+				tc.mutate(&in)
+				got, err := Resolve(in)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got.Mode != ModePassthrough || got.Source != SourceInternalPassthrough {
+					t.Fatalf("decision = %+v, want passthrough", got)
+				}
+			})
+		}
+	})
+
+	t.Run("configured On requires a reviewed binary control", func(t *testing.T) {
+		for _, tc := range []struct {
+			name      string
+			input     Input
+			wantError bool
+		}{
+			{name: "catalog toggle", input: glmInput()},
+			{name: "reviewed exact model", input: glmFastEffortInput()},
+			{
+				name: "neighboring model",
+				input: func() Input {
+					in := glmFastEffortInput()
+					in.CanonicalModelID = "zai-org/GLM-5.2-Fast-Preview"
+					return in
+				}(),
+				wantError: true,
+			},
+			{
+				name: "other adapter",
+				input: func() Input {
+					in := glmFastEffortInput()
+					in.WireShape = WireOpenAIResponses
+					return in
+				}(),
+				wantError: true,
+			},
+			{
+				name: "unknown metadata",
+				input: func() Input {
+					in := glmFastEffortInput()
+					in.Capability = Capability{}
+					return in
+				}(),
+				wantError: true,
+			},
+			{
+				name: "unsupported metadata",
+				input: func() Input {
+					in := glmFastEffortInput()
+					in.Capability.Supported = false
+					return in
+				}(),
+				wantError: true,
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				in := tc.input
+				in.Stored = StoredPolicy{Present: true, Mode: ModeOn}
+				got, err := Resolve(in)
+				if tc.wantError {
+					if !IsPolicyError(err) || !AllowsFallback(err) {
+						t.Fatalf("error = %v, want fallback-eligible policy error", err)
+					}
+					return
+				}
+				if err != nil || got.Mode != ModeOn || got.Source != SourceConfigured {
+					t.Fatalf("decision = %+v error = %v", got, err)
+				}
+			})
+		}
+	})
+
+	t.Run("reviewed explicit compatibility does not broaden follow harness", func(t *testing.T) {
+		in := glmFastEffortInput()
+		in.Stored = StoredPolicy{Present: true, Mode: ModeFollowHarness}
+		if _, err := Resolve(in); !IsPolicyError(err) {
+			t.Fatalf("error = %v, want policy error", err)
+		}
+	})
+
+	t.Run("reviewed exact model accepts explicit Off", func(t *testing.T) {
+		in := glmFastEffortInput()
+		in.Stored = StoredPolicy{Present: true, Mode: ModeOff}
+		got, err := Resolve(in)
+		if err != nil || got.Mode != ModeOff || got.Source != SourceConfigured {
+			t.Fatalf("decision = %+v error = %v", got, err)
 		}
 	})
 
@@ -266,11 +392,34 @@ func TestReviewedAdapterAvailability(t *testing.T) {
 			in := glmInput()
 			in.CanonicalModelID = model
 			got := ReviewedAdapterAvailability(in)
-			if len(got.Modes) != 2 ||
+			if len(got.Modes) != 3 ||
 				got.Modes[0] != ModeOff ||
-				got.Modes[1] != ModeFollowHarness ||
+				got.Modes[1] != ModeOn ||
+				got.Modes[2] != ModeFollowHarness ||
 				len(got.Efforts) != 0 {
 				t.Fatalf("%s availability = %+v", model, got)
+			}
+		}
+	})
+
+	t.Run("reviewed exact effort model offers only explicit On and Off", func(t *testing.T) {
+		got := ReviewedAdapterAvailability(glmFastEffortInput())
+		want := []Mode{ModeOff, ModeOn}
+		if !reflect.DeepEqual(got.Modes, want) || len(got.Efforts) != 0 {
+			t.Fatalf("availability = %+v, want modes %v", got, want)
+		}
+	})
+
+	t.Run("reviewed compatibility is exact provider and model scoped", func(t *testing.T) {
+		for _, mutate := range []func(*Input){
+			func(in *Input) { in.Provider = "example" },
+			func(in *Input) { in.CanonicalModelID += "-Preview" },
+		} {
+			in := glmFastEffortInput()
+			mutate(&in)
+			got := ReviewedAdapterAvailability(in)
+			if len(got.Modes) != 0 || len(got.Efforts) != 0 {
+				t.Fatalf("availability = %+v for input %+v", got, in)
 			}
 		}
 	})
@@ -386,6 +535,75 @@ func TestInspectAndApplyAnthropicMessages(t *testing.T) {
 			before,
 		)
 	}
+}
+
+func TestApplyAnthropicMessagesForcedOnAndOff(t *testing.T) {
+	const largeInteger = "9007199254740993123456789"
+	for _, mode := range []Mode{ModeOn, ModeOff} {
+		for _, tc := range []struct {
+			name     string
+			thinking string
+		}{
+			{name: "absent"},
+			{name: "disabled", thinking: `,"thinking":{"type":"disabled","display":"ignored"}`},
+			{name: "adaptive", thinking: `,"thinking":{"type":"adaptive","display":"omitted"}`},
+			{name: "enabled budget", thinking: `,"thinking":{"type":"enabled","budget_tokens":2047}`},
+		} {
+			t.Run(string(mode)+"/"+tc.name, func(t *testing.T) {
+				body := []byte(`{"model":"example/model","system":"keep","max_tokens":4096,"large_integer":` +
+					largeInteger +
+					`,"output_config":{"effort":"medium"},"tools":[{"name":"lookup","input_schema":{"type":"object"}}],"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"prior","signature":"sig_test"},{"type":"text","text":"ready"}]},{"role":"user","content":"hello"}]` +
+					tc.thinking + `}`)
+				var before map[string]json.RawMessage
+				if err := json.Unmarshal(body, &before); err != nil {
+					t.Fatal(err)
+				}
+				got, err := ApplyAnthropicMessages(body, Decision{Mode: mode})
+				if err != nil {
+					t.Fatal(err)
+				}
+				var envelope map[string]json.RawMessage
+				if err := json.Unmarshal(got, &envelope); err != nil {
+					t.Fatal(err)
+				}
+				wantType := "enabled"
+				if mode == ModeOff {
+					wantType = "disabled"
+				}
+				if string(envelope["thinking"]) != `{"type":"`+wantType+`"}` {
+					t.Fatalf("thinking = %s", envelope["thinking"])
+				}
+				delete(before, "thinking")
+				delete(envelope, "thinking")
+				if !equalCompactRawMessages(before, envelope) {
+					t.Fatalf("non-thinking fields changed\n got: %s\nwant: %s", got, body)
+				}
+			})
+		}
+	}
+}
+
+func equalCompactRawMessages(
+	left map[string]json.RawMessage,
+	right map[string]json.RawMessage,
+) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for key, leftValue := range left {
+		rightValue, ok := right[key]
+		if !ok {
+			return false
+		}
+		var leftCompact bytes.Buffer
+		var rightCompact bytes.Buffer
+		if json.Compact(&leftCompact, leftValue) != nil ||
+			json.Compact(&rightCompact, rightValue) != nil ||
+			!bytes.Equal(leftCompact.Bytes(), rightCompact.Bytes()) {
+			return false
+		}
+	}
+	return true
 }
 
 func TestClaudeAdaptiveThinkingInspectionAndFollowHarnessNormalization(

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/BasetenSwitchState.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/BasetenSwitchState.swift
@@ -1916,6 +1916,7 @@ final class BasetenSwitchState: ObservableObject {
         guard canMutateReasoning,
               pendingReasoning == nil,
               policy.mode == .default
+                || policy.mode == .on
                 || policy.mode == .off
                 || policy.mode == .followHarness
                 || policy.mode == .fixed else {
@@ -2552,6 +2553,8 @@ func reasoningDispatchArgs(
     }
     var arguments = [harness, "reasoning", provider, model]
     switch policy.mode {
+    case .on:
+        arguments.append("on")
     case .off:
         arguments.append("off")
     case .followHarness:
@@ -2570,6 +2573,8 @@ func reasoningRequestedTarget(_ policy: ReasoningPolicyValue) -> String {
     switch policy.mode {
     case .default:
         return "default"
+    case .on:
+        return "on"
     case .off:
         return "off"
     case .followHarness:

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/Display.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/Display.swift
@@ -205,6 +205,11 @@ func reasoningRowsForDisplay(
        client.subagentEffective != "inherit" {
         select(client.subagentModel)
     }
+    if let modelPicker = client.modelPicker, modelPicker.enabled {
+        for pickerModel in modelPicker.models {
+            select(pickerModel.slug)
+        }
+    }
 
     var seenModels = Set<String>()
     return options.compactMap { optionModel, option in

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/Display.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/Display.swift
@@ -149,6 +149,7 @@ func projectModelCatalog(
 enum ReasoningChoice: Hashable, Sendable {
     case defaultPassthrough
     case pendingDefault
+    case on
     case off
     case followHarness
     case effort(String)
@@ -156,16 +157,13 @@ enum ReasoningChoice: Hashable, Sendable {
 
     var policy: ReasoningPolicyValue? {
         switch self {
-        case .defaultPassthrough, .pendingDefault:
+        case .defaultPassthrough, .pendingDefault,
+             .followHarness, .effort, .unavailable:
             return nil
+        case .on:
+            return ReasoningPolicyValue(mode: .on)
         case .off:
             return ReasoningPolicyValue(mode: .off)
-        case .followHarness:
-            return ReasoningPolicyValue(mode: .followHarness)
-        case .effort(let effort):
-            return ReasoningPolicyValue(mode: .fixed, effort: effort)
-        case .unavailable:
-            return nil
         }
     }
 }
@@ -248,26 +246,12 @@ func reasoningRowsForDisplay(
 func reasoningChoices(
     status: ClientReasoningStatus
 ) -> [ReasoningChoice] {
-    var choices: [ReasoningChoice] = []
-    for mode in status.availableModes {
-        switch mode {
-        case .off:
-            choices.append(.off)
-        case .followHarness:
-            choices.append(.followHarness)
-        case .default, .fixed, .passthrough:
-            break
-        }
+    guard status.available,
+          status.availableModes.contains(.on),
+          status.availableModes.contains(.off) else {
+        return []
     }
-    choices.append(contentsOf: status.availableEfforts.map(
-        ReasoningChoice.effort))
-    if !choices.isEmpty,
-       status.configured.mode == .default,
-       status.effective.mode == .passthrough {
-        choices.insert(.defaultPassthrough, at: 0)
-    }
-    var seen = Set<ReasoningChoice>()
-    return choices.filter { seen.insert($0).inserted }
+    return [.on, .off]
 }
 
 func reasoningUsesDefaultPassthroughReadOnlyState(
@@ -284,17 +268,13 @@ func reasoningUsesDefaultPassthroughReadOnlyState(
 }
 
 func reasoningDefaultPassthroughReadOnlyLabel() -> String {
-    "Reasoning stays on for this model"
+    "Uses provider default"
 }
 
 func reasoningShowsResetAction(
     _ status: ClientReasoningStatus
 ) -> Bool {
-    guard status.configured.mode != .default else {
-        return false
-    }
-    return status.configured.mode != .off
-        || status.effective.mode != .off
+    status.configured.mode != .default
 }
 
 func reasoningSelection(
@@ -306,6 +286,8 @@ func reasoningSelection(
             ? status.effective
             : status.configured)
     switch policy.mode {
+    case .on:
+        return .on
     case .off:
         return .off
     case .followHarness:
@@ -331,12 +313,14 @@ func reasoningChoiceLabel(
         return "Default · Pass through unchanged"
     case .pendingDefault:
         return "Resetting to Safe Default…"
+    case .on:
+        return "On"
     case .off:
         return "Off"
     case .followHarness:
-        return "Use \(clientDisplayName(clientName)) setting"
+        return "Follow \(clientDisplayName(clientName)) (Legacy)"
     case .effort(let effort):
-        return reasoningEffortLabel(effort)
+        return "\(reasoningEffortLabel(effort)) (Legacy)"
     case .unavailable(let value):
         return "\(reasoningEffortLabel(value)) (Unavailable)"
     }
@@ -357,13 +341,40 @@ func reasoningCaption(
     row: ReasoningDisplayRow,
     clientName: String
 ) -> String {
-    if row.status.source == "compatibility_default" {
-        return "Safe default: reasoning off when \(clientDisplayName(clientName)) uses this model."
+    let client = clientDisplayName(clientName)
+    switch row.status.configured.mode {
+    case .on:
+        guard row.status.available else { return "Saved policy: On." }
+        return "Switch enables reasoning. \(client) effort is forwarded unchanged."
+    case .off:
+        guard row.status.available else { return "Saved policy: Off." }
+        return "Switch disables reasoning when \(client) uses this model."
+    case .followHarness:
+        return "Saved legacy policy: follow \(client)’s reasoning setting when supported."
+    case .fixed:
+        return "Saved legacy effort: \(reasoningEffortLabel(row.status.configured.effort))."
+    case .default, .passthrough:
+        if row.status.source == "compatibility_default",
+           row.status.effective.mode == .off {
+            return "Safe default: Off."
+        }
+        if row.status.effective.mode == .passthrough {
+            return "Default: provider behavior is unchanged."
+        }
+        return "Used when \(client) routes to this Baseten model."
     }
-    if row.status.configured.mode == .followHarness {
-        return "\(clientDisplayName(clientName))’s reasoning setting passes through when the adapter supports it."
+}
+
+func reasoningLegacySelectionLabel(
+    _ selection: ReasoningChoice,
+    clientName: String
+) -> String? {
+    switch selection {
+    case .followHarness, .effort, .unavailable:
+        return reasoningChoiceLabel(selection, clientName: clientName)
+    case .defaultPassthrough, .pendingDefault, .on, .off:
+        return nil
     }
-    return "Used when \(clientDisplayName(clientName)) routes to this Baseten model."
 }
 
 private func canonicalModelID(

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/GatewayClient.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/GatewayClient.swift
@@ -463,6 +463,7 @@ struct LiveModelCatalogEntry: Equatable, Sendable {
 
 enum ReasoningPolicyMode: String, Equatable, Sendable {
     case `default`
+    case on
     case off
     case followHarness = "follow_harness"
     case fixed

--- a/mac/BasetenSwitch/Sources/BasetenSwitch/RouterWindow.swift
+++ b/mac/BasetenSwitch/Sources/BasetenSwitch/RouterWindow.swift
@@ -1247,7 +1247,7 @@ private struct ClientRoutingView: View {
             } content: {
                 VStack(alignment: .leading, spacing: 10) {
                 Text(
-                    "These settings apply when \(clientDisplayName(client.name)) uses the selected Baseten model.")
+                    "Switch controls reasoning on or off. \(clientDisplayName(client.name)) effort is forwarded unchanged; support for effort levels depends on the model.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
@@ -1339,72 +1339,79 @@ private struct ClientRoutingView: View {
                     .accessibilityLabel(
                         "Saving \(row.displayName) reasoning")
             }
-            if defaultPassthroughReadOnly {
-                Label(
-                    reasoningDefaultPassthroughReadOnlyLabel(),
-                    systemImage: "info.circle")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            } else if choices.isEmpty {
-                Label(
-                    "No configurable reasoning control",
-                    systemImage: "info.circle")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            } else {
-                VStack(alignment: .trailing, spacing: 6) {
+            VStack(alignment: .trailing, spacing: 6) {
+                if defaultPassthroughReadOnly {
+                    Label(
+                        reasoningDefaultPassthroughReadOnlyLabel(),
+                        systemImage: "info.circle")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                } else {
                     if selection == .pendingDefault {
                         Text("Resetting to Safe Default…")
                             .font(.caption.weight(.medium))
                             .foregroundStyle(.secondary)
-                    } else if case .unavailable(let value) = selection {
-                        Text(
-                            "Saved: \(reasoningEffortLabel(value)) (Unavailable)")
-                            .font(.caption.weight(.medium))
-                            .foregroundStyle(.red)
-                    }
-                    Picker(
-                        "\(row.displayName) reasoning",
-                        selection: reasoningBinding(row)
+                    } else if let legacyLabel = reasoningLegacySelectionLabel(
+                        selection,
+                        clientName: client.name
                     ) {
-                        ForEach(choices, id: \.self) { choice in
-                            Text(reasoningChoiceLabel(
-                                choice,
-                                clientName: client.name))
-                                .tag(choice)
-                        }
+                        Text("Saved: \(legacyLabel)")
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(
+                                row.status.available
+                                    ? Color.secondary
+                                    : Color.red)
                     }
-                    .labelsHidden()
-                    .pickerStyle(.segmented)
-                    .fixedSize()
-                    .disabled(
-                        isPreview
-                            || !state.canMutateReasoning
-                            || !reasoningCatalogAllowsMutation
-                            || state.pendingReasoning != nil)
-                    .accessibilityIdentifier(
-                        "reasoning-\(row.provider)-\(row.model)")
-                    if reasoningShowsResetAction(row.status) {
-                        Button("Reset to Safe Default") {
-                            guard !isPreview else { return }
-                            state.requestReasoning(
-                                client: client.name,
-                                provider: row.provider,
-                                model: row.model,
-                                policy: ReasoningPolicyValue(
-                                    mode: .default))
+                    if choices.isEmpty {
+                        Label(
+                            "No configurable reasoning control",
+                            systemImage: "info.circle")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Picker(
+                            "\(row.displayName) reasoning",
+                            selection: reasoningBinding(row)
+                        ) {
+                            ForEach(choices, id: \.self) { choice in
+                                Text(reasoningChoiceLabel(
+                                    choice,
+                                    clientName: client.name))
+                                    .tag(choice)
+                            }
                         }
-                        .buttonStyle(.link)
-                        .font(.caption)
+                        .labelsHidden()
+                        .pickerStyle(.segmented)
+                        .fixedSize()
                         .disabled(
                             isPreview
                                 || !state.canMutateReasoning
                                 || !reasoningCatalogAllowsMutation
                                 || state.pendingReasoning != nil)
                         .accessibilityIdentifier(
-                            "reasoning-reset-\(row.provider)-\(row.model)")
+                            "reasoning-\(row.provider)-\(row.model)")
                     }
+                }
+                if reasoningShowsResetAction(row.status) {
+                    Button("Reset to Safe Default") {
+                        guard !isPreview else { return }
+                        state.requestReasoning(
+                            client: client.name,
+                            provider: row.provider,
+                            model: row.model,
+                            policy: ReasoningPolicyValue(
+                                mode: .default))
+                    }
+                    .buttonStyle(.link)
+                    .font(.caption)
+                    .disabled(
+                        isPreview
+                            || !state.canMutateReasoning
+                            || !reasoningCatalogAllowsMutation
+                            || state.pendingReasoning != nil)
+                    .accessibilityIdentifier(
+                        "reasoning-reset-\(row.provider)-\(row.model)")
                 }
             }
         }

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/ReasoningConfigurationTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/ReasoningConfigurationTests.swift
@@ -266,7 +266,7 @@ final class ReasoningConfigurationTests: XCTestCase {
         {
           "provider": "baseten",
           "model": "zai-org/GLM-5.2",
-          "policy": {"mode": "follow_harness"},
+          "policy": {"mode": "on"},
           "available": true,
           "error": "",
           "warning": "",
@@ -278,7 +278,7 @@ final class ReasoningConfigurationTests: XCTestCase {
               "supported": true,
               "reachability": ["family:opus"],
               "failure_behaviors": [],
-              "available_modes": ["off", "follow_harness"],
+              "available_modes": ["on", "off", "follow_harness"],
               "available_efforts": [],
               "unavailable_reason": "",
               "error": ""
@@ -299,7 +299,7 @@ final class ReasoningConfigurationTests: XCTestCase {
             client: "claude-code",
             provider: "baseten",
             model: model,
-            policy: ReasoningPolicyValue(mode: .followHarness))
+            policy: ReasoningPolicyValue(mode: .on))
 
         let request = try XCTUnwrap(ReasoningURLProtocol.observedRequest)
         XCTAssertEqual(request.httpMethod, "POST")
@@ -315,16 +315,18 @@ final class ReasoningConfigurationTests: XCTestCase {
         XCTAssertEqual(object["model"] as? String, model)
         XCTAssertEqual(
             (object["policy"] as? [String: Any])?["mode"] as? String,
-            "follow_harness")
+            "on")
         XCTAssertEqual(snapshot.clients.map(\.name), ["claude-code"])
-        XCTAssertEqual(snapshot.clients[0].availableModes, [.off, .followHarness])
+        XCTAssertEqual(
+            snapshot.clients[0].availableModes,
+            [.on, .off, .followHarness])
     }
 
     func testDisplayDeduplicatesFamiliesAndUsesGatewayOrderedChoices() {
         let client = reasoningClient(
             configured: ["mode": "default"],
             effective: ["mode": "off"],
-            availableModes: ["off", "follow_harness"],
+            availableModes: ["off", "on", "follow_harness"],
             availableEfforts: ["low", "high"],
             families: ["fable", "opus", "sonnet", "haiku"])
         let live = [reasoningLiveModel(stale: false)]
@@ -338,10 +340,33 @@ final class ReasoningConfigurationTests: XCTestCase {
             ["Fable", "Haiku", "Opus", "Sonnet"])
         XCTAssertEqual(
             reasoningChoices(status: rows[0].status),
-            [.off, .followHarness, .effort("low"), .effort("high")])
+            [.on, .off])
         XCTAssertEqual(
             reasoningSelection(status: rows[0].status),
             .off)
+    }
+
+    func testBinaryControlsRequireAvailableOnAndOffProjection() {
+        func choices(
+            modes: [String],
+            available: Bool = true
+        ) -> [ReasoningChoice] {
+            let dictionary = reasoningStatusDictionary(
+                configured: ["mode": "default"],
+                effective: ["mode": "passthrough"],
+                availableModes: modes,
+                availableEfforts: ["low", "medium", "high"])
+            var projected = dictionary
+            projected["available"] = available
+            return reasoningChoices(
+                status: ClientReasoningStatus(dict: projected)!)
+        }
+
+        XCTAssertEqual(choices(modes: ["on", "off"]), [.on, .off])
+        XCTAssertTrue(choices(modes: ["on"]).isEmpty)
+        XCTAssertTrue(choices(modes: ["off"]).isEmpty)
+        XCTAssertTrue(
+            choices(modes: ["on", "off"], available: false).isEmpty)
     }
 
     func testDisplayIncludesOnlySelectedModelsFromBroadGatewayOptions() {
@@ -490,7 +515,7 @@ final class ReasoningConfigurationTests: XCTestCase {
         XCTAssertTrue(reasoningChoices(status: status).isEmpty)
         XCTAssertEqual(
             reasoningDefaultPassthroughReadOnlyLabel(),
-            "Reasoning stays on for this model")
+            "Uses provider default")
         XCTAssertEqual(
             reasoningSelection(status: status),
             .defaultPassthrough)
@@ -498,70 +523,74 @@ final class ReasoningConfigurationTests: XCTestCase {
         XCTAssertFalse(reasoningShowsUnavailableWarning(status))
     }
 
-    func testExplicitFollowHarnessRemainsEditableAndCanResetToSafeDefault() {
+    func testExplicitFollowHarnessRemainsLegacyAndCanResetToDefault() {
         let status = reasoningStatus(
             configured: ["mode": "follow_harness"],
             effective: ["mode": "follow_harness"],
-            availableModes: ["off", "follow_harness"],
+            availableModes: ["on", "off", "follow_harness"],
             availableEfforts: [])
 
         XCTAssertFalse(
             reasoningUsesDefaultPassthroughReadOnlyState(status))
         XCTAssertEqual(
             reasoningChoices(status: status),
-            [.off, .followHarness])
+            [.on, .off])
         XCTAssertEqual(
             reasoningSelection(status: status),
             .followHarness)
         XCTAssertTrue(reasoningShowsResetAction(status))
     }
 
-    func testDistinctOffAndFollowHarnessRemainEditable() {
+    func testBinaryControlsDoNotRelabelLegacyFollowHarness() {
         let defaultStatus = reasoningStatus(
             configured: ["mode": "default"],
             effective: ["mode": "off"],
-            availableModes: ["off", "follow_harness"],
+            availableModes: ["off", "on", "follow_harness"],
             availableEfforts: [])
 
         XCTAssertFalse(
             reasoningUsesDefaultPassthroughReadOnlyState(defaultStatus))
         XCTAssertEqual(
             reasoningChoices(status: defaultStatus),
-            [.off, .followHarness])
+            [.on, .off])
         XCTAssertEqual(reasoningSelection(status: defaultStatus), .off)
 
         let explicitStatus = reasoningStatus(
             configured: ["mode": "follow_harness"],
             effective: ["mode": "follow_harness"],
-            availableModes: ["off", "follow_harness"],
+            availableModes: ["off", "on", "follow_harness"],
             availableEfforts: [])
         XCTAssertFalse(
             reasoningUsesDefaultPassthroughReadOnlyState(explicitStatus))
         XCTAssertEqual(
             reasoningChoices(status: explicitStatus),
-            [.off, .followHarness])
+            [.on, .off])
+        XCTAssertEqual(
+            reasoningSelection(status: explicitStatus),
+            .followHarness)
+        XCTAssertNil(reasoningSelection(status: explicitStatus).policy)
         XCTAssertTrue(reasoningShowsResetAction(explicitStatus))
     }
 
-    func testResetIsHiddenOnlyForExplicitOffWithEffectiveOff() {
-        let noOpOff = reasoningStatus(
+    func testResetIsShownForEveryExplicitPolicy() {
+        let explicitOff = reasoningStatus(
             configured: ["mode": "off"],
             effective: ["mode": "off"],
-            availableModes: ["off", "follow_harness"],
+            availableModes: ["off", "on"],
             availableEfforts: [])
-        XCTAssertFalse(reasoningShowsResetAction(noOpOff))
+        XCTAssertTrue(reasoningShowsResetAction(explicitOff))
 
-        let behaviorChangingOff = reasoningStatus(
-            configured: ["mode": "off"],
-            effective: ["mode": "passthrough"],
-            availableModes: ["off", "follow_harness"],
+        let explicitOn = reasoningStatus(
+            configured: ["mode": "on"],
+            effective: ["mode": "on"],
+            availableModes: ["off", "on"],
             availableEfforts: [])
-        XCTAssertTrue(reasoningShowsResetAction(behaviorChangingOff))
+        XCTAssertTrue(reasoningShowsResetAction(explicitOn))
 
         let followHarness = reasoningStatus(
             configured: ["mode": "follow_harness"],
             effective: ["mode": "follow_harness"],
-            availableModes: ["off", "follow_harness"],
+            availableModes: ["off", "on", "follow_harness"],
             availableEfforts: [])
         XCTAssertTrue(reasoningShowsResetAction(followHarness))
 
@@ -571,6 +600,13 @@ final class ReasoningConfigurationTests: XCTestCase {
             availableModes: ["follow_harness"],
             availableEfforts: ["low", "high"])
         XCTAssertTrue(reasoningShowsResetAction(fixed))
+
+        let inherited = reasoningStatus(
+            configured: ["mode": "default"],
+            effective: ["mode": "off"],
+            availableModes: ["off", "on"],
+            availableEfforts: [])
+        XCTAssertFalse(reasoningShowsResetAction(inherited))
     }
 
     func testUnavailableDefaultOffDoesNotSynthesizeOffChoice() {
@@ -589,7 +625,7 @@ final class ReasoningConfigurationTests: XCTestCase {
             reasoningUsesDefaultPassthroughReadOnlyState(status))
         XCTAssertEqual(
             reasoningChoices(status: status),
-            [.followHarness])
+            [])
         XCTAssertFalse(reasoningChoices(status: status).contains(.off))
         XCTAssertEqual(reasoningSelection(status: status), .off)
         XCTAssertTrue(reasoningShowsUnavailableWarning(status))
@@ -607,6 +643,7 @@ final class ReasoningConfigurationTests: XCTestCase {
         XCTAssertEqual(
             reasoningSelection(status: removed),
             .unavailable("xhigh"))
+        XCTAssertTrue(reasoningChoices(status: removed).isEmpty)
         XCTAssertTrue(reasoningShowsResetAction(removed))
     }
 
@@ -647,7 +684,7 @@ final class ReasoningConfigurationTests: XCTestCase {
         let defaultClient = reasoningClient(
             configured: ["mode": "default"],
             effective: ["mode": "off"],
-            availableModes: ["off", "follow_harness"],
+            availableModes: ["off", "on", "follow_harness"],
             availableEfforts: [],
             source: "compatibility_default",
             families: ["fable", "opus", "sonnet", "haiku"])
@@ -656,12 +693,12 @@ final class ReasoningConfigurationTests: XCTestCase {
             liveModels: [reasoningLiveModel(stale: false)])[0]
         XCTAssertEqual(
             reasoningCaption(row: defaultRow, clientName: defaultClient.name),
-            "Safe default: reasoning off when Claude Code uses this model.")
+            "Safe default: Off.")
 
         let followClient = reasoningClient(
             configured: ["mode": "follow_harness"],
             effective: ["mode": "follow_harness"],
-            availableModes: ["off", "follow_harness"],
+            availableModes: ["off", "on", "follow_harness"],
             availableEfforts: [],
             families: ["fable", "opus", "sonnet", "haiku"])
         let followRow = reasoningRowsForDisplay(
@@ -669,10 +706,52 @@ final class ReasoningConfigurationTests: XCTestCase {
             liveModels: [reasoningLiveModel(stale: false)])[0]
         XCTAssertEqual(
             reasoningCaption(row: followRow, clientName: followClient.name),
-            "Claude Code’s reasoning setting passes through when the adapter supports it.")
+            "Saved legacy policy: follow Claude Code’s reasoning setting when supported.")
+
+        let onStatus = reasoningStatus(
+            configured: ["mode": "on"],
+            effective: ["mode": "on"],
+            availableModes: ["on", "off"],
+            availableEfforts: [])
+        let onRow = ReasoningDisplayRow(
+            provider: "baseten",
+            model: model,
+            displayName: "GLM 5.2",
+            status: onStatus,
+            capability: nil,
+            mappingFamilies: ["Opus"])
+        XCTAssertEqual(
+            reasoningCaption(row: onRow, clientName: "claude-code"),
+            "Switch enables reasoning. Claude Code effort is forwarded unchanged.")
+
+        var unavailableDictionary = reasoningStatusDictionary(
+            configured: ["mode": "on"],
+            effective: ["mode": "passthrough"],
+            availableModes: [],
+            availableEfforts: [])
+        unavailableDictionary["available"] = false
+        let unavailableRow = ReasoningDisplayRow(
+            provider: "baseten",
+            model: model,
+            displayName: "GLM 5.2",
+            status: ClientReasoningStatus(dict: unavailableDictionary)!,
+            capability: nil,
+            mappingFamilies: ["Opus"])
+        XCTAssertEqual(
+            reasoningCaption(
+                row: unavailableRow,
+                clientName: "claude-code"),
+            "Saved policy: On.")
     }
 
     func testReasoningDispatchAndReconciliationUseExactTypedProjection() {
+        XCTAssertEqual(
+            reasoningDispatchArgs(
+                client: "claude-code",
+                provider: "baseten",
+                model: model,
+                policy: ReasoningPolicyValue(mode: .on)),
+            ["claude", "reasoning", "baseten", model, "on"])
         XCTAssertEqual(
             reasoningDispatchArgs(
                 client: "claude-code",
@@ -739,7 +818,7 @@ final class ReasoningConfigurationTests: XCTestCase {
             client: "claude-code",
             provider: "baseten",
             model: model,
-            policy: ReasoningPolicyValue(mode: .followHarness)))
+            policy: ReasoningPolicyValue(mode: .on)))
         XCTAssertFalse(state.requestReasoning(
             client: "claude-code",
             provider: "baseten",
@@ -757,7 +836,7 @@ final class ReasoningConfigurationTests: XCTestCase {
                 "reasoning",
                 "baseten",
                 model,
-                "follow-harness",
+                "on",
             ])
         XCTAssertNil(state.pendingReasoning)
         state.stop()
@@ -780,7 +859,7 @@ final class ReasoningConfigurationTests: XCTestCase {
             client: "anthropic-fallback",
             provider: "baseten",
             model: model,
-            policy: ReasoningPolicyValue(mode: .followHarness)))
+            policy: ReasoningPolicyValue(mode: .on)))
         await waitUntil { state.pendingReasoning == nil }
 
         let clients = await preflight.clients
@@ -793,7 +872,7 @@ final class ReasoningConfigurationTests: XCTestCase {
                 "reasoning",
                 "baseten",
                 model,
-                "follow-harness",
+                "on",
             ])
         state.stop()
     }
@@ -974,7 +1053,7 @@ final class ReasoningConfigurationTests: XCTestCase {
                         "configured": ["mode": "default"],
                         "effective": ["mode": "off"],
                         "source": "compatibility_default",
-                        "available_modes": ["off", "follow_harness"],
+                        "available_modes": ["off", "on", "follow_harness"],
                         "available_efforts": [],
                         "available": available,
                         "unavailable_reason": available
@@ -1084,7 +1163,7 @@ final class ReasoningConfigurationTests: XCTestCase {
         ReasoningPreflightSnapshot(dict: [
             "provider": "baseten",
             "model": model,
-            "policy": ["mode": "follow_harness"],
+            "policy": ["mode": "on"],
             "available": true,
             "error": "",
             "warning": "",
@@ -1110,7 +1189,7 @@ final class ReasoningConfigurationTests: XCTestCase {
                 ? []
                 : ["native_fallback", "local_error"],
             "available_modes": supported
-                ? ["off", "follow_harness"]
+                ? ["on", "off", "follow_harness"]
                 : ["off"],
             "available_efforts": [],
             "unavailable_reason": supported ? "" : "adapter_unsupported",
@@ -1143,7 +1222,9 @@ final class ReasoningConfigurationTests: XCTestCase {
                             "reasoning": reasoningStatusDictionary(
                                 configured: ["mode": "default"],
                                 effective: ["mode": "off"],
-                                availableModes: ["off", "follow_harness"],
+                                availableModes: [
+                                    "off", "on", "follow_harness",
+                                ],
                                 availableEfforts: []),
                         ],
                     ],

--- a/mac/BasetenSwitch/Tests/BasetenSwitchTests/ReasoningConfigurationTests.swift
+++ b/mac/BasetenSwitch/Tests/BasetenSwitchTests/ReasoningConfigurationTests.swift
@@ -459,6 +459,111 @@ final class ReasoningConfigurationTests: XCTestCase {
         XCTAssertEqual(Set(rows.map(\.model)), [model, nemotron])
     }
 
+    func testDisplayIncludesEnabledPickerOnlyFastModelWithBinaryControls() {
+        let fast = "zai-org/GLM-5.2-Fast"
+        let client = reasoningVisibilityClient(
+            defaultModel: model,
+            families: [("opus", model)],
+            pickerEnabled: true,
+            pickerModels: [
+                ("claude-baseten-glm-5-2-fast", fast),
+            ])
+
+        let rows = reasoningRowsForDisplay(client: client, liveModels: [])
+        let fastRow = try! XCTUnwrap(rows.first { $0.model == fast })
+
+        XCTAssertEqual(reasoningSelection(status: fastRow.status), .off)
+        XCTAssertEqual(reasoningChoices(status: fastRow.status), [.on, .off])
+        XCTAssertTrue(fastRow.mappingFamilies.isEmpty)
+    }
+
+    func testDisplayExcludesModelsFromDisabledPicker() {
+        let fast = "zai-org/GLM-5.2-Fast"
+        let client = reasoningVisibilityClient(
+            defaultModel: model,
+            families: [("opus", model)],
+            pickerEnabled: false,
+            pickerModels: [
+                ("claude-baseten-glm-5-2-fast", fast),
+            ])
+
+        XCTAssertEqual(
+            reasoningRowsForDisplay(client: client, liveModels: []).map(\.model),
+            [model])
+    }
+
+    func testDisplayDeduplicatesPickerAliasesAndRoutingSelections() {
+        let fast = "zai-org/GLM-5.2-Fast"
+        let client = reasoningVisibilityClient(
+            defaultModel: fast,
+            families: [("opus", fast)],
+            subagentModel: fast,
+            subagentRouting: "on",
+            subagentEffective: fast,
+            pickerEnabled: true,
+            pickerModels: [
+                ("claude-baseten-glm-fast", fast),
+                ("claude-baseten-glm-fast-long", fast),
+                ("native", "native"),
+            ])
+
+        let rows = reasoningRowsForDisplay(client: client, liveModels: [])
+
+        XCTAssertEqual(rows.map(\.model), [fast])
+        XCTAssertEqual(rows[0].mappingFamilies, ["Opus"])
+    }
+
+    func testDisplayRetainsUnavailablePickerModelAsReadOnly() {
+        let retired = "moonshotai/Retired-Reasoner"
+        let client = reasoningVisibilityClient(
+            defaultModel: model,
+            families: [("opus", model)],
+            unavailableModels: [retired],
+            pickerEnabled: true,
+            pickerModels: [
+                ("claude-baseten-retired-reasoner", retired),
+            ])
+
+        let rows = reasoningRowsForDisplay(client: client, liveModels: [])
+        let retiredRow = try! XCTUnwrap(rows.first { $0.model == retired })
+
+        XCTAssertFalse(retiredRow.status.available)
+        XCTAssertTrue(reasoningChoices(status: retiredRow.status).isEmpty)
+        XCTAssertEqual(reasoningSelection(status: retiredRow.status), .off)
+        XCTAssertEqual(
+            retiredRow.status.unavailableReason,
+            "catalog_metadata_missing")
+    }
+
+    func testDisplayDoesNotInventPickerControlsWithoutAdminProjection() {
+        let pickerOnly = ClientStatus(dict: [
+            "name": "claude-code",
+            "enabled": true,
+            "bind_addr": "127.0.0.1:8789",
+            "model_picker": [
+                "enabled": true,
+                "models": [[
+                    "alias": "claude-baseten-example-reasoner",
+                    "slug": "example-org/Example-Reasoner",
+                    "label": "Example Reasoner",
+                    "description": "Served by Baseten.",
+                    "context_tokens": 32_000,
+                ]],
+            ],
+            "model_catalog": [[
+                "label": "Example Reasoner",
+                "storage_target": "claude-baseten-example-reasoner",
+                "slug": "example-org/Example-Reasoner",
+                "alias": "claude-baseten-example-reasoner",
+                "available": true,
+            ]],
+            "model_options": ["baseten": [:]],
+        ])!
+
+        XCTAssertTrue(
+            reasoningRowsForDisplay(client: pickerOnly, liveModels: []).isEmpty)
+    }
+
     func testDisplayExcludesInactiveAndInheritedSubagentTargets() {
         let nemotron = "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B"
         let inactive = reasoningVisibilityClient(
@@ -1030,14 +1135,18 @@ final class ReasoningConfigurationTests: XCTestCase {
         subagentModel: String = "",
         subagentRouting: String = "off",
         subagentEffective: String = "inherit",
-        unavailableModels: Set<String> = []
+        unavailableModels: Set<String> = [],
+        pickerEnabled: Bool? = nil,
+        pickerModels: [(alias: String, slug: String)] = []
     ) -> ClientStatus {
+        let fast = "zai-org/GLM-5.2-Fast"
         let kimi = "moonshotai/Kimi-K2.7-Code"
         let nemotron = "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B"
         let retired = "moonshotai/Retired-Reasoner"
         let gpt = "openai/gpt-oss-120b"
         let catalogModels = [
             (model, "GLM 5.2", "claude-baseten-glm-5-2"),
+            (fast, "GLM 5.2 Fast", "claude-baseten-glm-5-2-fast"),
             (kimi, "Kimi K2.7 Code", "claude-baseten-kimi-k2-7-code"),
             (nemotron, "Nemotron Ultra", "claude-baseten-nemotron-ultra"),
             (retired, "Retired Reasoner", "claude-baseten-retired-reasoner"),
@@ -1063,7 +1172,7 @@ final class ReasoningConfigurationTests: XCTestCase {
                     ] as [String: Any],
                 ] as [String: Any])
         })
-        return ClientStatus(dict: [
+        var dictionary: [String: Any] = [
             "name": "claude-code",
             "enabled": true,
             "bind_addr": "127.0.0.1:8789",
@@ -1098,7 +1207,22 @@ final class ReasoningConfigurationTests: XCTestCase {
                 ] as [String: Any]
             },
             "model_options": ["baseten": options],
-        ])!
+        ]
+        if let pickerEnabled {
+            dictionary["model_picker"] = [
+                "enabled": pickerEnabled,
+                "models": pickerModels.map { pickerModel in
+                    [
+                        "alias": pickerModel.alias,
+                        "slug": pickerModel.slug,
+                        "label": "Picker model",
+                        "description": "Served by Baseten.",
+                        "context_tokens": 32_000,
+                    ] as [String: Any]
+                },
+            ]
+        }
+        return ClientStatus(dict: dictionary)!
     }
 
     private func reasoningLiveModel(stale: Bool) -> LiveModelCatalogEntry {


### PR DESCRIPTION
## What

- Add explicit reasoning On and Off controls to the typed CLI and native app.
- Default GLM-5.2-Fast to Off for supported Baseten Messages traffic, while honoring explicit On and allowing reset to the default.
- Preserve Claude Code's effort field without mapping levels. On and Off change only the top-level Messages thinking control.
- Keep saved legacy reasoning policies visible and resettable. Preserve other model defaults and native fallback requests.
- Include enabled model-picker selections in Reasoning, deduplicated with routing targets. Unsupported models remain read-only.

## Why

Users need a binary reasoning control without choosing an effort level in Switch. Available controls remain scoped to the selected model, provider, catalog capability, and protocol adapter.

## Testing

- `scripts/check.sh --offline`: Go build, vet, and 29 package tests; 323 Swift tests; isolated gateway, door, and lifecycle smoke tests.
- `scripts/security/run-gitleaks.sh .`: no secrets found.
- `(cd gateway && go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...)`: no vulnerabilities found.
- `git diff --check origin/main...HEAD`.

## Security and privacy

Messages On and Off replace only the top-level thinking control on the selected Baseten attempt. Other fields, including effort, tool history, and signatures, retain their values. Native fallback receives the original request. No response conversion is added.

The localhost reasoning projection includes the On option, and local telemetry reports the effective enabled state without claiming an effective effort level. Credential handling, routing destinations, dependencies, and release artifacts are unchanged. Tests use synthetic fixtures.
